### PR TITLE
Predicates / Gates of optional productions should not replace the basic grammar lookahead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## X.Y.Z (INSERT_DATE_HERE)
+
+#### Major Changes
+- [Predicates / Gates on productions should be in addition to standard lookahead.](https://github.com/SAP/chevrotain/issues/189)
+
+#### Breaking Changes
+**IsNextRule** method was removed from the Parser class. It's functionality is no longer needed as usage of predicates / gates
+no longer also requires manually implementing the lookahead function.
+
+
+
 ## 0.9.0 (4-29-2016)
 
 #### Major Changes

--- a/examples/parser/predicate_lookahead/predicate_lookahead.js
+++ b/examples/parser/predicate_lookahead/predicate_lookahead.js
@@ -22,26 +22,27 @@ var allTokens = [
 var PredicateLookaheadLexer = new Lexer(allTokens);
 
 /**
- * A custom lookahead function is invoked with context (this)
- * of the Parser. Thus it can access the Parser's internal state. (this.LA)
- * In this example we also limit some of the available alternatives using 'global' flag
+ * A Predicate / Gate function is invoked with context (this)
+ * of the Parser. Thus it can access the Parser's internal state if needed.
+ * In this example we limit some of the available alternatives using 'global' flag
  * 'maxNumberAllowed'
  *
- * A custom lookahead function should return true if the path should be taken
- * or false otherwise.
+ * A custom Predicate / Gate function should return true if the path should be taken or false otherwise.
+ * Note that this logic is in addition to the built in grammar lookahead function (choosing the alternative according to the next tokens)
+ * Not instead of it.
  */
 var maxNumberAllowed = 3;
 
 function isOne() {
-    return this.LA(1) instanceof One && maxNumberAllowed >= 1;
+    return maxNumberAllowed >= 1;
 }
 
 function isTwo() {
-    return this.LA(1) instanceof Two && maxNumberAllowed >= 2;
+    return maxNumberAllowed >= 2;
 }
 
 function isThree() {
-    return this.LA(1) instanceof Three && maxNumberAllowed >= 3;
+    return maxNumberAllowed >= 3;
 }
 
 // ----------------- parser -----------------
@@ -54,8 +55,8 @@ function PredicateLookaheadParser(input) {
         // @formatter:off
         return $.OR([
             // In this example we disable some of the alternatives depending on the value of the
-            // "maxNumberAllowed" flag. For each alternative a custom lookahead function is provided
-            // A lookahead function may also be provided for other grammar DSL rules.
+            // "maxNumberAllowed" flag. For each alternative a custom Predicate / Gate function is provided
+            // A Predicate / Gate function may also be provided for other grammar DSL rules.
             // (OPTION/MANY/AT_LEAST_ONE/...)
             {WHEN: isOne, THEN_DO: function() {
                 $.CONSUME(One);

--- a/test/full_flow/backtracking/backtracking_parser.ts
+++ b/test/full_flow/backtracking/backtracking_parser.ts
@@ -66,7 +66,10 @@ export class BackTrackingParser extends Parser {
                     WHEN:    this.BACKTRACK(this.withDefaultStatement, (result) => { return result === RET_TYPE.WITH_DEFAULT }),
                     THEN_DO: () => { statementTypeFound = this.SUBRULE(this.withDefaultStatement) }
                 },
-            ], " a statement")
+                // IGNORE_AMBIGUITIES is needed when backtracking is used
+                // Because the parser always performs the standard lookahead calculation anyhow
+                // and will thus detect an ambiguity issue.
+            ], " a statement", Parser.IGNORE_AMBIGUITIES)
 
         return statementTypeFound
     }

--- a/test/parse/predicate_spec.ts
+++ b/test/parse/predicate_spec.ts
@@ -1,0 +1,268 @@
+import {Token} from "../../src/scan/tokens_public"
+import {Parser} from "../../src/parse/parser_public"
+import {exceptions} from "../../src/parse/exceptions_public"
+
+describe("The chevrotain support for custom gates/predicates on DSL production:", () => {
+
+
+    class A extends Token {
+        constructor() { super("a", 0, 1, 1) }
+    }
+
+    class B extends Token {
+        constructor() { super("b", 0, 1, 1) }
+    }
+
+    class C extends Token {
+        constructor() { super("c", 0, 1, 1) }
+    }
+
+    let ALL_TOKENS = [A, B, C]
+
+    it("OPTION", () => {
+
+        function gateFunc() {
+            return this.gate
+        }
+
+        class PredicateOptionParser extends Parser {
+
+            constructor(input:Token[] = [], private gate:boolean) {
+                super(input, ALL_TOKENS);
+                (Parser as any).performSelfAnalysis(this)
+            }
+
+            public optionRule = this.RULE("optionRule", () => {
+                let result = "not entered!"
+                this.OPTION(gateFunc, () => {
+                    this.CONSUME(A)
+                    result = "entered!"
+                })
+                return result
+            })
+        }
+
+        let gateOpenInputGood = new PredicateOptionParser([new A()], true).optionRule()
+        expect(gateOpenInputGood).to.equal("entered!")
+
+        let gateOpenInputBad = new PredicateOptionParser([new B()], true).optionRule()
+        expect(gateOpenInputBad).to.equal("not entered!")
+
+        let gateClosedInputGood = new PredicateOptionParser([new A()], false).optionRule()
+        expect(gateClosedInputGood).to.equal("not entered!")
+
+        let gateClosedInputBad = new PredicateOptionParser([new B()], false).optionRule()
+        expect(gateClosedInputBad).to.equal("not entered!")
+    })
+
+    it("MANY", () => {
+        function gateFunc() {
+            return this.gate
+        }
+
+        class PredicateManyParser extends Parser {
+
+            constructor(input:Token[] = [], private gate:boolean) {
+                super(input, ALL_TOKENS);
+                (Parser as any).performSelfAnalysis(this)
+            }
+
+            public manyRule = this.RULE("manyRule", () => {
+                let result = "not entered!"
+                this.MANY(gateFunc, () => {
+                    this.CONSUME(A)
+                    result = "entered!"
+                })
+
+                return result
+            })
+        }
+
+        let gateOpenInputGood = new PredicateManyParser([new A(), new A()], true).manyRule()
+        expect(gateOpenInputGood).to.equal("entered!")
+
+        let gateOpenInputBad = new PredicateManyParser([new B()], true).manyRule()
+        expect(gateOpenInputBad).to.equal("not entered!")
+
+        let gateClosedInputGood = new PredicateManyParser([new A(), new A()], false).manyRule()
+        expect(gateClosedInputGood).to.equal("not entered!")
+
+        let gateClosedInputBad = new PredicateManyParser([new B()], false).manyRule()
+        expect(gateClosedInputBad).to.equal("not entered!")
+    })
+
+    it("MANY_SEP", () => {
+        function gateFunc() {
+            return this.gate
+        }
+
+        class PredicateManySepParser extends Parser {
+
+            constructor(input:Token[] = [], private gate:boolean) {
+                super(input, ALL_TOKENS);
+                (Parser as any).performSelfAnalysis(this)
+            }
+
+            public manySepRule = this.RULE("manySepRule", () => {
+                let result = "not entered!"
+                this.MANY_SEP(B, gateFunc, () => {
+                    this.CONSUME(A)
+                    result = "entered!"
+                })
+
+                return result
+            })
+        }
+
+        let gateOpenInputGood = new PredicateManySepParser([new A(), new B(), new A()], true).manySepRule()
+        expect(gateOpenInputGood).to.equal("entered!")
+
+        let gateOpenInputBad = new PredicateManySepParser([new B()], true).manySepRule()
+        expect(gateOpenInputBad).to.equal("not entered!")
+
+        let gateClosedInputGood = new PredicateManySepParser([new A(), new B(), new A()], false).manySepRule()
+        expect(gateClosedInputGood).to.equal("not entered!")
+
+        let gateClosedInputBad = new PredicateManySepParser([new B()], false).manySepRule()
+        expect(gateClosedInputBad).to.equal("not entered!")
+    })
+
+    it("AT_LEAST_ONE", () => {
+        function gateFunc() {
+            return this.gate
+        }
+
+        class PredicateAtLeastOneParser extends Parser {
+
+            constructor(input:Token[] = [], private gate:boolean) {
+                super(input, ALL_TOKENS);
+                (Parser as any).performSelfAnalysis(this)
+            }
+
+            public atLeastOneRule = this.RULE("atLeastOneRule", () => {
+                let result = "not entered!"
+                this.AT_LEAST_ONE(gateFunc, () => {
+                    this.CONSUME(A)
+                    result = "entered!"
+                })
+
+                return result
+            })
+        }
+
+        let gateOpenInputGood = new PredicateAtLeastOneParser([new A(), new A()], true).atLeastOneRule()
+        expect(gateOpenInputGood).to.equal("entered!")
+
+        let gateOpenInputBadParser = new PredicateAtLeastOneParser([new B()], true)
+        gateOpenInputBadParser.atLeastOneRule()
+        expect(gateOpenInputBadParser.errors).to.have.lengthOf(1)
+        expect(gateOpenInputBadParser.errors[0]).to.be.an.instanceOf(exceptions.EarlyExitException)
+
+        let gateClosedInputGood = new PredicateAtLeastOneParser([new A(), new A()], false)
+        gateClosedInputGood.atLeastOneRule()
+        expect(gateClosedInputGood.errors).to.have.lengthOf(1)
+        expect(gateClosedInputGood.errors[0]).to.be.an.instanceOf(exceptions.EarlyExitException)
+
+        let gateClosedInputBad = new PredicateAtLeastOneParser([new B()], false)
+        gateClosedInputBad.atLeastOneRule()
+        expect(gateClosedInputBad.errors).to.have.lengthOf(1)
+        expect(gateClosedInputBad.errors[0]).to.be.an.instanceOf(exceptions.EarlyExitException)
+    })
+
+    it("AT_LEAST_ONE_SEP", () => {
+        function gateFunc() {
+            return this.gate
+        }
+
+        class PredicateAtLeastOneSepParser extends Parser {
+
+            constructor(input:Token[] = [], private gate:boolean) {
+                super(input, ALL_TOKENS);
+                (Parser as any).performSelfAnalysis(this)
+            }
+
+            public atLeastOneSepRule = this.RULE("atLeastOneSepRule", () => {
+                let result = "not entered!"
+                this.AT_LEAST_ONE_SEP(B, gateFunc, () => {
+                    this.CONSUME(A)
+                    result = "entered!"
+                })
+
+                return result
+            })
+        }
+
+        let gateOpenInputGood = new PredicateAtLeastOneSepParser([new A(), new B(), new A()], true).atLeastOneSepRule()
+        expect(gateOpenInputGood).to.equal("entered!")
+
+        let gateOpenInputBadParser = new PredicateAtLeastOneSepParser([new B()], true)
+        gateOpenInputBadParser.atLeastOneSepRule()
+        expect(gateOpenInputBadParser.errors).to.have.lengthOf(1)
+        expect(gateOpenInputBadParser.errors[0]).to.be.an.instanceOf(exceptions.EarlyExitException)
+
+        let gateClosedInputGood = new PredicateAtLeastOneSepParser([new A(), new B(), new A()], false)
+        gateClosedInputGood.atLeastOneSepRule()
+        expect(gateClosedInputGood.errors).to.have.lengthOf(1)
+        expect(gateClosedInputGood.errors[0]).to.be.an.instanceOf(exceptions.EarlyExitException)
+
+        let gateClosedInputBad = new PredicateAtLeastOneSepParser([new B()], false)
+        gateClosedInputBad.atLeastOneSepRule()
+        expect(gateClosedInputBad.errors).to.have.lengthOf(1)
+        expect(gateClosedInputBad.errors[0]).to.be.an.instanceOf(exceptions.EarlyExitException)
+    })
+
+    it("OR", () => {
+        function gateFunc() {
+            return this.gate
+        }
+
+        class PredicateOrParser extends Parser {
+
+            constructor(input:Token[] = [], private gate:boolean) {
+                super(input, ALL_TOKENS);
+                (Parser as any).performSelfAnalysis(this)
+            }
+
+            public orRule = this.RULE("manyRule", () => {
+                // @formatter:off
+                    return this.OR1([
+                        // no predicate
+                        {ALT: () => {
+                            this.CONSUME1(A)
+                            return "A"
+                        }}, // Has predicate
+                        {WHEN: gateFunc, THEN_DO: () => {
+                            this.CONSUME1(B)
+                            return "B"
+                        }},
+                        // No predicate
+                        {ALT: () => {
+                            this.CONSUME1(C)
+                            return "C"
+                        }}
+                    ])
+                    // @formatter:on
+            })
+        }
+
+        let gateOpenInputA = new PredicateOrParser([new A()], true).orRule()
+        expect(gateOpenInputA).to.equal("A")
+
+        let gateOpenInputB = new PredicateOrParser([new B()], true).orRule()
+        expect(gateOpenInputB).to.equal("B")
+
+        let gateOpenInputC = new PredicateOrParser([new C()], true).orRule()
+        expect(gateOpenInputC).to.equal("C")
+
+        let gateClosedInputA = new PredicateOrParser([new A()], false).orRule()
+        expect(gateClosedInputA).to.equal("A")
+
+        let gateClosedInputBad = new PredicateOrParser([new B()], false)
+        gateClosedInputBad.orRule()
+        expect(gateClosedInputBad.errors).to.have.lengthOf(1)
+        expect(gateClosedInputBad.errors[0]).to.be.an.instanceOf(exceptions.NoViableAltException)
+
+        let gateClosedInputC = new PredicateOrParser([new C()], false).orRule()
+        expect(gateClosedInputC).to.equal("C")
+    })
+})

--- a/test/parse/recognizer_lookahead_spec.ts
+++ b/test/parse/recognizer_lookahead_spec.ts
@@ -78,51 +78,6 @@ class OptionsImplicitLookAheadParser extends Parser {
     }
 }
 
-class OptionsExplicitLookAheadParser extends Parser {
-
-    public getLookAheadCache():HashTable<Function> {
-        return getLookaheadFuncsForClass(this.className)
-    }
-
-    constructor(input:Token[] = []) {
-        super(input, ALL_TOKENS)
-        Parser.performSelfAnalysis(this)
-    }
-
-    public manyOptionsRule = this.RULE("manyOptionsRule", this.parseManyOptionsRule, () => { return "-666" })
-
-    private parseManyOptionsRule():string {
-        let total = ""
-
-        this.OPTION1(isOneTok, () => {
-            this.CONSUME1(OneTok)
-            total += "1"
-        })
-
-        this.OPTION2(isTwoTok, () => {
-            this.CONSUME1(TwoTok)
-            total += "2"
-        })
-
-        this.OPTION3(isThreeTok, () => {
-            this.CONSUME1(ThreeTok)
-            total += "3"
-        })
-
-        this.OPTION4(isFourTok, () => {
-            this.CONSUME1(FourTok)
-            total += "4"
-        })
-
-        this.OPTION5(isFiveTok, () => {
-            this.CONSUME1(FiveTok)
-            total += "5"
-        })
-
-        return total
-    }
-}
-
 function isOneTok():boolean {
     return this.NEXT_TOKEN() instanceof OneTok
 }
@@ -188,47 +143,6 @@ describe("The implicit lookahead calculation functionality of the Recognizer For
     })
 })
 
