### PR TITLE
BFS Style algorithim to compute the required Token lookahead 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## X.Y.Z (INSERT_DATE_HERE) 
+
+#### Bug Fixes
+- [Slow Parser Initialization.](https://github.com/SAP/chevrotain/issues/243)
+
+
+
 ## 0.13.2 (8-23-2016) 
 
 #### Bug Fixes

--- a/benchmark/parsers/cssDevParser.js
+++ b/benchmark/parsers/cssDevParser.js
@@ -147,7 +147,7 @@ var CssLexer = new Lexer(cssTokens);
 // ----------------- parser -----------------
 
 function CssParser(input) {
-    Parser.call(this, input, cssTokens, {maxLookahead: 3});
+    Parser.call(this, input, cssTokens);
     var $ = this;
 
     this.stylesheet = this.RULE('stylesheet', function() {
@@ -313,7 +313,7 @@ function CssParser(input) {
     // selector [ ',' S* selector ]*
     // '{' S* declaration? [ ';' S* declaration? ]* '}' S*
     this.ruleset = this.RULE('ruleset', function() {
-        $.MANY_SEP(Comma, function() {
+        $.AT_LEAST_ONE_SEP(Comma, function() {
             $.SUBRULE($.selector)
         })
 

--- a/benchmark/parsers/cssOldParser.js
+++ b/benchmark/parsers/cssOldParser.js
@@ -147,7 +147,7 @@ var CssLexer = new Lexer(cssTokens);
 // ----------------- parser -----------------
 
 function CssParser(input) {
-    Parser.call(this, input, cssTokens, {maxLookahead: 3});
+    Parser.call(this, input, cssTokens);
     var $ = this;
 
     this.stylesheet = this.RULE('stylesheet', function() {

--- a/examples/grammars/css/css.js
+++ b/examples/grammars/css/css.js
@@ -157,7 +157,7 @@
     // ----------------- parser -----------------
 
     function CssParser(input) {
-        Parser.call(this, input, cssTokens, {maxLookahead: 3});
+        Parser.call(this, input, cssTokens);
         var $ = this;
 
         this.stylesheet = this.RULE('stylesheet', function() {

--- a/src/parse/grammar/interpreter.ts
+++ b/src/parse/grammar/interpreter.ts
@@ -1,18 +1,11 @@
+/* tslint:disable:no-use-before-declare */
 import {RestWalker} from "./rest"
 import {gast} from "./gast_public"
-import {
-    IGrammarPath,
-    ITokenGrammarPath
-} from "./path_public"
-/* tslint:disable:no-use-before-declare */
-import {
-    cloneArr,
-    isEmpty,
-    first as _first, forEach, drop
-} from "../../utils/utils"
-/* tslint:enable:no-use-before-declare */
+import {IGrammarPath, ITokenGrammarPath} from "./path_public"
+import {cloneArr, isEmpty, first as _first, forEach, drop} from "../../utils/utils"
 import {tokenName} from "../../scan/tokens_public"
 import {first} from "./first"
+/* tslint:enable:no-use-before-declare */
 
 export abstract class AbstractNextPossibleTokensWalker extends RestWalker {
 
@@ -208,7 +201,12 @@ export class NextTerminalAfterAtLeastOneSepWalker extends AbstractNextTerminalAf
     }
 }
 
-export function possiblePathsFrom(targetDef:gast.IProduction[], maxLength:number, currPath = []):Function[][] {
+export interface PartialPathAndSuffixes {
+    partialPath:Function[]
+    suffixDef:gast.IProduction[]
+}
+
+export function possiblePathsFrom(targetDef:gast.IProduction[], maxLength:number, currPath = []):PartialPathAndSuffixes[] {
     // avoid side effects
     currPath = cloneArr(currPath)
     let result = []
@@ -222,6 +220,7 @@ export function possiblePathsFrom(targetDef:gast.IProduction[], maxLength:number
         let alternatives = possiblePathsFrom(remainingPathWith(prod.definition), maxLength, currPath)
         return result.concat(alternatives)
     }
+
     /**
      * Mandatory productions will halt the loop as the paths computed from their recursive calls will already contain the
      * following (rest) of the targetDef.
@@ -268,7 +267,10 @@ export function possiblePathsFrom(targetDef:gast.IProduction[], maxLength:number
 
         i++
     }
-    result.push(currPath)
+    result.push({
+        partialPath: currPath,
+        suffixDef:   drop(targetDef, 1)
+    })
 
     return result
 }

--- a/src/parse/parser_public.ts
+++ b/src/parse/parser_public.ts
@@ -1956,6 +1956,7 @@ export class Parser {
         if (errMsgTypes === undefined) {
             let ruleName = this.getCurrRuleFullName()
             let ruleGrammar = this.getGAstProductions().get(ruleName)
+            // TODO: getLookaheadPathsForOr can be slow for large enough maxLookahead and certain grammars, consider caching ?
             let lookAheadPathsPerAlternative = getLookaheadPathsForOr(occurrence, ruleGrammar, this.maxLookahead)
             let allLookAheadPaths = reduce(lookAheadPathsPerAlternative, (result, currAltPaths) => result.concat(currAltPaths), [])
             let nextValidTokenSequences = map(allLookAheadPaths, (currPath) =>

--- a/test/parse/grammar/interperter_spec.ts
+++ b/test/parse/grammar/interperter_spec.ts
@@ -29,6 +29,7 @@ import {setEquality} from "../../utils/matchers"
 
 import {gast} from "../../../src/parse/grammar/gast_public"
 import {Token} from "../../../src/scan/tokens_public"
+import {map} from "../../../src/utils/utils"
 
 let RepetitionMandatory = gast.RepetitionMandatory
 let Terminal = gast.Terminal
@@ -464,6 +465,10 @@ describe("The NextTerminalAfterAtLeastOneSepWalker", () => {
 
 describe("The chevrotain grammar interpreter capabilities", () => {
 
+    function extraPartialPaths(newResultFormat) {
+        return map(newResultFormat, (currItem) => currItem.partialPath)
+    }
+
     context("can calculate the next possible paths in a", () => {
 
         class Alpha extends Token {}
@@ -481,10 +486,10 @@ describe("The chevrotain grammar interpreter capabilities", () => {
                 new gast.Terminal(Gamma)
             ]
 
-            expect(possiblePathsFrom(seq, 1)).to.deep.equal([[Alpha]])
-            expect(possiblePathsFrom(seq, 2)).to.deep.equal([[Alpha, Beta]])
-            expect(possiblePathsFrom(seq, 3)).to.deep.equal([[Alpha, Beta, Gamma]])
-            expect(possiblePathsFrom(seq, 4)).to.deep.equal([[Alpha, Beta, Gamma]])
+            expect(extraPartialPaths(possiblePathsFrom(seq, 1))).to.deep.equal([[Alpha]])
+            expect(extraPartialPaths(possiblePathsFrom(seq, 2))).to.deep.equal([[Alpha, Beta]])
+            expect(extraPartialPaths(possiblePathsFrom(seq, 3))).to.deep.equal([[Alpha, Beta, Gamma]])
+            expect(extraPartialPaths(possiblePathsFrom(seq, 4))).to.deep.equal([[Alpha, Beta, Gamma]])
         })
 
         it("Optional", () => {
@@ -496,10 +501,10 @@ describe("The chevrotain grammar interpreter capabilities", () => {
                 new gast.Terminal(Gamma)
             ]
 
-            expect(possiblePathsFrom(seq, 1)).to.deep.equal([[Alpha]])
-            expect(possiblePathsFrom(seq, 2)).to.deep.equal([[Alpha, Beta], [Alpha, Gamma]])
-            expect(possiblePathsFrom(seq, 3)).to.deep.equal([[Alpha, Beta, Gamma], [Alpha, Gamma]])
-            expect(possiblePathsFrom(seq, 4)).to.deep.equal([[Alpha, Beta, Gamma], [Alpha, Gamma]])
+            expect(extraPartialPaths(possiblePathsFrom(seq, 1))).to.deep.equal([[Alpha]])
+            expect(extraPartialPaths(possiblePathsFrom(seq, 2))).to.deep.equal([[Alpha, Beta], [Alpha, Gamma]])
+            expect(extraPartialPaths(possiblePathsFrom(seq, 3))).to.deep.equal([[Alpha, Beta, Gamma], [Alpha, Gamma]])
+            expect(extraPartialPaths(possiblePathsFrom(seq, 4))).to.deep.equal([[Alpha, Beta, Gamma], [Alpha, Gamma]])
         })
 
         it("Alternation", () => {
@@ -518,10 +523,10 @@ describe("The chevrotain grammar interpreter capabilities", () => {
                 ])
             ])]
 
-            expect(possiblePathsFrom(alts, 1)).to.deep.equal([[Alpha], [Beta], [Beta]])
-            expect(possiblePathsFrom(alts, 2)).to.deep.equal([[Alpha], [Beta, Beta], [Beta, Alpha]])
-            expect(possiblePathsFrom(alts, 3)).to.deep.equal([[Alpha], [Beta, Beta], [Beta, Alpha, Gamma]])
-            expect(possiblePathsFrom(alts, 4)).to.deep.equal([[Alpha], [Beta, Beta], [Beta, Alpha, Gamma]])
+            expect(extraPartialPaths(possiblePathsFrom(alts, 1))).to.deep.equal([[Alpha], [Beta], [Beta]])
+            expect(extraPartialPaths(possiblePathsFrom(alts, 2))).to.deep.equal([[Alpha], [Beta, Beta], [Beta, Alpha]])
+            expect(extraPartialPaths(possiblePathsFrom(alts, 3))).to.deep.equal([[Alpha], [Beta, Beta], [Beta, Alpha, Gamma]])
+            expect(extraPartialPaths(possiblePathsFrom(alts, 4))).to.deep.equal([[Alpha], [Beta, Beta], [Beta, Alpha, Gamma]])
         })
 
         it("Repetition", () => {
@@ -532,10 +537,10 @@ describe("The chevrotain grammar interpreter capabilities", () => {
                 new gast.Terminal(Gamma)
             ]
 
-            expect(possiblePathsFrom(rep, 1)).to.deep.equal([[Alpha], [Gamma]])
-            expect(possiblePathsFrom(rep, 2)).to.deep.equal([[Alpha, Alpha], [Gamma]])
-            expect(possiblePathsFrom(rep, 3)).to.deep.equal([[Alpha, Alpha, Gamma], [Gamma]])
-            expect(possiblePathsFrom(rep, 4)).to.deep.equal([[Alpha, Alpha, Gamma], [Gamma]])
+            expect(extraPartialPaths(possiblePathsFrom(rep, 1))).to.deep.equal([[Alpha], [Gamma]])
+            expect(extraPartialPaths(possiblePathsFrom(rep, 2))).to.deep.equal([[Alpha, Alpha], [Gamma]])
+            expect(extraPartialPaths(possiblePathsFrom(rep, 3))).to.deep.equal([[Alpha, Alpha, Gamma], [Gamma]])
+            expect(extraPartialPaths(possiblePathsFrom(rep, 4))).to.deep.equal([[Alpha, Alpha, Gamma], [Gamma]])
         })
 
         it("Mandatory Repetition", () => {
@@ -546,10 +551,10 @@ describe("The chevrotain grammar interpreter capabilities", () => {
                 new gast.Terminal(Gamma)
             ]
 
-            expect(possiblePathsFrom(repMand, 1)).to.deep.equal([[Alpha]])
-            expect(possiblePathsFrom(repMand, 2)).to.deep.equal([[Alpha, Alpha]])
-            expect(possiblePathsFrom(repMand, 3)).to.deep.equal([[Alpha, Alpha, Gamma]])
-            expect(possiblePathsFrom(repMand, 4)).to.deep.equal([[Alpha, Alpha, Gamma]])
+            expect(extraPartialPaths(possiblePathsFrom(repMand, 1))).to.deep.equal([[Alpha]])
+            expect(extraPartialPaths(possiblePathsFrom(repMand, 2))).to.deep.equal([[Alpha, Alpha]])
+            expect(extraPartialPaths(possiblePathsFrom(repMand, 3))).to.deep.equal([[Alpha, Alpha, Gamma]])
+            expect(extraPartialPaths(possiblePathsFrom(repMand, 4))).to.deep.equal([[Alpha, Alpha, Gamma]])
         })
 
         it("Repetition with Separator", () => {
@@ -562,10 +567,10 @@ describe("The chevrotain grammar interpreter capabilities", () => {
                 new gast.Terminal(Gamma)
             ]
 
-            expect(possiblePathsFrom(rep, 1)).to.deep.equal([[Alpha], [Gamma]])
-            expect(possiblePathsFrom(rep, 2)).to.deep.equal([[Alpha, Alpha], [Gamma]])
-            expect(possiblePathsFrom(rep, 3)).to.deep.equal([[Alpha, Alpha, Gamma], [Gamma]])
-            expect(possiblePathsFrom(rep, 4)).to.deep.equal([[Alpha, Alpha, Gamma], [Gamma]])
+            expect(extraPartialPaths(possiblePathsFrom(rep, 1))).to.deep.equal([[Alpha], [Gamma]])
+            expect(extraPartialPaths(possiblePathsFrom(rep, 2))).to.deep.equal([[Alpha, Alpha], [Gamma]])
+            expect(extraPartialPaths(possiblePathsFrom(rep, 3))).to.deep.equal([[Alpha, Alpha, Gamma], [Gamma]])
+            expect(extraPartialPaths(possiblePathsFrom(rep, 4))).to.deep.equal([[Alpha, Alpha, Gamma], [Gamma]])
         })
 
         it("Mandatory Repetition with Separator", () => {
@@ -578,10 +583,10 @@ describe("The chevrotain grammar interpreter capabilities", () => {
                 new gast.Terminal(Gamma)
             ]
 
-            expect(possiblePathsFrom(repMandSep, 1)).to.deep.equal([[Alpha]])
-            expect(possiblePathsFrom(repMandSep, 2)).to.deep.equal([[Alpha, Alpha]])
-            expect(possiblePathsFrom(repMandSep, 3)).to.deep.equal([[Alpha, Alpha, Gamma]])
-            expect(possiblePathsFrom(repMandSep, 4)).to.deep.equal([[Alpha, Alpha, Gamma]])
+            expect(extraPartialPaths(possiblePathsFrom(repMandSep, 1))).to.deep.equal([[Alpha]])
+            expect(extraPartialPaths(possiblePathsFrom(repMandSep, 2))).to.deep.equal([[Alpha, Alpha]])
+            expect(extraPartialPaths(possiblePathsFrom(repMandSep, 3))).to.deep.equal([[Alpha, Alpha, Gamma]])
+            expect(extraPartialPaths(possiblePathsFrom(repMandSep, 4))).to.deep.equal([[Alpha, Alpha, Gamma]])
         })
 
         it("NonTerminal", () => {
@@ -595,10 +600,10 @@ describe("The chevrotain grammar interpreter capabilities", () => {
                 new gast.Terminal(Gamma)
             ]
 
-            expect(possiblePathsFrom(seq, 1)).to.deep.equal([[Alpha]])
-            expect(possiblePathsFrom(seq, 2)).to.deep.equal([[Alpha, Beta]])
-            expect(possiblePathsFrom(seq, 3)).to.deep.equal([[Alpha, Beta, Gamma]])
-            expect(possiblePathsFrom(seq, 4)).to.deep.equal([[Alpha, Beta, Gamma]])
+            expect(extraPartialPaths(possiblePathsFrom(seq, 1))).to.deep.equal([[Alpha]])
+            expect(extraPartialPaths(possiblePathsFrom(seq, 2))).to.deep.equal([[Alpha, Beta]])
+            expect(extraPartialPaths(possiblePathsFrom(seq, 3))).to.deep.equal([[Alpha, Beta, Gamma]])
+            expect(extraPartialPaths(possiblePathsFrom(seq, 4))).to.deep.equal([[Alpha, Beta, Gamma]])
         })
     })
 

--- a/test/parse/recognizer_lookahead_spec.ts
+++ b/test/parse/recognizer_lookahead_spec.ts
@@ -889,7 +889,7 @@ describe("The support for MultiToken (K>1) implicit lookahead capabilities in DS
                 (<any>Parser).performSelfAnalysis(this)
             }
 
-            public rule = this.RULE("orRule", () => {
+            public rule = this.RULE("rule", () => {
                 let result = "OPTION Not Taken"
                 this.OPTION(() => {
                     this.CONSUME1(OneTok)


### PR DESCRIPTION
instead of DFS.

This avoids performance issues with the initialization of some parsers
As alot of unnecessary work was done which was determined by the configured maxLookahead
instead of the actual lookahead required for the specific grammar.

Thanks to @Levin81 for algorithmic assistance.

Fixes #243