### PR TITLE
Add json only

### DIFF
--- a/performance/index.html
+++ b/performance/index.html
@@ -301,40 +301,33 @@
 
         addTest(suite, 'Ohm', parse_json_with_ohm);
 
-
         suite.on('cycle', function (event) {
+            var suite = event.target
+              , rate = suite.hz.toFixed(2)
+              , cell = document.getElementById('rate' + suite.name);
 
-            var table = document.getElementById("resultsTable");
-            data.labels.push(event.target.name);
-            data.datasets[0].data.push(event.target.hz.toFixed(2));
+            cell.innerHTML = '<large><b>' + rate + '<br>' + '</b></large>' +
+                    '<medium>&plusmn;' + suite.stats.rme.toFixed(2) + '%</medium>';
 
-            var rowName = event.target.name;
-            var rowNum = _.findIndex(table.rows, function (currRow) {
-                // the text domNode
-                return currRow.childNodes[1].innerHTML.indexOf(rowName) !== -1
-            })
-            var row = table.rows[rowNum];
-            var cell2 = row.cells[1];
-            cell2.innerHTML = '<large><b>' + event.target.hz.toFixed(2) + '<br>' + '</b></large>' +
-                    '<medium>&plusmn;' + event.target.stats.rme.toFixed(2) + '%</medium>';
+            data.labels.push(suite.name);
+            data.datasets[0].data.push(rate);
 
         }).on('complete', function (yyy) {
 
-            var table = document.getElementById("resultsTable");
+            var suites = this.filter('successful')
+              , fastestSuite = this.filter('fastest')[0];
 
-            var fastestSuite = this.filter('fastest')[0]
-            var succesfull = this.filter('successful')
+            suites.splice(suites.indexOf(fastestSuite), 1);
 
-            _.forEach(succesfull, function (currSuite, idx) {
-                var currRelativeCell = table.rows[idx + 1].cells[2]
+            var cell = document.getElementById('speed' + fastestSuite.name);
+            cell.innerHTML = "<b>100% <br> <small>(fastest)</b></small>";
+            $('#row' + fastestSuite.name).addClass("fastestRow");
 
-                if (currSuite === fastestSuite) {
-                    currRelativeCell.innerHTML = "<b>100% <br> <small>(fastest)</b></small>"
-                    $(table.rows[idx + 1]).toggleClass("fastestRow")
-                } else {
-                    currRelativeCell.innerHTML = '<large>' + ((currSuite.hz / fastestSuite.hz).toFixed(4) * 100).toFixed(2) + "%</large>"
-                }
-            })
+            _.forEach(suites, function (suite) {
+              var cell = document.getElementById('speed' + suite.name)
+                , speed = ((suite.hz / fastestSuite.hz).toFixed(4) * 100).toFixed(2);
+              cell.innerHTML = '<large>' + speed + "%</large>"
+            });
 
             window.clearInterval(dots);
             document.getElementById("wait").innerHTML = "";

--- a/performance/index.html
+++ b/performance/index.html
@@ -100,11 +100,11 @@
 
             <li><p>
                 <a rel="nofollow" href="https://github.com/cdglabs/ohm">Ohm-js</a> Parser Library
-                <a rel="nofollow"\
+                <a rel="nofollow"
                   href="https://github.com/sap/chevrotain/blob/gh-pages/performance/jsonParsers/ohm/ohm_json_grammar.js">grammar</a>
                 <a rel="nofollow"
                   href="https://github.com/sap/chevrotain/blob/gh-pages/performance/jsonParsers/ohm/ohm_json_parser.js">parser</a>
-            </p></li>`
+            </p></li>
 
         </ol>
         <p>The JSON Grammar was used because it is simple to implement, simple to compare and is often already

--- a/performance/index.html
+++ b/performance/index.html
@@ -97,6 +97,15 @@
                    href="https://github.com/sap/chevrotain/blob/gh-pages/performance/jsonParsers/nearley/nearley_json_parser_tokenizer.js">hand
                     built lexer</a>
             </p></li>
+
+            <li><p>
+                <a rel="nofollow" href="https://github.com/cdglabs/ohm">Ohm-js</a> Parser Library
+                <a rel="nofollow"\
+                  href="https://github.com/sap/chevrotain/blob/gh-pages/performance/jsonParsers/ohm/ohm_json_grammar.js">grammar</a>
+                <a rel="nofollow"
+                  href="https://github.com/sap/chevrotain/blob/gh-pages/performance/jsonParsers/ohm/ohm_json_parser.js">parser</a>
+            </p></li>`
+
         </ol>
         <p>The JSON Grammar was used because it is simple to implement, simple to compare and is often already
             available as a sample grammar for most Parsing Tools</p>
@@ -122,41 +131,66 @@
         <span id="wait" style="margin-left: auto;margin-right: auto;"></span>
 
         <table id="resultsTable">
+          <thead>
             <tr class="tableHeaderRow">
                 <th>Parser Library</th>
                 <th>Ops/sec</th>
                 <th>Relative Speed</th>
+                <th>Include?</th>
             </tr>
-            <tr>
+          </thead>
+
+          <tbody>
+            <tr id="rowChevrotain">
                 <td class="benchName"><a rel="nofollow" href="https://github.com/SAP/chevrotain">Chevrotain</a></td>
-                <td></td>
-                <td></td>
+                <td id="rateChevrotain"></td>
+                <td id="speedChevrotain"></td>
+                <td><input id="includeChevrotain" type="checkbox" checked=checked/></td>
             </tr>
-            <tr>
-                <td class="benchName"><a rel="nofollow" href="http://zaach.github.io/jison/">Jison</a></td>
-                <td></td>
-                <td></td>
-            </tr>
-            <tr>
-                <td class="benchName"><a rel="nofollow" href="http://www.antlr.org/">ANTLR4</a></td>
-                <td></td>
-                <td></td>
-            </tr>
-            <tr>
-                <td class="benchName"><a rel="nofollow" href="http://pegjs.org/">PEG.js</a></td>
-                <td></td>
-                <td></td>
-            </tr>
-            <tr>
+
+            <tr id="rowParsimmon">
                 <td class="benchName"><a rel="nofollow" href="https://github.com/jneen/parsimmon">Parsimmon</a></td>
-                <td></td>
-                <td></td>
+                <td id="rateParsimmon"></td>
+                <td id="speedParsimmon"></td>
+                <td><input id="includeParsimmon" type="checkbox" checked=checked /></td>
             </tr>
-            <tr>
+
+            <tr id="rowAntlr">
+                <td class="benchName"><a rel="nofollow" href="http://www.antlr.org/">ANTLR4</a></td>
+                <td id="rateAntlr"></td>
+                <td id="speedAntlr"></td>
+                <td><input id="includeAntlr" type="checkbox" checked=checked /></td>
+            </tr>
+
+            <tr id="rowPeg">
+                <td class="benchName"><a rel="nofollow" href="http://pegjs.org/">PEG.js</a></td>
+                <td id="ratePeg"></td>
+                <td id="speedPeg"></td>
+                <td><input id="includePeg" type="checkbox" checked=checked /></td>
+            </tr>
+
+            <tr id="rowJison">
+                <td class="benchName"><a rel="nofollow" href="http://zaach.github.io/jison/">Jison</a></td>
+                <td id="rateJison"></td>
+                <td id="speedJison"></td>
+                <td><input id="includeJison" type="checkbox" checked=checked /></td>
+            </tr>
+
+            <tr id="rowNearley">
                 <td class="benchName"><a rel="nofollow" href="http://nearley.js.org/">Nearley</a></td>
-                <td></td>
-                <td></td>
+                <td id="rateNearley"></td>
+                <td id="speedNearley"></td>
+                <td><input id="includeNearley" type="checkbox" checked=checked /></td>
             </tr>
+
+            <tr id="rowOhm">
+                <td class="benchName"><a rel="nofollow" href="https://github.com/cdglabs/ohm">Ohm-js</a></td>
+                <td id="rateOhm"></td>
+                <td id="speedOhm"></td>
+                <td><input id="includeOhm" type="checkbox" /></td>
+            </tr>
+
+          </tbody>
         </table>
         <canvas id="parsersResultChart"></canvas>
     </section>
@@ -171,25 +205,6 @@
         })(navigator.userAgent || navigator.vendor || window.opera);
         return check;
     };
