### PR TITLE
Cache information if a grammar production has already been overriden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## X.Y.Z (INSERT_DATE_HERE)
+
+#### Minor Changes
+- [Avoid rebuilding the GAST on parser construction when using RULE_OVERRIDE.](https://github.com/SAP/chevrotain/issues/171)
+
+
+
 ## 0.8.0 (4-8-2016)
 
 #### Breaking Changes
@@ -74,11 +81,13 @@ so not many changes will be needed (if at all) for most users.
 - [Bring order to the chaos of the examples folder.] (https://github.com/SAP/chevrotain/tree/master/examples)
 
 
+
 ## 0.7.1 (4-3-2016)
 
 #### Minor Changes
 - [Parsing Errors should include Parser context information.](#165)
 - [AT_LEAST_ONE dsl rule, errMsg param should be optional.](#91)
+
 
 
 ## 0.7.0 (4-2-2016)
@@ -87,10 +96,12 @@ so not many changes will be needed (if at all) for most users.
 - [Lexer multi "modes" support.](#134)
 
 
+
 ## 0.6.3 (3-28-2016)
 
 #### Minor Changes
 - [Re-synced tokens should be reported to the user.](#154)
+
 
 
 ## 0.6.2 (3-25-2016)
@@ -99,10 +110,12 @@ so not many changes will be needed (if at all) for most users.
 - [LexerDefinitionErrorType enum was not exported as part of the public API.](#158)
 
 
+
 ## 0.6.1 (3-25-2016)
 
 #### Bug Fixes
 - [ParserDefinitionError enum was not exported.](https://github.com/SAP/chevrotain/commit/96edf7fe26d41f25272ea2a39d27fd7eb27991b2)
+
 
 
 ## 0.6.0 (3-20-2016)

--- a/src/parse/cache.ts
+++ b/src/parse/cache.ts
@@ -40,6 +40,12 @@ export function getFirstAfterRepForClass(className:string):HashTable<IFirstAfter
     return getFromNestedHashTable(className, CLASS_TO_FIRST_AFTER_REPETITION)
 }
 
+export let CLASS_TO_PRODUCTION_OVERRIDEN = new HashTable<HashTable<boolean>>()
+
+export function getProductionOverriddenForClass(className:string):HashTable<boolean> {
+    return getFromNestedHashTable(className, CLASS_TO_PRODUCTION_OVERRIDEN)
+}
+
 export let CLASS_TO_OR_LA_CACHE = new HashTable<HashTable<string>[]>()
 export let CLASS_TO_MANY_LA_CACHE = new HashTable<HashTable<string>[]>()
 export let CLASS_TO_MANY_SEP_LA_CACHE = new HashTable<HashTable<string>[]>()
@@ -47,9 +53,8 @@ export let CLASS_TO_AT_LEAST_ONE_LA_CACHE = new HashTable<HashTable<string>[]>()
 export let CLASS_TO_AT_LEAST_ONE_SEP_LA_CACHE = new HashTable<HashTable<string>[]>()
 export let CLASS_TO_OPTION_LA_CACHE = new HashTable<HashTable<string>[]>()
 
-// TODO: CONST in typescript 1.5
 // TODO reflective test to verify this has not changed, for example (OPTION6 added)
-export let MAX_OCCURRENCE_INDEX = 5
+export const MAX_OCCURRENCE_INDEX = 5
 
 export function initLookAheadKeyCache(className) {
     CLASS_TO_OR_LA_CACHE[className] = new Array(MAX_OCCURRENCE_INDEX)

--- a/src/parse/parser_public.ts
+++ b/src/parse/parser_public.ts
@@ -1039,7 +1039,7 @@ export class Parser {
      *
      * @param {string} name - The name of the rule.
      * @param {Function} implementation - The implementation of the rule.
-     * @param {IRuleConfig} [config] - The rule's optionalconfigurationn
+     * @param {IRuleConfig} [config] - The rule's optional configurationn
      *
      * @returns {Function} The parsing rule which is the production implementation wrapped with the parsing logic that handles
      *                     Parser state / error recovery&reporting/ ...
@@ -1078,11 +1078,15 @@ export class Parser {
         this.definitionErrors.push.apply(this.definitionErrors, ruleErrors) // mutability for the win
 
 
+        let alreadyOverridden = cache.getProductionOverriddenForClass(this.className)
         let parserClassProductions = cache.getProductionsForClass(this.className)
-        // when overriding always rebuilt the gast
-        // TODO: this will slightly slow down the construction of a parser with OVERRIDEN rules, how to mitigate ?
-        let gastProduction = buildTopProduction(impl.toString(), ruleName, this.tokensMap)
-        parserClassProductions.put(ruleName, gastProduction)
+
+        // only build the GAST of an overridden rule once.
+        if (!alreadyOverridden.containsKey(ruleName)) {
+            alreadyOverridden.put(ruleName, true)
+            let gastProduction = buildTopProduction(impl.toString(), ruleName, this.tokensMap)
+            parserClassProductions.put(ruleName, gastProduction)
+        }
 
         return this.defineRule(ruleName, impl, config)
     }


### PR DESCRIPTION
in the context of a specific grammar.

This enables avoiding the rebuilding of the GAST representation
of an overriden rule on each and every initialization of the Parser.

Fixes #171