### PR TITLE
Performance Improvements: Lookahead functions

### DIFF
--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -12,7 +12,7 @@ var isBenchmarkOnlyLexer = false
 
 var _ = require("lodash")
 
-var times = 100
+var times = 200
 var warmupTimes = 10
 
 function performBenchmark(name, input, devParse, oldParse) {

--- a/benchmark/parsers/cssDevParser.js
+++ b/benchmark/parsers/cssDevParser.js
@@ -26,7 +26,7 @@ function MAKE_PATTERN(def, flags) {
 // array of cssTokens
 var cssTokens = [];
 var extendToken = function() {
-    var newToken = chevrotain.extendToken.apply(null, arguments);
+    var newToken = chevrotain.extendLazyToken.apply(null, arguments);
     cssTokens.push(newToken);
     return newToken;
 }

--- a/benchmark/parsers/cssOldParser.js
+++ b/benchmark/parsers/cssOldParser.js
@@ -26,7 +26,7 @@ function MAKE_PATTERN(def, flags) {
 // array of cssTokens
 var cssTokens = [];
 var extendToken = function() {
-    var newToken = chevrotain.extendToken.apply(null, arguments);
+    var newToken = chevrotain.extendLazyToken.apply(null, arguments);
     cssTokens.push(newToken);
     return newToken;
 }

--- a/benchmark/parsers/devJsonParser.js
+++ b/benchmark/parsers/devJsonParser.js
@@ -2,7 +2,7 @@
 var chevrotain = require("../../lib/chevrotain");
 
 // ----------------- lexer -----------------
-var extendToken = chevrotain.extendToken;
+var extendToken = chevrotain.extendLazyToken;
 var Lexer = chevrotain.Lexer;
 var Parser = chevrotain.Parser;
 
@@ -32,7 +32,7 @@ function JsonParserDev(input) {
     Parser.call(this, input, allTokens, {
             // by default the error recovery / fault tolerance capabilities are disabled
             // use this flag to enable them
-            recoveryEnabled: true
+            recoveryEnabled: false
         }
     );
 

--- a/benchmark/parsers/oldJsonParser.js
+++ b/benchmark/parsers/oldJsonParser.js
@@ -2,7 +2,7 @@
 var chevrotain = require("../../examples/grammars/node_modules/chevrotain/lib/chevrotain");
 
 // ----------------- lexer -----------------
-var extendToken = chevrotain.extendToken;
+var extendToken = chevrotain.extendLazyToken;
 var Lexer = chevrotain.Lexer;
 var Parser = chevrotain.Parser;
 
@@ -32,7 +32,7 @@ function JsonParserOld(input) {
     Parser.call(this, input, allTokens, {
             // by default the error recovery / fault tolerance capabilities are disabled
             // use this flag to enable them
-            recoveryEnabled: true
+            recoveryEnabled: false
         }
     );
 

--- a/src/scan/lexer_public.ts
+++ b/src/scan/lexer_public.ts
@@ -15,7 +15,7 @@ import {
     flatten,
     mapValues
 } from "../utils/utils"
-import {fillUpLineToOffset, getStartColumnFromLineToOffset, getStartLineFromLineToOffset} from "./tokens"
+import {fillUpLineToOffset, getStartColumnFromLineToOffset, getStartLineFromLineToOffset, augmentTokenClasses} from "./tokens"
 
 export type TokenConstructor = Function
 
@@ -213,6 +213,7 @@ export class Lexer {
             // Considering a lexer with definition errors may never be used, there is no point
             // to performing the analysis anyhow...
             if (isEmpty(this.lexerDefinitionErrors)) {
+                augmentTokenClasses(currModDef)
                 let currAnalyzeResult = analyzeTokenClasses(currModDef)
                 this.allPatterns[currModName] = currAnalyzeResult.allPatterns
                 this.patternIdxToClass[currModName] = currAnalyzeResult.patternIdxToClass

--- a/src/scan/tokens.ts
+++ b/src/scan/tokens.ts
@@ -1,3 +1,7 @@
+import {TokenConstructor} from "./lexer_public"
+import {has, forEach} from "../utils/utils"
+import {Token, LazyToken} from "./tokens_public"
+
 export function fillUpLineToOffset(lineToOffset:number[], text:string):void {
     let currLine = 0
     let currOffset = 0
@@ -93,4 +97,22 @@ function findColumnOfOffset(offset:number, lineToOffset:number[]):number {
     // +1 because columns always start at 1
     return offset - lineToOffset[line - 1] + 1
 
+}
+
+export function isBaseTokenClass(tokClass:Function):boolean {
+    return tokClass === Token || tokClass === LazyToken
+}
+
+let tokenShortNameIdx = 0
+
+export function augmentTokenClasses(tokenClasses:TokenConstructor[]):void {
+    forEach(tokenClasses, (currTokClass) => {
+        if (!hasShortKeyProperty(currTokClass)) {
+            currTokClass.uniqueTokenTypeShortKey = tokenShortNameIdx++
+        }
+    })
+}
+
+export function hasShortKeyProperty(tokClass:TokenConstructor):boolean {
+    return has(tokClass, "uniqueTokenTypeShortKey")
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -320,5 +320,8 @@ export function merge(obj1:Object, obj2:Object):any {
     return result
 }
 
-
 export function NOOP() {}
+
+export function getSuperClass(clazz:Function):Function {
+    return Object.getPrototypeOf(clazz.prototype).constructor
+}


### PR DESCRIPTION
Faster lookahead functions for common use case of no Token inheritance
and single token lookahead.

Improves Performance up to 10% in more complex grammars (On V8).