-
-    if (!mobileAndTabletcheck()) {
-        var table = document.getElementById("resultsTable");
-        table.innerHTML += '<tr> \
-                    <td class="benchName"><a rel="nofollow" href="https://github.com/cdglabs/ohm">Ohm-js</a></td>\
-                    <td></td>\
-                    <td></td>\
-                    </tr>'
-
-
-        var toolsList = document.getElementById("toolsList");
-        toolsList.innerHTML += `<li><p>\
-                    <a rel="nofollow" href="https://github.com/cdglabs/ohm">Ohm-js</a> Parser Library\
-            <a rel="nofollow"\
-            href="https://github.com/sap/chevrotain/blob/gh-pages/performance/jsonParsers/ohm/ohm_json_grammar.js">grammar</a>\
-                    <a rel="nofollow"\
-            href="https://github.com/sap/chevrotain/blob/gh-pages/performance/jsonParsers/ohm/ohm_json_parser.js">parser</a>\
-                    </p></li>`
-    }
 
     var orgData = {
         labels: [],

--- a/performance/index.html
+++ b/performance/index.html
@@ -40,6 +40,9 @@
 <script src="jsonParsers/nearley/nearley_json_parser_tokenizer.js"></script>
 <script src="jsonParsers/nearley/api.js"></script>
 
+<script src="lib/jsonify/jsonify.js"></script>
+<script src="jsonParsers/jsonify/jsonify_json_parser.js"></script>
+
 <script src="jsonParsers/browser/browser_json_parser.js"></script>
 
 <script src="https://code.jquery.com/jquery-3.1.0.slim.min.js"
@@ -122,6 +125,11 @@
                    href="jsonParsers/browser/browser_json_parser.js">implementation</a>]
             </p></li>
 