-
-describe("The Explicit lookahead functionality of the Recognizer for OPTION", () => {
-
-    it("can accept lookahead function param for OPTION1", () => {
-        let input = [new OneTok()]
-        let parser = new OptionsExplicitLookAheadParser(input)
-        expect(parser.manyOptionsRule()).to.equal("1")
-    })
-
-    it("can accept lookahead function param for OPTION2", () => {
-        let input = [new TwoTok()]
-        let parser = new OptionsExplicitLookAheadParser(input)
-        expect(parser.manyOptionsRule()).to.equal("2")
-    })
-
-    it("can accept lookahead function param for OPTION3", () => {
-        let input = [new ThreeTok()]
-        let parser = new OptionsExplicitLookAheadParser(input)
-        expect(parser.manyOptionsRule()).to.equal("3")
-    })
-
-    it("can accept lookahead function param for OPTION4", () => {
-        let input = [new FourTok()]
-        let parser = new OptionsExplicitLookAheadParser(input)
-        expect(parser.manyOptionsRule()).to.equal("4")
-    })
-
-    it("can accept lookahead function param for OPTION5", () => {
-        let input = [new FiveTok()]
-        let parser = new OptionsExplicitLookAheadParser(input)
-        expect(parser.manyOptionsRule()).to.equal("5")
-    })
-
-    it("Will not cache any ImplicitLookahead functions", () => {
-        let parser = new OptionsExplicitLookAheadParser()
-        let lookaheadCache = parser.getLookAheadCache()
-        expect(lookaheadCache.keys().length).to.equal(0)
-    })
-})
-
-
 class ManyImplicitLookAheadParser extends Parser {
 
     public getLookAheadCache():HashTable<Function> {
@@ -274,50 +188,6 @@ class ManyImplicitLookAheadParser extends Parser {
     }
 }
 
-class ManyExplicitLookAheadParser extends Parser {
-
-    public getLookAheadCache():HashTable<Function> {
-        return getLookaheadFuncsForClass(this.className)
-    }
-
-    constructor(input:Token[] = []) {
-        super(input, ALL_TOKENS)
-        Parser.performSelfAnalysis(this)
-    }
-
-    public manyRule = this.RULE("manyRule", this.parseManyRule, () => { return "-666" })
-
-    private parseManyRule():string {
-        let total = ""
-
-        this.MANY1(isOneTok, () => {
-            this.CONSUME1(OneTok)
-            total += "1"
-        })
-
-        this.MANY2(isTwoTok, () => {
-            this.CONSUME1(TwoTok)
-            total += "2"
-        })
-
-        this.MANY3(isThreeTok, () => {
-            this.CONSUME1(ThreeTok)
-            total += "3"
-        })
-
-        this.MANY4(isFourTok, () => {
-            this.CONSUME1(FourTok)
-            total += "4"
-        })
-
-        this.MANY5(isFiveTok, () => {
-            this.CONSUME1(FiveTok)
-            total += "5"
-        })
-
-        return total
-    }
-}
 
 describe("The implicit lookahead calculation functionality of the Recognizer For MANY", () => {
 
@@ -370,53 +240,6 @@ describe("The implicit lookahead calculation functionality of the Recognizer For
     })
 })
 
