### PR TITLE
Performance optimization: Create cache keys using bitwise operations.

### DIFF
--- a/benchmark/parsers/devJsonParser.js
+++ b/benchmark/parsers/devJsonParser.js
@@ -21,7 +21,7 @@ var NumberLiteral = extendToken("NumberLiteral", /-?(0|[1-9]\d*)(\.\d+)?([eE][+-
 var WhiteSpace = extendToken("WhiteSpace", /\s+/);
 WhiteSpace.GROUP = Lexer.SKIPPED; // marking WhiteSpace as 'SKIPPED' makes the lexer skip it.
 
-var allTokens = [WhiteSpace, NumberLiteral, StringLiteral, LCurly, RCurly, LSquare, RSquare, Comma, Colon, True, False, Null];
+var allTokens = [WhiteSpace, StringLiteral, NumberLiteral, Comma, Colon, LCurly, RCurly, LSquare, RSquare, True, False, Null];
 var JsonLexer = new Lexer(allTokens);
 
 

--- a/benchmark/parsers/oldJsonParser.js
+++ b/benchmark/parsers/oldJsonParser.js
@@ -21,7 +21,7 @@ var NumberLiteral = extendToken("NumberLiteral", /-?(0|[1-9]\d*)(\.\d+)?([eE][+-
 var WhiteSpace = extendToken("WhiteSpace", /\s+/);
 WhiteSpace.GROUP = Lexer.SKIPPED; // marking WhiteSpace as 'SKIPPED' makes the lexer skip it.
 
-var allTokens = [WhiteSpace, NumberLiteral, StringLiteral, LCurly, RCurly, LSquare, RSquare, Comma, Colon, True, False, Null];
+var allTokens = [WhiteSpace, StringLiteral, NumberLiteral, Comma, Colon, LCurly, RCurly, LSquare, RSquare, True, False, Null];
 var JsonLexer = new Lexer(allTokens);
 
 

--- a/src/lang/lang_extensions.ts
+++ b/src/lang/lang_extensions.ts
@@ -73,7 +73,7 @@ export class HashTable<V> {
         return <any>utils.values(this._state)
     }
 
-    put(key:string, value:V):void {
+    put(key:string|number, value:V):void {
         this._state[key] = value
     }
 

--- a/src/parse/cache.ts
+++ b/src/parse/cache.ts
@@ -46,37 +46,8 @@ export function getProductionOverriddenForClass(className:string):HashTable<bool
     return getFromNestedHashTable(className, CLASS_TO_PRODUCTION_OVERRIDEN)
 }
 
-export let CLASS_TO_OR_LA_CACHE = new HashTable<HashTable<string>[]>()
-export let CLASS_TO_MANY_LA_CACHE = new HashTable<HashTable<string>[]>()
-export let CLASS_TO_MANY_SEP_LA_CACHE = new HashTable<HashTable<string>[]>()
-export let CLASS_TO_AT_LEAST_ONE_LA_CACHE = new HashTable<HashTable<string>[]>()
-export let CLASS_TO_AT_LEAST_ONE_SEP_LA_CACHE = new HashTable<HashTable<string>[]>()
-export let CLASS_TO_OPTION_LA_CACHE = new HashTable<HashTable<string>[]>()
-
 // TODO reflective test to verify this has not changed, for example (OPTION6 added)
 export const MAX_OCCURRENCE_INDEX = 5
-
-export function initLookAheadKeyCache(className) {
-    CLASS_TO_OR_LA_CACHE[className] = new Array(MAX_OCCURRENCE_INDEX)
-    CLASS_TO_MANY_LA_CACHE[className] = new Array(MAX_OCCURRENCE_INDEX)
-    CLASS_TO_MANY_SEP_LA_CACHE[className] = new Array(MAX_OCCURRENCE_INDEX)
-    CLASS_TO_AT_LEAST_ONE_LA_CACHE[className] = new Array(MAX_OCCURRENCE_INDEX)
-    CLASS_TO_AT_LEAST_ONE_SEP_LA_CACHE[className] = new Array(MAX_OCCURRENCE_INDEX)
-    CLASS_TO_OPTION_LA_CACHE[className] = new Array(MAX_OCCURRENCE_INDEX)
-
-    initSingleLookAheadKeyCache(CLASS_TO_OR_LA_CACHE[className])
-    initSingleLookAheadKeyCache(CLASS_TO_MANY_LA_CACHE[className])
-    initSingleLookAheadKeyCache(CLASS_TO_MANY_SEP_LA_CACHE[className])
-    initSingleLookAheadKeyCache(CLASS_TO_AT_LEAST_ONE_LA_CACHE[className])
-    initSingleLookAheadKeyCache(CLASS_TO_AT_LEAST_ONE_SEP_LA_CACHE[className])
-    initSingleLookAheadKeyCache(CLASS_TO_OPTION_LA_CACHE[className])
-}
-
-function initSingleLookAheadKeyCache(laCache:HashTable<string>[]):void {
-    for (let i = 0; i < MAX_OCCURRENCE_INDEX; i++) {
-        laCache[i] = new HashTable<string>()
-    }
-}
 
 function getFromNestedHashTable(className:string, hashTable:HashTable<any>) {
     let result = hashTable.get(className)

--- a/test/parse/cache_spec.ts
+++ b/test/parse/cache_spec.ts
@@ -1,19 +1,14 @@
 import * as cache from "../../src/parse/cache"
 import {clearCache} from "../../src/parse/cache_public"
-import {HashTable} from "../../src/lang/lang_extensions"
 
 describe("The chevrotain cache", () => {
 
     it("Can clear the cache", () => {
-        cache.CLASS_TO_AT_LEAST_ONE_LA_CACHE.put("bamba", [new HashTable<string>()])
         cache.CLASS_TO_SELF_ANALYSIS_DONE.put("bisli", true)
-
-        expect(cache.CLASS_TO_AT_LEAST_ONE_LA_CACHE.containsKey("bamba")).to.be.true
         expect(cache.CLASS_TO_SELF_ANALYSIS_DONE.containsKey("bisli")).to.be.true
 
         clearCache()
 
-        expect(cache.CLASS_TO_AT_LEAST_ONE_LA_CACHE.containsKey("bamba")).to.be.false
         expect(cache.CLASS_TO_SELF_ANALYSIS_DONE.containsKey("bisli")).to.be.false
     })
 })


### PR DESCRIPTION
The cached Keys are for cached lookahead functions.

This is slightly faster (1-4% on V8) than using
Short string keys, and in addition simplifies the key building logic
as a previous optimization to avoid string concat has now been removed.