### PR TITLE
Consistent API for "OR" DSL method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## X.Y.Z (INSERT_DATE_HERE) 
+
+#### Breaking Changes
+- [OR DSL method Syntax should be more consistent. #192](https://github.com/SAP/chevrotain/issues/192)
+
+
+
 ## 0.13.4 (9-1-2016) 
 
 #### Minor Changes

--- a/examples/parser/parametrized_rules/parametrized.js
+++ b/examples/parser/parametrized_rules/parametrized.js
@@ -64,8 +64,8 @@ class HelloParser extends chevrotain.Parser {
 
             // The mood parameter is used to determine which path to take
             this.OR([
-                {WHEN: () => mood === "positive", THEN_DO: () => this.SUBRULE(this.positive)},
-                {WHEN: () => mood === "negative", THEN_DO: () => this.SUBRULE(this.negative)}
+                {GATE: () => mood === "positive", ALT: () => this.SUBRULE(this.positive)},
+                {GATE: () => mood === "negative", ALT: () => this.SUBRULE(this.negative)}
             ])
 
             this.CONSUME(World)

--- a/examples/parser/predicate_lookahead/predicate_lookahead.js
+++ b/examples/parser/predicate_lookahead/predicate_lookahead.js
@@ -58,15 +58,15 @@ function PredicateLookaheadParser(input) {
             // "maxNumberAllowed" flag. For each alternative a custom Predicate / Gate function is provided
             // A Predicate / Gate function may also be provided for other grammar DSL rules.
             // (OPTION/MANY/AT_LEAST_ONE/...)
-            {WHEN: isOne, THEN_DO: function() {
+            {GATE: isOne, ALT: function() {
                 $.CONSUME(One);
                 return 1;
             }},
-            {WHEN: isTwo, THEN_DO: function() {
+            {GATE: isTwo, ALT: function() {
                 $.CONSUME(Two);
                 return 2;
             }},
-            {WHEN: isThree, THEN_DO: function() {
+            {GATE: isThree, ALT: function() {
                 $.CONSUME(Three);
                 return 3;
             }}

--- a/src/parse/gast_builder.ts
+++ b/src/parse/gast_builder.ts
@@ -46,7 +46,7 @@ let atLeastOneRegExGlobal = new RegExp(atLeastOneRegEx.source, "g")
 let orRegEx = /\.\s*OR(\d)?\s*\(/
 let orRegExGlobal = new RegExp(orRegEx.source, "g")
 
-let orPartRegEx = /{\s*(WHEN|ALT)\s*:/g
+let orPartRegEx = /\s*(ALT)\s*:/g
 
 export interface ITerminalNameToConstructor {
     [fqn: string]: Function

--- a/src/parse/grammar/lookahead.ts
+++ b/src/parse/grammar/lookahead.ts
@@ -84,7 +84,7 @@ export function buildAlternativesLookAheadFunc(alts:lookAheadSequence[], hasPred
             // unfortunately the predicates must be extracted every single time
             // as they cannot be cached due to keep references to parameters(vars) which are no longer valid.
             // note that in the common case of no predicates, no cpu time will be wasted on this (see else block)
-            let predicates:Predicate[] = map(orAlts, (currAlt) => currAlt.WHEN)
+            let predicates:Predicate[] = map(orAlts, (currAlt) => currAlt.GATE)
 
             for (let t = 0; t < numOfAlts; t++) {
                 let currAlt = alts[t]

--- a/test/full_flow/backtracking/backtracking_parser.ts
+++ b/test/full_flow/backtracking/backtracking_parser.ts
@@ -65,12 +65,12 @@ export class BackTrackingParser extends Parser {
                 // we can build an LL(K) parser that can distinguish the two alternatives as a negative example
                 // would be to simply create a qualifiedName with a length of k+1.
                 {
-                    WHEN:    this.BACKTRACK(this.withEqualsStatement, (result) => { return result === RET_TYPE.WITH_EQUALS }),
-                    THEN_DO: () => { statementTypeFound = this.SUBRULE(this.withEqualsStatement) }
+                    GATE:    this.BACKTRACK(this.withEqualsStatement, (result) => { return result === RET_TYPE.WITH_EQUALS }),
+                    ALT: () => { statementTypeFound = this.SUBRULE(this.withEqualsStatement) }
                 },
                 {
-                    WHEN:    this.BACKTRACK(this.withDefaultStatement, (result) => { return result === RET_TYPE.WITH_DEFAULT }),
-                    THEN_DO: () => { statementTypeFound = this.SUBRULE(this.withDefaultStatement) }
+                    GATE:    this.BACKTRACK(this.withDefaultStatement, (result) => { return result === RET_TYPE.WITH_DEFAULT }),
+                    ALT: () => { statementTypeFound = this.SUBRULE(this.withDefaultStatement) }
                 },
             ], " a statement")
 

--- a/test/parse/gast_builder_spec.ts
+++ b/test/parse/gast_builder_spec.ts
@@ -40,14 +40,14 @@ describe("The GAst Builder namespace", () => {
         "            let typeKw = this.CONSUME1(TypeTok)\r\n" +
         "            let typeName = this.CONSUME1(IdentTok)\r\n" +
         "            let typeSpec = this.OR([\r\n" +
-        "                {WHEN: this.isStructType, THEN_DO: ()=> {\r\n" +
+        "                {ALT: this.isStructType, ALT: ()=> {\r\n" +
         "                    let structType = this.SUBRULE(this.structuredType)\r\n" +
         "                    this.OPTION(()=> {return this.NEXT_TOKEN() instanceof SemicolonTok}, ()=> {\r\n" +
         "                        semiColon = this.CONSUME1(SemicolonTok)\r\n" +
         "                    })\r\n" +
         "                    return structType\r\n" +
         "                }},\r\n" +
-        "                {WHEN: this.isAssignedTypeSpec, THEN_DO: ()=> {\r\n" +
+        "                {ALT: this.isAssignedTypeSpec, ALT: ()=> {\r\n" +
         "                    let assTypeSpec = this.SUBRULE(this.assignedTypeSpec)\r\n" +
         "                    semiColon = this.CONSUME2(SemicolonTok)\r\n" +
         "                    return assTypeSpec\r\n" +
@@ -64,10 +64,10 @@ describe("The GAst Builder namespace", () => {
         "            let elementName = this.CONSUME1(IdentTok)\r\n" +
         "\r\n" +
         "            let assTypeSpec = this.OR([\r\n" +
-        "                {WHEN: this.isAssignedTypeSpec, THEN_DO: ()=> {\r\n" +
+        "                {GATE: this.isAssignedTypeSpec, ALT: ()=> {\r\n" +
         "                    return this.SUBRULE(this.assignedTypeSpec)\r\n" +
         "                }},\r\n" +
-        "                {WHEN: ()=> {return true}, THEN_DO: ()=> {\r\n" +
+        "                {GATE: ()=> {return true}, ALT: ()=> {\r\n" +
         "                    return this.SUBRULE(this.assignedTypeSpecImplicit)\r\n" +
         "                }}\r\n" +
         "            ], \"\").tree\r\n" +
@@ -163,10 +163,10 @@ describe("The GAst Builder namespace", () => {
 
         let refText = map(actual, (rangeProd) => { return rangeProd.text})
         expect(refText[0]).to.equal(".OR([\r\n" +
-            "                {WHEN: this.isAssignedTypeSpec, THEN_DO: ()=> {\r\n" +
+            "                {GATE: this.isAssignedTypeSpec, ALT: ()=> {\r\n" +
             "                    return this.SUBRULE(this.assignedTypeSpec)\r\n" +
             "                }},\r\n" +
-            "                {WHEN: ()=> {return true}, THEN_DO: ()=> {\r\n" +
+            "                {GATE: ()=> {return true}, ALT: ()=> {\r\n" +
             "                    return this.SUBRULE(this.assignedTypeSpecImplicit)\r\n" +
             "                }}\r\n" +
             "            ], \"\")")
@@ -438,10 +438,10 @@ describe("The GAst Builder namespace", () => {
     it("can build nested OR grammar successfully", () => {
 
         let input = " let max = this.OR([\n\
-                {WHEN: isExpression, THEN_DO: ()=> {\n\
+                {GATE: isExpression, ALT: ()=> {\n\
                     this.OR([\n\
                             \n\
-                        {WHEN: isAlias, THEN_DO: ()=> {\n\
+                        {GATE: isAlias, ALT: ()=> {\n\
                             return PT(this.CONSUME1(ViaTok))\n\
                         }}\n\
                     ], 'Expression or Star Token')\n\

--- a/test/parse/predicate_spec.ts
+++ b/test/parse/predicate_spec.ts
@@ -152,7 +152,7 @@ describe("The chevrotain support for custom gates/predicates on DSL production:"
                             this.CONSUME1(A)
                             return "A"
                         }}, // Has predicate
-                        {WHEN: gateFunc, THEN_DO: () => {
+                        {GATE: gateFunc, ALT: () => {
                             this.CONSUME1(B)
                             return "B"
                         }},
@@ -199,8 +199,8 @@ describe("The chevrotain support for custom gates/predicates on DSL production:"
 
                 public topRule = this.RULE("topRule", (param) => {
                     return this.OR1([
-                        {WHEN: () => param, THEN_DO: () => this.CONSUME1(A).image},
-                        {WHEN: () => !param, THEN_DO: () => this.CONSUME1(B).image}
+                        {GATE: () => param, ALT: () => this.CONSUME1(A).image},
+                        {GATE: () => !param, ALT: () => this.CONSUME1(B).image}
                     ])
                 })
             }


### PR DESCRIPTION
Both The variant with Gates and Without Gates
Will use the "ALT" property for the grammar action.
The "GATE" property now replaces the "WHEN" property as it
more explicitly specifies the intent.

Fixes #192