### PR TITLE
Human Readable Token Labels

### DIFF
--- a/diagrams/src/diagrams_builder.js
+++ b/diagrams/src/diagrams_builder.js
@@ -58,7 +58,7 @@
         var pattern = prod.terminalType.PATTERN
         // PATTERN static property will not exist when using custom lexers (hand built or other lexer generators)
         var toolTipTitle = pattern ? pattern.source : undefined
-        return railroad.Terminal(chevrotain.tokenName(prod.terminalType),
+        return railroad.Terminal(chevrotain.tokenLabel(prod.terminalType),
             undefined,
             toolTipTitle,
             prod.occurrenceInParent,
@@ -76,7 +76,7 @@
      * @return {RailRoadDiagram.Terminal}
      */
     function createTerminalFromToken(tokenConstructor, occurrenceInParent, topRuleName, dslRuleName) {
-        var result = Terminal(chevrotain.tokenName(tokenConstructor),
+        var result = Terminal(chevrotain.tokenLabel(tokenConstructor),
             undefined,
             tokenConstructor.PATTERN.source,
             occurrenceInParent,

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,6 @@
 import {Parser, EMPTY_ALT} from "./parse/parser_public"
 import {Lexer} from "./scan/lexer_public"
-import {Token, VirtualToken, EOF, extendToken, tokenName} from "./scan/tokens_public"
+import {Token, VirtualToken, EOF, extendToken, tokenName, tokenLabel} from "./scan/tokens_public"
 import {exceptions} from "./parse/exceptions_public"
 import {gast} from "./parse/grammar/gast_public"
 import {clearCache} from "./parse/cache_public"
@@ -24,6 +24,7 @@ API.EOF = EOF
 // Tokens utilities
 API.extendToken = extendToken
 API.tokenName = tokenName
+API.tokenLabel = tokenLabel
 
 // Other Utilities
 API.EMPTY_ALT = EMPTY_ALT

--- a/src/scan/tokens_public.ts
+++ b/src/scan/tokens_public.ts
@@ -2,6 +2,17 @@ import {isString, isRegExp, isFunction, assign, isUndefined} from "../utils/util
 import {functionName} from "../lang/lang_extensions"
 import {Lexer} from "./lexer_public"
 
+export function tokenLabel(clazz:Function):string {
+    // Used to customize the token label for diagramming.
+    if (isString((<any>clazz).LABEL)) {
+        return (<any>clazz).LABEL
+    }
+    else {
+        return tokenName(clazz)
+    }
+}
+
+
 export function tokenName(clazz:Function):string {
     // used to support js inheritance patterns that do not use named functions
     // in that situation setting a property tokenName on a token constructor will

--- a/test/scan/token_spec.ts
+++ b/test/scan/token_spec.ts
@@ -1,4 +1,4 @@
-import {extendToken, tokenName, Token} from "../../src/scan/tokens_public"
+import {extendToken, tokenName, tokenLabel, Token} from "../../src/scan/tokens_public"
 
 let TrueLiteral = extendToken("TrueLiteral")
 class FalseLiteral extends Token {}
@@ -19,6 +19,8 @@ describe("The Chevrotain Tokens namespace", () => {
 
     let C = extendToken("C", /\d+/, B)
     let D = extendToken("D", /\w+/, B)
+    let Plus = extendToken("Plus", /\+/)
+    Plus.LABEL = "+"
 
     it("provides an extendToken utility - creating an instance", () => {
         let aInstance = new A("Hello", 0, 1, 1)
@@ -57,5 +59,12 @@ describe("The Chevrotain Tokens namespace", () => {
     it("provides an extendToken utility - static properties inheritance", () => {
         expect(D.GROUP).to.equal("Special")
         expect(C.GROUP).to.equal("Special")
+    })
+
+    it("Allows customization of the label", () => {
+        // Default to class name
+        expect(tokenLabel(B)).to.equal("B")
+        // Unless there's a LABEL property
+        expect(tokenLabel(Plus)).to.equal("+")
     })
 })


### PR DESCRIPTION
Specifying `LABEL` on an ES6 class or add it to an ES5 contstructor customizes how a token is showed in documentation.

```
class Add extends Token {
  static PATTERN = /\+/;
  static LABEL = '+';
}
```

```
var Add = extendsToken('Add', '/\+/');
Add.LABEL = '+';
```