-
-describe("The Explicit lookahead functionality of the Recognizer for MANY", () => {
-
-    it("can accept lookahead function param for MANY1", () => {
-        let input = [new OneTok()]
-        let parser = new ManyExplicitLookAheadParser(input)
-        expect(parser.manyRule()).to.equal("1")
-    })
-
-    it("can accept lookahead function param for MANY2", () => {
-        let input = [new TwoTok()]
-        let parser = new ManyExplicitLookAheadParser(input)
-        expect(parser.manyRule()).to.equal("2")
-    })
-
-    it("can accept lookahead function param for MANY3", () => {
-        let input = [new ThreeTok()]
-        let parser = new ManyExplicitLookAheadParser(input)
-        expect(parser.manyRule()).to.equal("3")
-    })
-
-    it("can accept lookahead function param for MANY4", () => {
-        let input = [new FourTok()]
-        let parser = new ManyExplicitLookAheadParser(input)
-        expect(parser.manyRule()).to.equal("4")
-    })
-
-    it("can accept lookahead function param for MANY5", () => {
-        let input = [new FiveTok()]
-        let parser = new ManyExplicitLookAheadParser(input)
-        expect(parser.manyRule()).to.equal("5")
-    })
-
-    it("can accept lookahead function param for flow mixing several MANYs", () => {
-        let input = [new OneTok(), new OneTok(), new ThreeTok(), new ThreeTok(), new ThreeTok(), new FiveTok()]
-        let parser = new ManyExplicitLookAheadParser(input)
-        expect(parser.manyRule()).to.equal("113335")
-    })
-
-    it("Will not cache any ImplicitLookahead functions when provided with explicit versions", () => {
-        let parser = new ManyExplicitLookAheadParser()
-        let lookaheadCache = parser.getLookAheadCache()
-        expect(lookaheadCache.keys().length).to.equal(0)
-    })
-})
-
-
 class ManySepImplicitLookAheadParser extends Parser {
 
     public getLookAheadCache():HashTable<Function> {
@@ -461,51 +284,6 @@ class ManySepImplicitLookAheadParser extends Parser {
         }))
 
         return {total: total, separators: separators}
