### PR TITLE
Fix performance-test chart label typo

### DIFF
--- a/performance/index.html
+++ b/performance/index.html
@@ -195,7 +195,7 @@
         pegjsJsonLexerAndParser.parse(json_sample1k)
     }).add('parsimmon', function () {
         parse_json_parsimmon(json_sample1k)
-    }).add('Ohm', function () {
+    }).add('nearley', function () {
         parse_json_with_nearley(json_sample1k)
     }).add('Ohm', function () {
         parse_json_with_ohm(json_sample1k)


### PR DESCRIPTION
The littlest of nits, but it might save someone a little confusion.

![shot](https://cloud.githubusercontent.com/assets/5231746/17161165/157c530a-53a3-11e6-911b-9ee3eacc6a50.png)