+            <li><p>
+                <a rel="nofollow" href="https://github.com/substack/jsonify">Substack Jsonify</a> JSON Parser for comparison
+                [<a rel="nofollow" href="jsonParsers/jsonify/jsonify_json_parser.js">implementation</a>]
+            </p></li>
+
           </ol>
 
         </div>
@@ -172,6 +180,13 @@
                 <td id="rateChevrotain"></td>
                 <td id="speedChevrotain"></td>
                 <td><input id="includeChevrotain" type="checkbox" checked=checked/></td>
+            </tr>
+
+            <tr id="rowJsonify" class="json-only hide">
+                <td class="benchName"><a rel="nofollow" href="https://github.com/substack/jsonify">Jsonify</a></td>
+                <td id="rateJsonify"></td>
+                <td id="speedJsonify"></td>
+                <td><input id="includeJsonify" type="checkbox" /></td>
             </tr>
 
             <tr id="rowParsimmon">
@@ -316,6 +331,8 @@
         addTest(suite, 'Browser', parse_json_browser);
 
         addTest(suite, 'Chevrotain', chevrotainParseWithChevrotainLexer);
+
+        addTest(suite, 'Jsonify', parse_json_jsonify);
 
         addTest(suite, 'Parsimmon', parse_json_parsimmon);
 

--- a/performance/index.html
+++ b/performance/index.html
@@ -45,6 +45,9 @@
 
 <script src="jsonParsers/browser/browser_json_parser.js"></script>
 
+<script src="https://unpkg.com/oboe@2.1.2/dist/oboe-browser.min.js"></script>
+<script src="jsonParsers/oboe/oboe_json_parser.js"></script>
+
 <script src="https://code.jquery.com/jquery-3.1.0.slim.min.js"
         integrity="sha256-cRpWjoSOw5KcyIOaZNo4i6fZ9tKPhYYb6i5T9RSVJG8=" crossorigin="anonymous"></script>
 
@@ -126,6 +129,11 @@
             </p></li>
 
             <li><p>
+                <a rel="nofollow" href="https://github.com/jimhigson/oboe.js">Oboe</a> JSON Parser for comparison
+                [<a rel="nofollow" href="jsonParsers/oboe/oboe_json_parser.js">implementation</a>]
+            </p></li>
+
+            <li><p>
                 <a rel="nofollow" href="https://github.com/substack/jsonify">Substack Jsonify</a> JSON Parser for comparison
                 [<a rel="nofollow" href="jsonParsers/jsonify/jsonify_json_parser.js">implementation</a>]
             </p></li>
@@ -187,6 +195,13 @@
                 <td id="rateJsonify"></td>
                 <td id="speedJsonify"></td>
                 <td><input id="includeJsonify" type="checkbox" /></td>
+            </tr>
+
+            <tr id="rowOboe" class="json-only hide">
+                <td class="benchName"><a rel="nofollow" href="http://oboejs.com/">Oboe</a></td>
+                <td id="rateOboe"></td>
+                <td id="speedOboe"></td>
+                <td><input id="includeOboe" type="checkbox" /></td>
             </tr>
 
             <tr id="rowParsimmon">
