### PR TITLE
validation to check that the grammar in OR alternatives using

### DIFF
--- a/test/parse/grammar/lookahead_spec.ts
+++ b/test/parse/grammar/lookahead_spec.ts
@@ -99,4 +99,23 @@ module chevrotain.lookahead.spec {
         })
     })
 
+
+    class A extends t.Token {}
+    class B extends t.Token {}
+    class C extends t.Token {}
+    class D extends t.Token {}
+    class E extends t.Token {}
+
+    describe("The Grammar Lookahead module", function () {
+        "use strict"
+
+        it("can detect ambiguities when calculating lookahead functions for OR alternatives", function () {
+            var input = [[A, B], [C, D], [E, C]]
+            var ambiguities = lookahead.checkAlternativesAmbiguities(input)
+            expect(ambiguities.length).toBe(1)
+            expect(ambiguities[0].alts).toEqual([2, 3])
+        })
+    })
+
+
 }

--- a/test/parse/recognizer_lookahead_spec.ts
+++ b/test/parse/recognizer_lookahead_spec.ts
@@ -794,4 +794,45 @@ module chevrotain.recognizer.lookahead.spec {
         })
     })
 
+
+    class OrAmbiguityLookAheadParser extends BaseIntrospectionRecognizer {
+
+        constructor(input:tok.Token[] = []) {
+            super(input, <any>chevrotain.recognizer.lookahead.spec)
+            recog.BaseIntrospectionRecognizer.performSelfAnalysis(this)
+        }
+
+        public ambiguityRule = this.RULE("ambiguityRule", this.parseAmbiguityRule)
+
+        private parseAmbiguityRule():void {
+
+            // @formatter:off
+            this.OR1([
+                {ALT: () => {
+                    this.CONSUME1(OneTok)
+                    this.CONSUME1(TwoTok)
+                }},
+                {ALT: () => { // <-- this alternative starts with the same token as the previous one, ambiguity!
+                    this.CONSUME1(OneTok)
+                    this.CONSUME1(ThreeTok)
+                }},
+                {ALT: () => {
+                    this.CONSUME1(TwoTok)
+                }},
+                {ALT: () => {
+                    this.CONSUME2(ThreeTok)
+                }}
+            ], "digits")
+            // @formatter:on
+        }
+    }
+
+    describe("OR production ambiguity detection when using implicit lookahead calculation", function () {
+
+        it("will throw an error when two alternatives have the same single token (lookahead 1) prefix", function () {
+            var parser = new OrAmbiguityLookAheadParser()
+            expect(() => parser.ambiguityRule()).toThrow()
+        })
+    })
+
 }


### PR DESCRIPTION
Implicit lookahead, can be distinguished using a single token lookahead.
This can only be checked during parser runtime
as the OR lookahead may be explicit or implict and this is
only known during parser runtime.