-    }
-}
-
-class ManySepExplicitLookAheadParser extends Parser {
-
-    public getLookAheadCache():HashTable<Function> {
-        return getLookaheadFuncsForClass(this.className)
-    }
-
-    constructor(input:Token[] = []) {
-        super(input, ALL_TOKENS)
-        Parser.performSelfAnalysis(this)
-    }
-
-    public manySepRule = this.RULE("manySepRule", this.parseManyRule, () => { return "-666" })
-
-    private parseManyRule():string {
-        let total = ""
-
-        this.MANY_SEP1(Comma, isOneTok, () => {
-            this.CONSUME1(OneTok)
-            total += "1"
-        })
-
-        this.MANY_SEP2(Comma, isTwoTok, () => {
-            this.CONSUME1(TwoTok)
-            total += "2"
-        })
-
-        this.MANY_SEP3(Comma, isThreeTok, () => {
-            this.CONSUME1(ThreeTok)
-            total += "3"
-        })
-
-        this.MANY_SEP4(Comma, isFourTok, () => {
-            this.CONSUME1(FourTok)
-            total += "4"
-        })
-
-        this.MANY_SEP5(Comma, isFiveTok, () => {
-            this.CONSUME1(FiveTok)
-            total += "5"
-        })
-
-        return total
     }
 }
 
