### PR TITLE
removing MANY_OR DSL construct.

### DIFF
--- a/src/parse/GAstBuilder.ts
+++ b/src/parse/GAstBuilder.ts
@@ -44,8 +44,6 @@ module chevrotain.gastBuilder {
     var optionRegEx = /this\s*.\s*OPTION\s*\(/g
     var orRegEx = /this\s*.\s*OR\s*\(/g
     var manyRegEx = /this\s*.\s*MANY\s*\(/g
-    var manyOrRegEx = /this\s*.\s*MANY_OR\s*\(/g
-    var orInManyRegEx = /_OR\s*\(/g
     var atLeastOneRegEx = /this\s*.\s*AT_LEAST_ONE\s*\(/g
 
     var orPartRegEx = /{\s*WHEN\s*:/g
@@ -160,10 +158,9 @@ module chevrotain.gastBuilder {
         var manyRanges = createManyRanges(text)
         var optionRanges = createOptionRanges(text)
         var orRanges = createOrRanges(text)
-        var manyOrRanges = createManyOrRanges(text)
 
         return _.union(terminalRanges, refsRanges, atLeastOneRanges, atLeastOneRanges,
-            manyRanges, optionRanges, orRanges, manyOrRanges)
+            manyRanges, optionRanges, orRanges)
     }
 
     export function createTerminalRanges(text:string):IProdRange[] {
@@ -192,21 +189,6 @@ module chevrotain.gastBuilder {
         // (A |BB | CDE) ==> or.def[0] --> FLAT(A) , or.def[1] --> FLAT(BB) , or.def[2] --> FLAT(CCDE)
         var orSubPartsRanges = createOrPartRanges(orRanges)
         return _.union(orRanges, orSubPartsRanges)
-    }
-
-    // MANY_OR is just "syntactic sugar" its parsed as MANY(OR(...)
-    export function createManyOrRanges(text):IProdRange[] {
-        var manyRanges = createOperatorProdRangeParenthesis(text, ProdType.MANY, manyOrRegEx)
-        var orInManyRanges = createOperatorProdRangeParenthesis(text, ProdType.OR, orInManyRegEx)
-        _.forEach(orInManyRanges, (innerOr) => {
-            // for MANY_OR(....) the terminating parentehsis is the same, which will break the condition of striclyContains...
-            // so we adjust the OR to 'end' just before the MANY
-            innerOr.range.end = innerOr.range.end - 1
-        })
-        // have to split up the OR cases into separate FLAT productions
-        // (A |BB | CDE) ==> or.def[0] --> FLAT(A) , or.def[1] --> FLAT(BB) , or.def[2] --> FLAT(CCDE)
-        var orSubPartsRanges = createOrPartRanges(orInManyRanges)
-        return _.union(manyRanges, orInManyRanges, orSubPartsRanges)
     }
 
     var findClosingCurly:(start:number, text:string) => number = <any>_.partial(findClosingOffset, "{", "}")

--- a/src/parse/Recognizer.ts
+++ b/src/parse/Recognizer.ts
@@ -251,20 +251,6 @@ module chevrotain.recognizer {
             }
         }
 
-        protected MANY_OR(cases:IManyOrCase[]):void {
-            var lastWasValid:any = true
-            while (lastWasValid) {
-                for (var i = 0; i < cases.length; i++) {
-                    lastWasValid = false
-                    if (cases[i].WHEN.call(this)) {
-                        cases[i].THEN_DO()
-                        lastWasValid = true
-                        break
-                    }
-                }
-            }
-        }
-
         protected AT_LEAST_ONE(lookAheadFunc:() => boolean, consume:() => void, errMsg:string):void {
             if (lookAheadFunc.call(this)) {
                 consume.call(this)
@@ -432,27 +418,6 @@ module chevrotain.recognizer {
                 // AT_LEAST_ONE we change the grammar to AT_LEAST_TWO, AT_LEAST_THREE ... , the possible recursive call
                 // from the tryInRepetitionRecovery(...) will only happen IFF there really are TWO/THREE/.... items.
                 this.tryInRepetitionRecovery(this.AT_LEAST_ONE, arguments, lookAheadFunc, expectTokAfterLastMatch)
-            }
-        }
-
-        protected MANY_OR(cases:IManyOrCase[], expectTokAfterLastMatch?:Function, nextTokIdx?:number):void {
-            super.MANY_OR(cases)
-
-            if (this.shouldInRepetitionRecoveryBeTried(expectTokAfterLastMatch, nextTokIdx)) {
-                this.tryInRepetitionRecovery(
-                    this.MANY_OR,
-                    arguments,
-                    // the lookahead Func for trying preemptive in repetition recovery in MANY_OR is
-                    // performed by trying all the OR cases lookaheads one by one
-                    () => {
-                        var allLookAheadFuncs = _.map(cases, (singleCase:IManyOrCase) => {
-                            return singleCase.WHEN
-                        })
-                        return _.find(allLookAheadFuncs, (singleLookAheadFunc) => {
-                                return singleLookAheadFunc.call(this)
-                            }) !== undefined
-                    },
-                    expectTokAfterLastMatch)
             }
         }
 


### PR DESCRIPTION
because:
A. It provides inconsistent API
   there is a MANY_OR but not AT_LEAST_ONE_OR

B. It is used to reduce verbosity in the DSL. (nesting only OR inside MANY)
   MANY(LA_FUNC, () => {
      OR([
      	{WHEN:LA_FUNC1 THEN_DO:XXX},
      	{WHEN:LA_FUNC2 THEN_DO:YYY},
      	{WHEN:LA_FUNC3 THEN_DO:ZZZ}
      	...
      ]
   })

   but once all the LA_FUNCs can be computed automatically on the fly
   it will look much more "pretty"

   MANY(() => {
   	OR([
   	{ALT:XXX},
   	{ALT:YYY},
   	{ALT:ZZZ}
   ]})

C. The third reason for MANY_OR is performance optimizations.
   to avoid checking the lookahead conditions twice.
   once when entering the MANY and once when choosing the
   alternative in the OR.

   the counter argument for this is:
   * make it pretty first and fast second.
   * it could probably still be made fast by remembering the
     result of the lookahead condition without adding new DSL syntax.

{ALT1:1}