### PR TITLE
Devops: Disable SauceLab badge always updating.

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -380,11 +380,17 @@ module.exports = function(grunt) {
         'karma:browsers_integration_tests_amd_minified'
     ]
 
-    if (process.env.TRAVIS_PULL_REQUEST && !process.env.SAUCE_USERNAME) {
+    if (process.env.TRAVIS_PULL_REQUEST) {
         browsers_tests = function() {
-            console.log("Skipping browser tests on pull request because \n" +
-                "process.env.SAUCE_USERNAME & process.env.SAUCE_ACCESS_KEY \n" +
-                "are not available on pull requests from external repositories.")
+            console.log("Skipping browser tests due to running in a pull request env without the SauceLabs credentials\n"
+            )
+        }
+    }
+
+    if (process.env.TRAVIS_BRANCH !== "master") {
+        browsers_tests = function() {
+            console.log("Skipping browser tests as they should only run on the 'master' branch\n" +
+            "As there seems to be issues enabling tags and result filtering with the karma-sauce-labs-launcher")
         }
     }
 

--- a/karma_sauce.conf.js
+++ b/karma_sauce.conf.js
@@ -71,11 +71,16 @@ module.exports = function(config) {
         recordScreenshots: false
     }
 
-    // Avoid updating SauceLabs badge for non Master branch builds.
-    if (process.env.TRAVIS && 
-        process.env.TRAVIS_BRANCH === "master" && 
+    if (process.env.TRAVIS) {
+        sauceConfig.build = 'TRAVIS #' + process.env.TRAVIS_BUILD_NUMBER + ' (' + process.env.TRAVIS_BUILD_ID + ')'
+
+    }
+
+    // TODO: this does not actually seem to work... if it would work we can use filtering by tag name in the badge.
+    if (process.env.TRAVIS_BRANCH === "master" &&
         process.env.TRAVIS_PULL_REQUEST !== "false") {
-        sauceConfig.build = 'TRAVIS #' + process.env.TRAVIS_BUILD_NUMBER + ' (' + process.env.TRAVIS_BUILD_ID + ')';
+        console.log("Sauce Labs results will be reported in the badge")
+        sauceConfig.tags = ["master"]
     }
 
     config.set({


### PR DESCRIPTION
It should only update for results from the master branch.
This seems to require disabling SauceLabs browser testing on pull requests builds.
Because I was unable to get the "tags" feature of the karma saucelabs launcher to work.