@@ -565,53 +343,6 @@ describe("The implicit lookahead calculation functionality of the Recognizer For
 })
 
 
-describe("The Explicit lookahead functionality of the Recognizer for MANY", () => {
-
-    it("can accept lookahead function param for MANY1", () => {
-        let input = [new OneTok()]
-        let parser = new ManySepExplicitLookAheadParser(input)
-        expect(parser.manySepRule()).to.equal("1")
-    })
-
-    it("can accept lookahead function param for MANY2", () => {
-        let input = [new TwoTok()]
-        let parser = new ManySepExplicitLookAheadParser(input)
-        expect(parser.manySepRule()).to.equal("2")
-    })
-
-    it("can accept lookahead function param for MANY3", () => {
-        let input = [new ThreeTok()]
-        let parser = new ManySepExplicitLookAheadParser(input)
-        expect(parser.manySepRule()).to.equal("3")
-    })
-
-    it("can accept lookahead function param for MANY4", () => {
-        let input = [new FourTok()]
-        let parser = new ManySepExplicitLookAheadParser(input)
-        expect(parser.manySepRule()).to.equal("4")
-    })
-
-    it("can accept lookahead function param for MANY5", () => {
-        let input = [new FiveTok()]
-        let parser = new ManySepExplicitLookAheadParser(input)
-        expect(parser.manySepRule()).to.equal("5")
-    })
-
-    it("can accept lookahead function param for flow mixing several MANYs", () => {
-        let input = [new OneTok(), new Comma(), new OneTok(), new ThreeTok(), new Comma(),
-            new ThreeTok(), new Comma(), new ThreeTok(), new FiveTok()]
-        let parser = new ManySepExplicitLookAheadParser(input)
-        expect(parser.manySepRule()).to.equal("113335")
-    })
-
-    it("Will not cache any ImplicitLookahead functions when provided with explicit versions", () => {
-        let parser = new ManySepExplicitLookAheadParser()
-        let lookaheadCache = parser.getLookAheadCache()
-        expect(lookaheadCache.keys().length).to.equal(0)
-    })
-})
-
-
 class AtLeastOneImplicitLookAheadParser extends Parser {
 
     public getLookAheadCache():HashTable<Function> {
@@ -657,51 +388,6 @@ class AtLeastOneImplicitLookAheadParser extends Parser {
     }
 }
 
-class AtLeastOneExplicitLookAheadParser extends Parser {
-
-    public getLookAheadCache():HashTable<Function> {
-        return getLookaheadFuncsForClass(this.className)
-    }
-
-    constructor(input:Token[] = []) {
-        super(input, ALL_TOKENS)
-        Parser.performSelfAnalysis(this)
-    }
-
-    public atLeastOneRule = this.RULE("atLeastOneRule", this.parseAtLeastOneRule, {recoveryValueFunc: () => { return "-666" }})
-
-    private parseAtLeastOneRule():string {
-        let total = ""
-
-        this.AT_LEAST_ONE1(isOneTok, () => {
-            this.CONSUME1(OneTok)
-            total += "1"
-        }, "Ones")
-
-        this.AT_LEAST_ONE2(isTwoTok, () => {
-            this.CONSUME1(TwoTok)
-            total += "2"
-        }, "Twos")
-
-        this.AT_LEAST_ONE3(isThreeTok, () => {
-            this.CONSUME1(ThreeTok)
-            total += "3"
-        }, "Threes")
-
-        this.AT_LEAST_ONE4(isFourTok, () => {
-            this.CONSUME1(FourTok)
-            total += "4"
-        }, "Fours")
-
-        this.AT_LEAST_ONE5(isFiveTok, () => {
-            this.CONSUME1(FiveTok)
-            total += "5"
-        }, "Fives")
-
-        return total
-    }
-}
-
 describe("The implicit lookahead calculation functionality of the Recognizer For AT_LEAST_ONE", () => {
 
     it("will cache the generatedLookAhead functions BEFORE (check cache is clean)", () => {
@@ -729,29 +415,6 @@ describe("The implicit lookahead calculation functionality of the Recognizer For
         expect(lookaheadCache.keys().length).to.equal(5)
     })
 })
-
-describe("The Explicit lookahead functionality of the Recognizer for AT_LEAST_ONE", () => {
-
-    it("can accept lookahead function param for AT_LEAST_ONE1-5", () => {
-        let input = [new OneTok(), new TwoTok(), new TwoTok(), new ThreeTok(),
-            new FourTok(), new FourTok(), new FiveTok()]
-        let parser = new AtLeastOneExplicitLookAheadParser(input)
-        expect(parser.atLeastOneRule()).to.equal("1223445")
-    })
-
-    it("will fail when zero occurrences of AT_LEAST_ONE in input", () => {
-        let input = [new OneTok(), new TwoTok(), /*new ThreeTok(),*/ new FourTok(), new FiveTok()]
-        let parser = new AtLeastOneExplicitLookAheadParser(input)
-        expect(parser.atLeastOneRule()).to.equal("-666")
-    })
-
-    it("Will not cache any ImplicitLookahead functions when provided with explicit versions", () => {
-        let parser = new AtLeastOneExplicitLookAheadParser()
-        let lookaheadCache = parser.getLookAheadCache()
-        expect(lookaheadCache.keys().length).to.equal(0)
-    })
-})
-
 
 class AtLeastOneSepImplicitLookAheadParser extends Parser {
 
@@ -800,51 +463,6 @@ class AtLeastOneSepImplicitLookAheadParser extends Parser {
     }
 }
 
-class AtLeastOneSepExplicitLookAheadParser extends Parser {
-
-    public getLookAheadCache():HashTable<Function> {
-        return getLookaheadFuncsForClass(this.className)
-    }
-
-    constructor(input:Token[] = []) {
-        super(input, ALL_TOKENS)
-        Parser.performSelfAnalysis(this)
-    }
-
-    public atLeastOneSepRule = this.RULE("atLeastOneSepRule", this.parseAtLeastOneSepRule, {recoveryValueFunc: () => "-666"})
-
-    private parseAtLeastOneSepRule():string {
-        let total = ""
-
-        this.AT_LEAST_ONE_SEP1(Comma, isOneTok, () => {
-            this.CONSUME1(OneTok)
-            total += "1"
-        }, "Ones")
-
-        this.AT_LEAST_ONE_SEP2(Comma, isTwoTok, () => {
-            this.CONSUME1(TwoTok)
-            total += "2"
-        }, "Twos")
-
-        this.AT_LEAST_ONE_SEP3(Comma, isThreeTok, () => {
-            this.CONSUME1(ThreeTok)
-            total += "3"
-        }, "Threes")
-
-        this.AT_LEAST_ONE_SEP4(Comma, isFourTok, () => {
-            this.CONSUME1(FourTok)
-            total += "4"
-        }, "Fours")
-
-        this.AT_LEAST_ONE_SEP5(Comma, isFiveTok, () => {
-            this.CONSUME1(FiveTok)
-            total += "5"
-        }, "Fives")
-
-        return total
-    }
-}
-
 describe("The implicit lookahead calculation functionality of the Recognizer For AT_LEAST_ONE_SEP", () => {
 
     it("will cache the generatedLookAhead functions BEFORE (check cache is clean)", () => {
@@ -874,29 +492,6 @@ describe("The implicit lookahead calculation functionality of the Recognizer For
         expect(lookaheadCache.keys().length).to.equal(5)
     })
 })
-
-describe("The Explicit lookahead functionality of the Recognizer for AT_LEAST_ONE_SEP", () => {
-
-    it("can accept lookahead function param for AT_LEAST_ONE_SEP1-5", () => {
-        let input = [new OneTok(), new TwoTok(), new Comma(), new TwoTok(), new ThreeTok(),
-            new FourTok(), new Comma(), new FourTok(), new FiveTok()]
-        let parser = new AtLeastOneSepExplicitLookAheadParser(input)
-        expect(parser.atLeastOneSepRule()).to.equal("1223445")
-    })
-
-    it("will fail when zero occurrences of AT_LEAST_ONE_SEP in input", () => {
-        let input = [new OneTok(), new TwoTok(), /*new ThreeTok(),*/ new FourTok(), new FiveTok()]
-        let parser = new AtLeastOneSepExplicitLookAheadParser(input)
-        expect(parser.atLeastOneSepRule()).to.equal("-666")
-    })
-
-    it("Will not cache any ImplicitLookahead functions when provided with explicit versions", () => {
-        let parser = new AtLeastOneSepExplicitLookAheadParser()
-        let lookaheadCache = parser.getLookAheadCache()
-        expect(lookaheadCache.keys().length).to.equal(0)
-    })
-})
-
 
 class OrImplicitLookAheadParser extends Parser {
 
@@ -1059,78 +654,6 @@ describe("The implicit lookahead calculation functionality of the Recognizer For
         let parser = new OrImplicitLookAheadParser()
         let lookaheadCache = parser.getLookAheadCache()
         expect(lookaheadCache.keys().length).to.equal(5)
-    })
-})
-
-class OrExplicitLookAheadParser extends Parser {
-
-    public getLookAheadCache():HashTable<Function> {
-        return getLookaheadFuncsForClass(this.className)
-    }
-
-    constructor(input:Token[] = []) {
-        super(input, ALL_TOKENS)
-        Parser.performSelfAnalysis(this)
-    }
-
-    public orRule = this.RULE("orRule", this.parseOrRule, {recoveryValueFunc: () => "-666"})
-
-    private parseOrRule():string {
-        let total = ""
-
-        // @formatter:off
-            this.OR1([
-                {WHEN: isOneTok, THEN_DO: () => {
-                    this.CONSUME1(OneTok)
-                    total += "1"
-                }},
-                {WHEN: isTwoTok, THEN_DO: () => {
-                    this.CONSUME1(TwoTok)
-                    total += "2"
-                }},
-                {WHEN: isThreeTok, THEN_DO: () => {
-                    this.CONSUME1(ThreeTok)
-                    total += "3"
-                }},
-                {WHEN: isFourTok, THEN_DO: () => {
-                    this.CONSUME1(FourTok)
-                    total += "4"
-                }},
-                {WHEN: isFiveTok, THEN_DO: () => {
-                    this.CONSUME1(FiveTok)
-                    total += "5"
-                }},
-            ], "digits")
-
-            // @formatter:on
-        return total
-    }
-}
-
-describe("The Explicit lookahead functionality of the Recognizer for OR", () => {
-
-    it("will cache the generatedLookAhead functions BEFORE (check cache is clean)", () => {
-        let parser = new OrExplicitLookAheadParser()
-        let lookaheadCache = parser.getLookAheadCache()
-        expect(lookaheadCache.keys().length).to.equal(0)
-    })
-
-    it("can accept the lookahead param explicitly for OR", () => {
-        let input = [new TwoTok()]
-        let parser = new OrExplicitLookAheadParser(input)
-        expect(parser.orRule()).to.equal("2")
-    })
-
-    it("will fail when none of the alternatives match", () => {
-        let input = [new SixTok()]
-        let parser = new OrExplicitLookAheadParser(input)
-        expect(parser.orRule()).to.equal("-666")
-    })
-
-    it("will NOT cache the generatedLookAhead functions in explicit mode", () => {
-        let parser = new OrExplicitLookAheadParser()
-        let lookaheadCache = parser.getLookAheadCache()
-        expect(lookaheadCache.keys().length).to.equal(0)
     })
 })
 


### PR DESCRIPTION
only add additional constraints to it.

Removed Parser.prototype.isNextRule method.
It is no longer needed the users of the library should never compute
lookahead funcitons. only predicates and backtracking.

Fixes #189.