@@ -333,6 +348,14 @@
         addTest(suite, 'Chevrotain', chevrotainParseWithChevrotainLexer);
 
         addTest(suite, 'Jsonify', parse_json_jsonify);
+
+        addTest(suite, 'Oboe', {
+          defer: true,
+          onCycle: function() { newOboe(); },
+          fn: function (deferred) {
+            parse_json_oboe(json_sample1k, deferred)
+          }
+        }, true);
 
         addTest(suite, 'Parsimmon', parse_json_parsimmon);
 

--- a/performance/index.html
+++ b/performance/index.html
@@ -345,6 +345,15 @@
         }).run({'async': true});
     }
 
+    $(document).ready(function() {
+      var loc = window.location || location
+        , query = loc.search || ''
+        , showJsons = (query.indexOf('jsons=true') > -1);
+
+      if (showJsons) $('.json-only').toggleClass('hide');
+
+    });
+
 
 </script>
 </body>

--- a/performance/index.html
+++ b/performance/index.html
@@ -278,6 +278,12 @@
         // this sets a upper bound on the benchmark runtime (at the cost of accuracy for the slower parsers)
         Benchmark.options.maxTime = 2
 
+        // Use these to force the number of runs. Useful when adding a new parser.
+        // Benchmark.options.initCount = 1
+        // Benchmark.options.minSamples = 1
+        // Benchmark.options.minTime = -1
+        // Benchmark.options.maxTime = -1
+
         var i = 0
         var suite = new Benchmark.Suite;
         var fullSuite = suite.add('Chevrotain', function () {

--- a/performance/index.html
+++ b/performance/index.html
@@ -40,6 +40,8 @@
 <script src="jsonParsers/nearley/nearley_json_parser_tokenizer.js"></script>
 <script src="jsonParsers/nearley/api.js"></script>
 
+<script src="jsonParsers/browser/browser_json_parser.js"></script>
+
 <script src="https://code.jquery.com/jquery-3.1.0.slim.min.js"
         integrity="sha256-cRpWjoSOw5KcyIOaZNo4i6fZ9tKPhYYb6i5T9RSVJG8=" crossorigin="anonymous"></script>
 
@@ -107,6 +109,23 @@
             </p></li>
 
         </ol>
+
+        <div class="json-only hide">
+
+          <p>These <em>only</em> parse JSON and are included for speed comparison.</p>
+
+          <ol>
+
+            <li><p>
+                The browser's JSON.parse() for comparison.
+                [<a rel="nofollow"
+                   href="jsonParsers/browser/browser_json_parser.js">implementation</a>]
+            </p></li>
+
+          </ol>
+
+        </div>
+
         <p>The JSON Grammar was used because it is simple to implement, simple to compare and is often already
             available as a sample grammar for most Parsing Tools</p>
 
@@ -141,6 +160,13 @@
           </thead>
 
           <tbody>
+            <tr id="rowBrowser" class="json-only hide">
+                <td class="benchName">Browser</td>
+                <td id="rateBrowser"></td>
+                <td id="speedBrowser"></td>
+                <td><input id="includeBrowser" type="checkbox" /></td>
+            </tr>
+
             <tr id="rowChevrotain">
                 <td class="benchName"><a rel="nofollow" href="https://github.com/SAP/chevrotain">Chevrotain</a></td>
                 <td id="rateChevrotain"></td>
@@ -286,6 +312,8 @@
 
         var i = 0
         var suite = new Benchmark.Suite;
+
+        addTest(suite, 'Browser', parse_json_browser);
 
         addTest(suite, 'Chevrotain', chevrotainParseWithChevrotainLexer);
 

--- a/performance/index.html
+++ b/performance/index.html
@@ -247,6 +247,16 @@
         clearData();
     }
 
+    function addTest(suite, id, action, direct) {
+      var el = document.getElementById('include' + id);
+      if (el && el.checked) {
+        if (direct)
+          suite.add(id, action);
+        else
+          suite.add(id, function() { action(json_sample1k); });
+      }
+    }
+
     function onRunAll() {
         clearResults();
         $("#runAllButton").prop('disabled', true);

--- a/performance/index.html
+++ b/performance/index.html
@@ -286,31 +286,23 @@
 
         var i = 0
         var suite = new Benchmark.Suite;
-        var fullSuite = suite.add('Chevrotain', function () {
-            chevrotainParseWithChevrotainLexer(json_sample1k)
-        }).add('Jison', function () {
-            jisonJsonLexerAndParser.parse(json_sample1k)
-        }).add('ANTLR4', function () {
-            antlr4LexerAndParser(json_sample1k)
-        }).add('pegjs', function () {
-            pegjsJsonLexerAndParser.parse(json_sample1k)
-        }).add('parsimmon', function () {
-            parse_json_parsimmon(json_sample1k)
-        }).add('nearley', function () {
-            parse_json_with_nearley(json_sample1k)
-        })
+
+        addTest(suite, 'Chevrotain', chevrotainParseWithChevrotainLexer);
+
+        addTest(suite, 'Parsimmon', parse_json_parsimmon);
+
+        addTest(suite, 'Antlr', antlr4LexerAndParser);
+
+        addTest(suite, 'Peg', pegjsJsonLexerAndParser.parse.bind(pegjsJsonLexerAndParser));
+
+        addTest(suite, 'Jison', jisonJsonLexerAndParser.parse.bind(jisonJsonLexerAndParser));
+
+        addTest(suite, 'Nearley', parse_json_with_nearley);
+
+        addTest(suite, 'Ohm', parse_json_with_ohm);
 
 
-        // Ohm is just too slow to be benchmarked on mobile...
-        if (!mobileAndTabletcheck()) {
-            fullSuite.add('Ohm', function () {
-                parse_json_with_ohm(json_sample1k)
-            })
-
-            var table = document.getElementById("resultsTable");
-        }
-
-        fullSuite.on('cycle', function (event) {
+        suite.on('cycle', function (event) {
 
             var table = document.getElementById("resultsTable");
             data.labels.push(event.target.name);

--- a/performance/jsonParsers/browser/browser_json_parser.js
+++ b/performance/jsonParsers/browser/browser_json_parser.js
@@ -1,0 +1,8 @@
+
+var x;
+(function (exports) {
+
+  exports.parse_json_browser = function parse_json_browser(input) {
+    x = JSON.parse(input);
+  }
+})(this);

--- a/performance/jsonParsers/jsonify/jsonify_json_parser.js
+++ b/performance/jsonParsers/jsonify/jsonify_json_parser.js
@@ -1,0 +1,7 @@
+
+var x;
+(function (exports) {
+  exports.parse_json_jsonify = function parse_json_jsonify(input) {
+    x = jsonifyParse(input);
+  }
+})(this);

--- a/performance/jsonParsers/oboe/oboe_json_parser.js
+++ b/performance/jsonParsers/oboe/oboe_json_parser.js
@@ -1,0 +1,18 @@
+(function (exports) {
+
+  var o = null;
+
+  exports.parse_json_oboe = function parse_json_oboe(input, deferred) {
+    o.emit('data', input);
+    deferred.resolve();
+  }
+
+  exports.newOboe = function newOboe() {
+    o = oboe();
+    o.on('done', function(result) {});
+    o.on('fail', function(error) { console.log('oboe error:',error); });
+  };
+
+  exports.newOboe();
+
+})(this);

--- a/performance/lib/jsonify/jsonify.js
+++ b/performance/lib/jsonify/jsonify.js
@@ -1,0 +1,258 @@
+// copied from:
+//  https://github.com/substack/jsonify/blob/master/lib/parse.js
+
+(function (exports) {
+
+  var at, // The index of the current character
+      ch, // The current character
+      escapee = {
+          '"':  '"',
+          '\\': '\\',
+          '/':  '/',
+          b:    '\b',
+          f:    '\f',
+          n:    '\n',
+          r:    '\r',
+          t:    '\t'
+      },
+      text,
+
+      error = function (m) {
+          // Call error when something is wrong.
+          throw {
+              name:    'SyntaxError',
+              message: m,
+              at:      at,
+              text:    text
+          };
+      },
+
+      next = function (c) {
+          // If a c parameter is provided, verify that it matches the current character.
+          if (c && c !== ch) {
+              error("Expected '" + c + "' instead of '" + ch + "'");
+          }
+
+          // Get the next character. When there are no more characters,
+          // return the empty string.
+
+          ch = text.charAt(at);
+          at += 1;
+          return ch;
+      },
+
+      number = function () {
+          // Parse a number value.
+          var number,
+              string = '';
+
+          if (ch === '-') {
+              string = '-';
+              next('-');
+          }
+          while (ch >= '0' && ch <= '9') {
+              string += ch;
+              next();
+          }
+          if (ch === '.') {
+              string += '.';
+              while (next() && ch >= '0' && ch <= '9') {
+                  string += ch;
+              }
+          }
+          if (ch === 'e' || ch === 'E') {
+              string += ch;
+              next();
+              if (ch === '-' || ch === '+') {
+                  string += ch;
+                  next();
+              }
+              while (ch >= '0' && ch <= '9') {
+                  string += ch;
+                  next();
+              }
+          }
+          number = +string;
+          if (!isFinite(number)) {
+              error("Bad number");
+          } else {
+              return number;
+          }
+      },
+
+      string = function () {
+          // Parse a string value.
+          var hex,
+              i,
+              string = '',
+              uffff;
+
+          // When parsing for string values, we must look for " and \ characters.
+          if (ch === '"') {
+              while (next()) {
+                  if (ch === '"') {
+                      next();
+                      return string;
+                  } else if (ch === '\\') {
+                      next();
+                      if (ch === 'u') {
+                          uffff = 0;
+                          for (i = 0; i < 4; i += 1) {
+                              hex = parseInt(next(), 16);
+                              if (!isFinite(hex)) {
+                                  break;
+                              }
+                              uffff = uffff * 16 + hex;
+                          }
+                          string += String.fromCharCode(uffff);
+                      } else if (typeof escapee[ch] === 'string') {
+                          string += escapee[ch];
+                      } else {
+                          break;
+                      }
+                  } else {
+                      string += ch;
+                  }
+              }
+          }
+          error("Bad string");
+      },
+
+      white = function () {
+
+  // Skip whitespace.
+
+          while (ch && ch <= ' ') {
+              next();
+          }
+      },
+
+      word = function () {
+
+  // true, false, or null.
+
+          switch (ch) {
+          case 't':
+              next('t');
+              next('r');
+              next('u');
+              next('e');
+              return true;
+          case 'f':
+              next('f');
+              next('a');
+              next('l');
+              next('s');
+              next('e');
+              return false;
+          case 'n':
+              next('n');
+              next('u');
+              next('l');
+              next('l');
+              return null;
+          }
+          error("Unexpected '" + ch + "'");
+      },
+
+      value,  // Place holder for the value function.
+
+      array = function () {
+
+  // Parse an array value.
+
+          var array = [];
+
+          if (ch === '[') {
+              next('[');
+              white();
+              if (ch === ']') {
+                  next(']');
+                  return array;   // empty array
+              }
+              while (ch) {
+                  array.push(value());
+                  white();
+                  if (ch === ']') {
+                      next(']');
+                      return array;
+                  }
+                  next(',');
+                  white();
+              }
+          }
+          error("Bad array");
+      },
+
+      object = function () {
+
+  // Parse an object value.
+
+          var key,
+              object = {};
+
+          if (ch === '{') {
+              next('{');
+              white();
+              if (ch === '}') {
+                  next('}');
+                  return object;   // empty object
+              }
+              while (ch) {
+                  key = string();
+                  white();
+                  next(':');
+                  if (Object.hasOwnProperty.call(object, key)) {
+                      error('Duplicate key "' + key + '"');
+                  }
+                  object[key] = value();
+                  white();
+                  if (ch === '}') {
+                      next('}');
+                      return object;
+                  }
+                  next(',');
+                  white();
+              }
+          }
+          error("Bad object");
+      };
+
+  value = function () {
+
+  // Parse a JSON value. It could be an object, an array, a string, a number,
+  // or a word.
+
+      white();
+      switch (ch) {
+      case '{':
+          return object();
+      case '[':
+          return array();
+      case '"':
+          return string();
+      case '-':
+          return number();
+      default:
+          return ch >= '0' && ch <= '9' ? number() : word();
+      }
+  };
+
+  // Return the json_parse function. It will have access to all of the above
+  // functions and variables.
+  exports.jsonifyParse = function jsonifyParse(source) {
+      var result;
+
+      text = source;
+      at = 0;
+      ch = ' ';
+      result = value();
+      white();
+      if (ch) {
+        error("Syntax error");
+      }
+
+      return result;
+  };
+
+})(this);


### PR DESCRIPTION
This adds on to the other PR as a base.

The existence of this new content is hidden unless there is a query param: `?jsons=true`

When that exists it:

1. adds a list describing the JSON specific parsers after the list of parser generator/combinators
2. adds the three to the table of parsers; excluded by default
