### PR TITLE
validation that detects "END OF INPUT" anchor

### DIFF
--- a/src/scan/lexer.ts
+++ b/src/scan/lexer.ts
@@ -240,6 +240,11 @@ module chevrotain.lexer {
             throw new Error(invalidPatterns.join("\n ---------------- \n"))
         }
 
+        var InvalidEndOfInputAnchor = findEndOfInputAnchor(tokenClasses)
+        if (!_.isEmpty(InvalidEndOfInputAnchor)) {
+            throw new Error(InvalidEndOfInputAnchor.join("\n ---------------- \n"))
+        }
+
         var invalidFlags = findUnsupportedFlags(tokenClasses)
         if (!_.isEmpty(invalidFlags)) {
             throw new Error(invalidFlags.join("\n ---------------- \n"))
@@ -271,6 +276,21 @@ module chevrotain.lexer {
 
         var errors = _.map(invalidRegex, (currClass) => {
             return "Token class: ->" + lang.functionName(currClass) + "<- static 'PATTERN' can only be a RegEx"
+        })
+
+        return errors
+    }
+
+    var end_of_input = /[^\\][\$]/
+
+    export function findEndOfInputAnchor(tokenClasses:TokenConstructor[]):string[] {
+        var invalidRegex = _.filter(tokenClasses, (currClass) => {
+            var pattern = currClass[PATTERN]
+            return end_of_input.test(pattern.source)
+        })
+
+        var errors = _.map(invalidRegex, (currClass) => {
+            return "Token class: ->" + lang.functionName(currClass) + "<- static 'PATTERN' cannot contain end of input anchor '$'"
         })
 
         return errors

--- a/test/scan/lexer_spec.ts
+++ b/test/scan/lexer_spec.ts
@@ -69,6 +69,10 @@ module chevrotain.lexer.spec {
         static PATTERN = /bamba/m
     }
 
+    class EndOfInputAnchor extends tok.Token {
+        static PATTERN = /BAMBA$/
+    }
+
     class GlobalPattern extends tok.Token {
         static PATTERN = /bamba/g
     }
@@ -128,13 +132,28 @@ module chevrotain.lexer.spec {
         })
 
         it("will detect patterns using unsupported global flag", function () {
-            var result = l.findUnsupportedFlags([ValidNaPattern, GlobalPattern])
+            var tokenClasses = [ValidNaPattern, GlobalPattern]
+            var result = l.findUnsupportedFlags(tokenClasses)
             expect(result.length).toBe(1)
             expect(_.contains(result[0], "GlobalPattern")).toBe(true)
+            expect(() => {l.validatePatterns(tokenClasses)}).toThrow()
         })
 
         it("won't detect valid patterns as duplicates", function () {
             var result = l.findDuplicatePatterns([MultiLinePattern, IntegerValid])
+            expect(result.length).toBe(0)
+        })
+
+        it("will detect patterns using unsupported end of input anchor", function () {
+            var tokenClasses = [ValidNaPattern, EndOfInputAnchor]
+            var result = l.findEndOfInputAnchor([ValidNaPattern, EndOfInputAnchor])
+            expect(result.length).toBe(1)
+            expect(_.contains(result[0], "EndOfInputAnchor")).toBe(true)
+            expect(() => {l.validatePatterns(tokenClasses)}).toThrow()
+        })
+
+        it("won't detect valid patterns as using unsupported end of input anchor", function () {
+            var result = l.findEndOfInputAnchor([IntegerTok, IntegerValid])
             expect(result.length).toBe(0)
         })
 


### PR DESCRIPTION
in SimpleLexer patterns.

This is not supported as the SimpleLexer works on matching
part of the input from the start for each token.