### PR TITLE
ECMA5 Tokens cleanup/upgrade.

### DIFF
--- a/examples/ecmascript5/ecmascript5_tokens.ts
+++ b/examples/ecmascript5/ecmascript5_tokens.ts
@@ -9,58 +9,38 @@ module chevrotain.examples.ecma5 {
     import lex = chevrotain.lexer
 
     /*
-     * Spec: http://www.ecma-international.org/ecma-262/5.1/
-     * Conventions:
-     * 0. The spec defines input elements in: http://www.ecma-international.org/ecma-262/5.1/#sec-7
-     * 1. The class hierarchy in this file does not follow the grammar like definition of the input elements in the spec.
-     *    The hierarchy is based to be useful in the rest of the parsing process.
-     * 2. The classes of the input elements that appear in this file describe the terminal tokens of the input elements
-     * 3. Each sub-section under section 7 is described in an "abstract" class in this file. Terminal tokens of the section
-     *    are described by classes that extend directly or indirectly the base class of the section.
-     * 4. In some cases additional abstract classes are added under the abstract base class of a a section. These classes
-     *    usually describe special cases that should be handled specially in the rest of the parsing process.
-     * 5. The prefix "Abs" in the name of a class means "abstract" class. Although there is no abstract classes in
-     *    TypeScript. These classes are not to be instantiated.
+     * Spec: http://www.ecma-international.org/ecma-262/5.1/#sec-7
+     * important notes:
+     * 1. The Tokens class hierarchy in this module is based upon, but does not precisely match the spec's hierarchy.
+     *    Instead the hierarchy is meant to provide easy categorization/classification of the tokens for "future phases"
+     *    such as: parsing/syntax highlighting/refactoring
+     *
+     * 2. Classes with the prefix 'Abs' are used to define the hierarchy. These are meant to be Abstract classes
+     *    even though TypeScript does not have Abstract classes. The naive approach would be to use Interfaces,
+     *    however, in TypeScript 1.4 Interfaces "disappear" in the runtime and thus they can not be used for categorization/classification
+     *    as its not possible to do: XXX instanceof ISomeInterface.
+     *
+     *    TODO: Check the possibility of using decorators in typescript 1.5 instead
      */
-
-    // Link: http://www.ecma-international.org/ecma-262/5.1/#sec-7
-    // The following is the base class of all chevrotain ECMAScript5 tokens/input elements
-    // TODO: this category may not be relevant from the parser's or tool builders perspective
-    export class AbsInputElement extends tok.Token { static PATTERN = lex.NA }
-
-    /*
-     * Unicode Format-Control Characters
-     * Link: http://www.ecma-international.org/ecma-262/5.1/#sec-7.1
-     */
-    export class AbsFormatControlCharacters extends AbsInputElement { static PATTERN = lex.NA }
-    // TODO: It seems these the following two special characters can only be used in identifiers
-    //       so their existence as a separate unique token class may have no use.
-    export class ZeroWidthNonJoiner extends AbsFormatControlCharacters { static PATTERN = lex.NA } // \u200c
-    export class ZeroWidthJoiner extends AbsFormatControlCharacters { static PATTERN = lex.NA } // \u200D
-    // TODO: this seems to be treated as a type of whitespace according to the spec, consider having it extend AbsWhiteSpace?
-    export class ByteOrderMarkUFCC extends AbsFormatControlCharacters {static PATTERN = lex.NA } // \uFEFF
 
     // Link: http://www.ecma-international.org/ecma-262/5.1/#sec-7.2
-    export class AbsWhiteSpace extends AbsInputElement {
+    export class AbsWhiteSpace extends tok.Token {
         static PATTERN = lex.NA
         static IGNORE = true
     }
+
     export class Tab extends AbsWhiteSpace { static PATTERN = /\u0009/ }
     export class Vertical extends AbsWhiteSpace { static PATTERN = /\u000B/ }
     export class FormFeed extends AbsWhiteSpace { static PATTERN = /\u000C/ }
     export class Space extends AbsWhiteSpace { static PATTERN = /\u0020/ }
     export class NoBreakSpace extends AbsWhiteSpace { static PATTERN = /\u00A0/ }
-
-    //TODO-FN what is the difference between ByteOrderMarkWSTok and ByteOrderMarkUFCCTok
-    // TODO-SS I don't think there is, Table 1 in section 7.1 only seems to assign certain chars
-    // to certain token.
     export class ByteOrderMarkWS extends AbsWhiteSpace { static PATTERN = /\uFEFF/ }
 
     // TODO-SS does this need to exist? what happens in other implementations?
     export class UnicodeSpaceSeparator extends AbsWhiteSpace { static PATTERN = lex.NA } // Other category "Zs"
 
     // Link: http://www.ecma-international.org/ecma-262/5.1/#sec-7.3
-    export class AbsLineTerminator extends AbsInputElement {
+    export class AbsLineTerminator extends AbsWhiteSpace {
         static PATTERN = lex.NA
         static IGNORE = true
     }
@@ -68,12 +48,10 @@ module chevrotain.examples.ecma5 {
     export class CarriageReturn extends AbsLineTerminator { static PATTERN = /\u000D/ }
     export class LineSeparator extends AbsLineTerminator { static PATTERN = /\u2028/ }
     export class ParagraphSeparator extends AbsLineTerminator { static PATTERN = /\u2029/ }
-    // The line terminator sequence <CR><LF> is handled in the grammar
-    // TODO-SS: why? the parser only needs to know a line Terminator exists at a certain input idx, nothing less, nothing more.
-    // have to check for a certain sequence of tokens to detect a line terminator during parsing just copmlicates things...
+    export class CarriageReturnLineFeed extends AbsLineTerminator { static PATTERN = /\u000D\u000A/ }
 
     // Link: http://www.ecma-international.org/ecma-262/5.1/#sec-7.4
-    export class AbsComment extends AbsInputElement {
+    export class AbsComment extends tok.Token {
         static PATTERN = lex.NA
         static IGNORE = true
     }
@@ -86,22 +64,10 @@ module chevrotain.examples.ecma5 {
      */
     // TODO-SS: pattern? simpleLexer does not support multi-line?
     export class MultipleLineCommentWithTerminator extends AbsComment { static PATTERN = lex.NA }
-    // TODO-SS: this variation may not be relevant if the automatic semicolon insertion will be performed
-    //          "on the fly" during scanning
     export class MultipleLineCommentWithoutTerminator extends AbsComment { static PATTERN = lex.NA }
 
-    /*
-     * Link: http://www.ecma-international.org/ecma-262/5.1/#sec-7.5
-     * The word Token is confusing since it is used in the spec in a different way that is used by chevrotain. The
-     * following classes follow the same conventions in the beginning of this file. The AbsToken is the class that
-     * describes all the "chevrotain terminal tokens" that exist in the Tokens section of the spec.
-     * No terminal tokens are defined in this section. Terminal tokens that extend this class exist in the following sections
-     */
-    // TODO: this category may not be relevant from the parser's or tool builders perspective
-    export class AbsToken extends AbsInputElement { static PATTERN = lex.NA }
-
     // Link: http://www.ecma-international.org/ecma-262/5.1/#sec-7.6
-    export class IdentifierName extends AbsToken { static PATTERN = lex.NA }
+    export class IdentifierName extends tok.Token { static PATTERN = lex.NA }
 
     export class AbsAnyKeyword extends IdentifierName { static PATTERN = lex.NA }
 
@@ -155,23 +121,16 @@ module chevrotain.examples.ecma5 {
     export class ProtectedTok extends AbsFutureReservedWordStrictMode { static PATTERN = /protected/}
     export class StaticTok extends AbsFutureReservedWordStrictMode { static PATTERN = /static/}
 
-    // TODO-SS this is a subset of JS Identifier without the unicode mess
-    export class Identifier extends IdentifierName { static PATTERN = /[_A-Za-z][_A-Za-z\d]*/ }
+    // TODO-SS this pattern is a subset of JS Identifier without the unicode mess, need the full pattern
+    export class Identifier extends IdentifierName { static PATTERN = /[_A-Za-z\$][_A-Za-z\d]*/ }
 
-    // These special identifiers have special handling in the parser
-    // and thus require a Token class.
+    // The 'get' and 'set' identifiers require a Token class as they have special handling in the grammar
     // @link http://www.ecma-international.org/ecma-262/5.1/#sec-11.1.5
     export class GetTok extends Identifier { static PATTERN = /get/}
     export class SetTok extends Identifier { static PATTERN = /set/}
 
-    /*
-     * Link: http://www.ecma-international.org/ecma-262/5.1/#sec-7.7
-     * In this case we don't follow the convention and we don't have a single abstract base class for the section
-     * since all punctuators under "Punctuator" production are tokens and therefore will extend the AbsToken, and all
-     * punctuators unde "DivPunctuator" production are not tokens.
-     * For more info check the Tokens section the spec.
-     */
-    export class AbsPunctuator extends AbsToken {}
+    // Link: http://www.ecma-international.org/ecma-262/5.1/#sec-7.7
+    export class AbsPunctuator extends tok.Token { static PATTERN = lex.NA }
     export class LCurly extends AbsPunctuator { static PATTERN = /{/ }
     export class RCurly extends AbsPunctuator { static PATTERN = /}/ }
     export class LParen extends AbsPunctuator { static PATTERN = /\(/ }
@@ -238,7 +197,7 @@ module chevrotain.examples.ecma5 {
     export class SlashEq extends AbsAssignmentOperator { static PATTERN = /\/=/ }
 
     // Link: http://www.ecma-international.org/ecma-262/5.1/#sec-7.8
-    export class AbsLiteral extends AbsInputElement { static PATTERN = lex.NA }
+    export class AbsLiteral extends tok.Token { static PATTERN = lex.NA }
 
     export class NullTok extends AbsLiteral { static PATTERN = /null/}
 
@@ -258,16 +217,10 @@ module chevrotain.examples.ecma5 {
         static PATTERN = /'([^\\']+|\\([bfnrtv'"\\]|[0-3]?[0-7]{1,2}|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}))*'/
     }
 
-    export class AbsRegularExpressionLiteral extends AbsLiteral { static PATTERN = lex.NA }
-    // TODO-SS: is this EmptyRegExp relevant for parser/tooling? maybe it is only relevant inside the lexer
-    //          as a special rule how to identify "emptyRegExp"
-    export class EmptyRegularExpression extends AbsRegularExpressionLiteral { static PATTERN = lex.NA }// /(?:)/
-    export class RegularExpression extends AbsRegularExpressionLiteral {
-        static PATTERN = lex.NA // TODO-SS: pattern
-        // Any regex that's not empty
-    }
+    // TODO: pattern?
+    export class RegularExpressionLiteral extends AbsLiteral { static PATTERN = lex.NA }
 
-    // the Identifer Token must appear last in the array of Token passed to
+    // the Identifier Token must appear last in the array of Token passed to
     // the simpleLexer, otherwise keywords may be lexed as Identifiers
     var sortedTokens = _.sortBy(_.values(ecma5), (tokClass) => {
         return tokClass === Identifier ? 666 : 1


### PR DESCRIPTION
1. remove redundant comments
2. reword module notes.
3. remove unneeded token categories.