### PR TITLE
add animated sorting of results as each benchmark completes

### DIFF
--- a/performance/index.html
+++ b/performance/index.html
@@ -186,7 +186,6 @@
 
             <div class="benchName">Parser Library</div>
             <div class="benchRate">Ops/sec</div>
-            <div class="benchDelta">Delta</div>
             <div class="benchSpeed">Relative Speed</div>
             <div class="benchInclude">?</div>
 
@@ -197,8 +196,7 @@
             <div class="dataRow Chevrotain">
 
               <div class="benchName"><a rel="nofollow" href="https://github.com/SAP/chevrotain">Chevrotain</a></div>
-              <div class="benchRate">&nbsp;</div>
-              <div class="benchDelta">&nbsp;</div>
+              <div class="benchRate"><div class="value">&nbsp;</div><div class="delta">&nbsp;</div></div>
               <div class="benchSpeed">&nbsp;</div>
               <div class="benchInclude"><input type="checkbox" checked=checked/></div>
 
@@ -207,8 +205,7 @@
             <div class="dataRow Parsimmon">
 
               <div class="benchName"><a rel="nofollow" href="https://github.com/jneen/parsimmon">Parsimmon</a></div>
-              <div class="benchRate">&nbsp;</div>
-              <div class="benchDelta">&nbsp;</div>
+              <div class="benchRate"><div class="value">&nbsp;</div><div class="delta">&nbsp;</div></div>
               <div class="benchSpeed">&nbsp;</div>
               <div class="benchInclude"><input type="checkbox" checked=checked/></div>
 
@@ -217,8 +214,7 @@
             <div class="dataRow Antlr">
 
               <div class="benchName"><a rel="nofollow" href="http://www.antlr.org/">ANTLR4</a></div>
-              <div class="benchRate">&nbsp;</div>
-              <div class="benchDelta">&nbsp;</div>
+              <div class="benchRate"><div class="value">&nbsp;</div><div class="delta">&nbsp;</div></div>
               <div class="benchSpeed">&nbsp;</div>
               <div class="benchInclude"><input type="checkbox" checked=checked/></div>
 
@@ -227,8 +223,7 @@
             <div class="dataRow Peg">
 
               <div class="benchName"><a rel="nofollow" href="http://pegjs.org/">PEG.js</a></div>
-              <div class="benchRate">&nbsp;</div>
-              <div class="benchDelta">&nbsp;</div>
+              <div class="benchRate"><div class="value">&nbsp;</div><div class="delta">&nbsp;</div></div>
               <div class="benchSpeed">&nbsp;</div>
               <div class="benchInclude"><input type="checkbox" checked=checked/></div>
 
@@ -237,8 +232,7 @@
             <div class="dataRow Jison">
 
               <div class="benchName"><a rel="nofollow" href="http://zaach.github.io/jison/">Jison</a></div>
-              <div class="benchRate">&nbsp;</div>
-              <div class="benchDelta">&nbsp;</div>
+              <div class="benchRate"><div class="value">&nbsp;</div><div class="delta">&nbsp;</div></div>
               <div class="benchSpeed">&nbsp;</div>
               <div class="benchInclude"><input type="checkbox" checked=checked/></div>
 
@@ -247,8 +241,7 @@
             <div class="dataRow Nearley">
 
               <div class="benchName"><a rel="nofollow" href="http://nearley.js.org/">Nearley</a></div>
-              <div class="benchRate">&nbsp;</div>
-              <div class="benchDelta">&nbsp;</div>
+              <div class="benchRate"><div class="value">&nbsp;</div><div class="delta">&nbsp;</div></div>
               <div class="benchSpeed">&nbsp;</div>
               <div class="benchInclude"><input type="checkbox" checked=checked/></div>
 
@@ -257,8 +250,7 @@
             <div class="dataRow Ohm">
 
               <div class="benchName"><a rel="nofollow" href="https://github.com/cdglabs/ohm">Ohm-js</a></div>
-              <div class="benchRate">&nbsp;</div>
-              <div class="benchDelta">&nbsp;</div>
+              <div class="benchRate"><div class="value">&nbsp;</div><div class="delta">&nbsp;</div></div>
               <div class="benchSpeed">&nbsp;</div>
               <div class="benchInclude"><input type="checkbox"/></div>
 
@@ -267,8 +259,7 @@
             <div class="dataRow Browser json-only hide">
 
               <div class="benchName">Browser</div>
-              <div class="benchRate">&nbsp;</div>
-              <div class="benchDelta">&nbsp;</div>
+              <div class="benchRate"><div class="value">&nbsp;</div><div class="delta">&nbsp;</div></div>
               <div class="benchSpeed">&nbsp;</div>
               <div class="benchInclude"><input type="checkbox"/></div>
 
@@ -277,8 +268,7 @@
             <div class="dataRow Jsonify json-only hide">
 
               <div class="benchName"><a rel="nofollow" href="https://github.com/substack/jsonify">Jsonify</a></div>
-              <div class="benchRate">&nbsp;</div>
-              <div class="benchDelta">&nbsp;</div>
+              <div class="benchRate"><div class="value">&nbsp;</div><div class="delta">&nbsp;</div></div>
               <div class="benchSpeed">&nbsp;</div>
               <div class="benchInclude"><input type="checkbox"/></div>
 
@@ -287,8 +277,7 @@
             <div class="dataRow Oboe json-only hide">
 
               <div class="benchName"><a rel="nofollow" href="http://oboejs.com/">Oboe</a></div>
-              <div class="benchRate">&nbsp;</div>
-              <div class="benchDelta">&nbsp;</div>
+              <div class="benchRate"><div class="value">&nbsp;</div><div class="delta">&nbsp;</div></div>
               <div class="benchSpeed">&nbsp;</div>
               <div class="benchInclude"><input type="checkbox"/></div>
 
@@ -331,8 +320,8 @@
     }
     function clearTable() {
         // when using .empty() the cells collapse... so, use non-breaking space
-        $(".dataRow .benchRate").html('&nbsp;')
-        $(".dataRow .benchDelta").html('&nbsp;')
+        $(".dataRow .benchRate .value").html('&nbsp;')
+        $(".dataRow .benchRate .delta").html('&nbsp;')
         $(".dataRow .benchSpeed").html('&nbsp;')
         $(".fastestRow").removeClass("fastestRow")
     }
@@ -347,6 +336,7 @@
         clearData();
     }
 
+    var actionCount = 0
     function addTest(suite, id, action, direct) {
         var $el = $('.' + id + ' input');
         if ($el && $el.is(':checked')) {
@@ -356,6 +346,30 @@
             else {
                 suite.add(id, function () { action(json_sample1k); });
             }
+
+            // add animator aid. creates a delay while animation occurs.
+            var animated = false
+                , id = 'delayor' + actionCount++
+
+            suite.add(id, {
+                defer     : true,
+                initCount : 1,
+                minSamples: 1,
+                minTime   : -1,
+                maxTime   : -1,
+                fn: function (deferred) {
+                  if (!animated) {
+                    animated = true
+                    window.sortResults()
+                    setTimeout(function () {
+                      deferred.resolve()
+                    }, 1050);
+                  }
+                  else {
+                    deferred.resolve()
+                  }
+                }
+            })
         }
     }
 
@@ -420,16 +434,15 @@
         suite.on('cycle', function (event) {
             var suite = event.target
                 , rate = suite.hz.toFixed(2)
-                , $rate = $('.' + suite.name + ' .benchRate')
-                , $delta = $('.' + suite.name + ' .benchDelta');
+                , $rate = $('.' + suite.name + ' .benchRate .value')
+                , $delta = $('.' + suite.name + ' .benchRate .delta')
+                ;
 
             $rate.html(rate);
-            $delta.html('&plusmn;' + suite.stats.rme.toFixed(2) + '%')
+            $delta.html('&plusmn;' + suite.stats.rme.toFixed(2) + '%');
 
             data.labels.push(suite.name);
             data.datasets[0].data.push(rate);
-
-            window.sortResults()
 
         }).on('complete', function (yyy) {
 
@@ -499,7 +512,7 @@
 
             var $rows = $(rows);
             $rows.snapshotStyles();
-            tinysort(rows, { selector:'.benchRate', order: 'desc' });
+            tinysort(rows, { selector:'.benchRate .value', order: 'desc' });
             $rows.releaseSnapshot();
         };
 

--- a/performance/index.html
+++ b/performance/index.html
@@ -51,6 +51,7 @@
 <script src="https://code.jquery.com/jquery-3.1.0.slim.min.js"
         integrity="sha256-cRpWjoSOw5KcyIOaZNo4i6fZ9tKPhYYb6i5T9RSVJG8=" crossorigin="anonymous"></script>
 
+<script src="https://cdnjs.cloudflare.com/ajax/libs/tinysort/2.3.6/tinysort.min.js"></script>
 
 <div align="center" class="card center">
     <section style="text-align:left;">
@@ -143,7 +144,7 @@
 
             </ol>
 
-        </div>
+      </div>
 
         <p>
             The JSON Grammar was used because it is simple to implement, simple to compare and is often already <br>
@@ -173,95 +174,132 @@
             machines.
         </p>
 
-    </section>
     <section style="text-align:left;">
+
         <button onclick="onRunAll()" id="runAllButton">Run</button>
-        <span id="wait" style="margin-left: auto;margin-right: auto;"></span>
 
-        <table id="resultsTable">
-            <thead>
-            <tr class="tableHeaderRow">
-                <th>Parser Library</th>
-                <th>Ops/sec</th>
-                <th>Relative Speed</th>
-                <th>Include?</th>
-            </tr>
-            </thead>
+        <div id="wait" style="margin-left: auto;margin-right: auto;">&nbsp;</div>
 
-            <tbody>
-            <tr id="rowBrowser" class="json-only hide">
-                <td class="benchName">Browser</td>
-                <td id="rateBrowser"></td>
-                <td id="speedBrowser"></td>
-                <td><input id="includeBrowser" type="checkbox"/></td>
-            </tr>
+        <div id="resultsContainer">
 
-            <tr id="rowChevrotain">
-                <td class="benchName"><a rel="nofollow" href="https://github.com/SAP/chevrotain">Chevrotain</a></td>
-                <td id="rateChevrotain"></td>
-                <td id="speedChevrotain"></td>
-                <td><input id="includeChevrotain" type="checkbox" checked=checked/></td>
-            </tr>
+          <div class="headerRow">
 
-            <tr id="rowJsonify" class="json-only hide">
-                <td class="benchName"><a rel="nofollow" href="https://github.com/substack/jsonify">Jsonify</a></td>
-                <td id="rateJsonify"></td>
-                <td id="speedJsonify"></td>
-                <td><input id="includeJsonify" type="checkbox"/></td>
-            </tr>
+            <div class="benchName">Parser Library</div>
+            <div class="benchRate">Ops/sec</div>
+            <div class="benchDelta">Delta</div>
+            <div class="benchSpeed">Relative Speed</div>
+            <div class="benchInclude">?</div>
 
-            <tr id="rowOboe" class="json-only hide">
-                <td class="benchName"><a rel="nofollow" href="http://oboejs.com/">Oboe</a></td>
-                <td id="rateOboe"></td>
-                <td id="speedOboe"></td>
-                <td><input id="includeOboe" type="checkbox"/></td>
-            </tr>
+          </div>
 
-            <tr id="rowParsimmon">
-                <td class="benchName"><a rel="nofollow" href="https://github.com/jneen/parsimmon">Parsimmon</a></td>
-                <td id="rateParsimmon"></td>
-                <td id="speedParsimmon"></td>
-                <td><input id="includeParsimmon" type="checkbox" checked=checked/></td>
-            </tr>
+          <div id="dataRows">
 
-            <tr id="rowAntlr">
-                <td class="benchName"><a rel="nofollow" href="http://www.antlr.org/">ANTLR4</a></td>
-                <td id="rateAntlr"></td>
-                <td id="speedAntlr"></td>
-                <td><input id="includeAntlr" type="checkbox" checked=checked/></td>
-            </tr>
+            <div class="dataRow Chevrotain">
 
-            <tr id="rowPeg">
-                <td class="benchName"><a rel="nofollow" href="http://pegjs.org/">PEG.js</a></td>
-                <td id="ratePeg"></td>
-                <td id="speedPeg"></td>
-                <td><input id="includePeg" type="checkbox" checked=checked/></td>
-            </tr>
+              <div class="benchName"><a rel="nofollow" href="https://github.com/SAP/chevrotain">Chevrotain</a></div>
+              <div class="benchRate">&nbsp;</div>
+              <div class="benchDelta">&nbsp;</div>
+              <div class="benchSpeed">&nbsp;</div>
+              <div class="benchInclude"><input type="checkbox" checked=checked/></div>
 
-            <tr id="rowJison">
-                <td class="benchName"><a rel="nofollow" href="http://zaach.github.io/jison/">Jison</a></td>
-                <td id="rateJison"></td>
-                <td id="speedJison"></td>
-                <td><input id="includeJison" type="checkbox" checked=checked/></td>
-            </tr>
+            </div>
 
-            <tr id="rowNearley">
-                <td class="benchName"><a rel="nofollow" href="http://nearley.js.org/">Nearley</a></td>
-                <td id="rateNearley"></td>
-                <td id="speedNearley"></td>
-                <td><input id="includeNearley" type="checkbox" checked=checked/></td>
-            </tr>
+            <div class="dataRow Parsimmon">
 
-            <tr id="rowOhm">
-                <td class="benchName"><a rel="nofollow" href="https://github.com/cdglabs/ohm">Ohm-js</a></td>
-                <td id="rateOhm"></td>
-                <td id="speedOhm"></td>
-                <td><input id="includeOhm" type="checkbox"/></td>
-            </tr>
+              <div class="benchName"><a rel="nofollow" href="https://github.com/jneen/parsimmon">Parsimmon</a></div>
+              <div class="benchRate">&nbsp;</div>
+              <div class="benchDelta">&nbsp;</div>
+              <div class="benchSpeed">&nbsp;</div>
+              <div class="benchInclude"><input type="checkbox" checked=checked/></div>
 
-            </tbody>
-        </table>
+            </div>
+
+            <div class="dataRow Antlr">
+
+              <div class="benchName"><a rel="nofollow" href="http://www.antlr.org/">ANTLR4</a></div>
+              <div class="benchRate">&nbsp;</div>
+              <div class="benchDelta">&nbsp;</div>
+              <div class="benchSpeed">&nbsp;</div>
+              <div class="benchInclude"><input type="checkbox" checked=checked/></div>
+
+            </div>
+
+            <div class="dataRow Peg">
+
+              <div class="benchName"><a rel="nofollow" href="http://pegjs.org/">PEG.js</a></div>
+              <div class="benchRate">&nbsp;</div>
+              <div class="benchDelta">&nbsp;</div>
+              <div class="benchSpeed">&nbsp;</div>
+              <div class="benchInclude"><input type="checkbox" checked=checked/></div>
+
+            </div>
+
+            <div class="dataRow Jison">
+
+              <div class="benchName"><a rel="nofollow" href="http://zaach.github.io/jison/">Jison</a></div>
+              <div class="benchRate">&nbsp;</div>
+              <div class="benchDelta">&nbsp;</div>
+              <div class="benchSpeed">&nbsp;</div>
+              <div class="benchInclude"><input type="checkbox" checked=checked/></div>
+
+            </div>
+
+            <div class="dataRow Nearley">
+
+              <div class="benchName"><a rel="nofollow" href="http://nearley.js.org/">Nearley</a></div>
+              <div class="benchRate">&nbsp;</div>
+              <div class="benchDelta">&nbsp;</div>
+              <div class="benchSpeed">&nbsp;</div>
+              <div class="benchInclude"><input type="checkbox" checked=checked/></div>
+
+            </div>
+
+            <div class="dataRow Ohm">
+
+              <div class="benchName"><a rel="nofollow" href="https://github.com/cdglabs/ohm">Ohm-js</a></div>
+              <div class="benchRate">&nbsp;</div>
+              <div class="benchDelta">&nbsp;</div>
+              <div class="benchSpeed">&nbsp;</div>
+              <div class="benchInclude"><input type="checkbox"/></div>
+
+            </div>
+
+            <div class="dataRow Browser json-only hide">
+
+              <div class="benchName">Browser</div>
+              <div class="benchRate">&nbsp;</div>
+              <div class="benchDelta">&nbsp;</div>
+              <div class="benchSpeed">&nbsp;</div>
+              <div class="benchInclude"><input type="checkbox"/></div>
+
+            </div>
+
+            <div class="dataRow Jsonify json-only hide">
+
+              <div class="benchName"><a rel="nofollow" href="https://github.com/substack/jsonify">Jsonify</a></div>
+              <div class="benchRate">&nbsp;</div>
+              <div class="benchDelta">&nbsp;</div>
+              <div class="benchSpeed">&nbsp;</div>
+              <div class="benchInclude"><input type="checkbox"/></div>
+
+            </div>
+
+            <div class="dataRow Oboe json-only hide">
+
+              <div class="benchName"><a rel="nofollow" href="http://oboejs.com/">Oboe</a></div>
+              <div class="benchRate">&nbsp;</div>
+              <div class="benchDelta">&nbsp;</div>
+              <div class="benchSpeed">&nbsp;</div>
+              <div class="benchInclude"><input type="checkbox"/></div>
+
+            </div>
+
+          </div>
+
+        </div>
+
         <canvas id="parsersResultChart"></canvas>
+
     </section>
 </div>
 <script>
@@ -292,9 +330,11 @@
         }
     }
     function clearTable() {
-        $("td:nth-child(2)").empty()
-        $("td:nth-child(3)").empty()
-        $("tr").removeClass("fastestRow")
+        // when using .empty() the cells collapse... so, use non-breaking space
+        $(".dataRow .benchRate").html('&nbsp;')
+        $(".dataRow .benchDelta").html('&nbsp;')
+        $(".dataRow .benchSpeed").html('&nbsp;')
+        $(".fastestRow").removeClass("fastestRow")
     }
 
     function clearGraph() {
@@ -308,15 +348,13 @@
     }
 
     function addTest(suite, id, action, direct) {
-        var el = document.getElementById('include' + id);
-        if (el && el.checked) {
+        var $el = $('.' + id + ' input');
+        if ($el && $el.is(':checked')) {
             if (direct) {
                 suite.add(id, action);
             }
             else {
-                suite.add(id, function () {
-                    action(json_sample1k);
-                });
+                suite.add(id, function () { action(json_sample1k); });
             }
         }
     }
@@ -382,13 +420,16 @@
         suite.on('cycle', function (event) {
             var suite = event.target
                 , rate = suite.hz.toFixed(2)
-                , cell = document.getElementById('rate' + suite.name);
+                , $rate = $('.' + suite.name + ' .benchRate')
+                , $delta = $('.' + suite.name + ' .benchDelta');
 
-            cell.innerHTML = '<large><b>' + rate + '<br>' + '</b></large>' +
-                '<medium>&plusmn;' + suite.stats.rme.toFixed(2) + '%</medium>';
+            $rate.html(rate);
+            $delta.html('&plusmn;' + suite.stats.rme.toFixed(2) + '%')
 
             data.labels.push(suite.name);
             data.datasets[0].data.push(rate);
+
+            window.sortResults()
 
         }).on('complete', function (yyy) {
 
@@ -397,18 +438,17 @@
 
             suites.splice(suites.indexOf(fastestSuite), 1);
 
-            var cell = document.getElementById('speed' + fastestSuite.name);
-            cell.innerHTML = "<b>100% <br> <small>(fastest)</b></small>";
-            $('#row' + fastestSuite.name).addClass("fastestRow");
+            $('.' + fastestSuite.name + ' .benchSpeed').html("100%");
+            $('.' + fastestSuite.name).addClass("fastestRow");
 
             _.forEach(suites, function (suite) {
-                var cell = document.getElementById('speed' + suite.name)
+                var $cell = $('.' + suite.name + ' .benchSpeed')
                     , speed = ((suite.hz / fastestSuite.hz).toFixed(4) * 100).toFixed(2);
-                cell.innerHTML = '<large>' + speed + "%</large>"
+                $cell.html(speed + '%')
             });
 
             window.clearInterval(dots);
-            document.getElementById("wait").innerHTML = "";
+            $('#wait').html('&nbsp;')
 
             myBarChart = new Chart(ctx, {
                 type: 'horizontalBar',
@@ -428,10 +468,42 @@
             , query = loc.search || ''
             , showJsons = (query.indexOf('jsons=true') > -1);
 
-        if (showJsons) $('.json-only').toggleClass('hide');
+        if (showJsons) $('.json-only').removeClass('hide');
+
+        // adapted from:
+        //  http://blog.stevensanderson.com/2013/03/15/animating-lists-with-css-3-transitions/
+
+        var stylesToSnapshot = ["transform", "-webkit-transform"];
+
+        $.fn.snapshotStyles = function snapshotStyles() {
+            if (window.getComputedStyle) {
+                $(this).each(function () {
+                    for (var i = 0; i < stylesToSnapshot.length; i++)
+                        this.style[stylesToSnapshot[i]] = getComputedStyle(this)[stylesToSnapshot[i]];
+                });
+            }
+            return this;
+        };
+
+        $.fn.releaseSnapshot = function releaseSnapshot() {
+            $(this).each(function () {
+                this.offsetHeight; // Force position to be recomputed before transition starts
+                for (var i = 0; i < stylesToSnapshot.length; i++)
+                    this.style[stylesToSnapshot[i]] = "";
+            });
+        };
+
+        window.sortResults = function sortResults() {
+            var container = document.getElementById('resultsContainer')
+                , rows = container.querySelectorAll('.dataRow');
+
+            var $rows = $(rows);
+            $rows.snapshotStyles();
+            tinysort(rows, { selector:'.benchRate', order: 'desc' });
+            $rows.releaseSnapshot();
+        };
 
     });
-
 
 </script>
 </body>

--- a/performance/style.css
+++ b/performance/style.css
@@ -2,38 +2,12 @@
     /*font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;*/
 /*}*/
 
-#resultsTable {
-    /*width: 80%;*/
-    border-collapse: collapse;
-}
-
 #parsersResultChart {
     /*width: 80%;*/
 }
 
-table, th, td {
-    border: 1px solid black;
-    text-align: center;
-    padding: 1rem;
-}
-
-tr {
-    height: 8rem;
-}
-
-.fastestRow {
+.fastestRow div {
     background-color: lightgreen;
-}
-
-.benchName {
-    font-weight: bold;
-    font-size: large;
-}
-
-.tableHeaderRow {
-    background-color: darkgreen;
-    color: white;
-    font-size: large;
 }
 
 
@@ -64,4 +38,162 @@ tr {
     width: 100px;
     height: 50px;
     margin-bottom: 15px;
+}
+
+
+/*
+ style the stuff as if they were a table.
+ allow for position relative/absolute for sorting and transforms.
+ */
+#resultsContainer {
+  width:800px;
+  margin:0;
+  margin-bottom:500px;
+}
+
+#dataRows {
+  position:relative;
+}
+
+.headerRow, .dataRow {
+  margin:0;
+  padding:0;
+  width:100%;
+}
+
+.headerRow div, .dataRow div {
+  margin:0;
+  margin-left:-2px;
+  margin-right:-2px;
+  display: inline-block;
+  height: 100%;
+  border: 1px solid black;
+  border-left:none;
+}
+
+.dataRow div {
+  border-top:none;
+}
+
+.headerRow {
+  height:70px;
+}
+
+.headerRow div {
+  font-size: 1.5em;
+  background-color: darkgreen;
+  color: white;
+  padding-top:15px;
+}
+
+.headerRow .benchRate,.headerRow .benchDelta, .headerRow .benchSpeed,.headerRow .benchInclude {
+  text-align:center;
+}
+
+.dataRow {
+  height:50px;
+  background-color:white;
+  position: absolute;
+  top:0;
+  transition: all 1s ease-in-out;
+}
+
+.dataRow div {
+  font-size: 1.25em;
+  padding-top:10px;
+}
+
+.benchName, .benchRate, .benchSpeed, .benchInclude {
+}
+
+div.benchName {
+  width: 175px;
+  text-align:right;
+  padding-right: 10px;
+  border-left: 1px solid black;
+}
+
+.benchRate, .benchDelta {
+  width:125px;
+}
+.benchSpeed {
+  width: 175px;
+}
+div.benchInclude {
+  width: 50px;
+  border-left:1px solid black;
+}
+
+.benchRate, .benchDelta, .benchSpeed, .benchInclude {
+  text-align:center;
+}
+
+
+/* for animating the table sort change. adapted from:
+   http://blog.stevensanderson.com/2013/03/15/animating-lists-with-css-3-transitions/
+   Basically, we freeze the styles, then sort the elements, then unfreeze the styles
+   and these rules then tell each element where they should be based on the order
+   they are in as elements.
+   Also, the z-index makes ones moving higher in the list show in front of the
+   others as they move up.
+*/
+
+#dataRows div.dataRow:nth-child(1)  {
+  transform: translate3d(0, 0, 0);
+  z-index: 100;
+}
+
+#dataRows div.dataRow:nth-child(2)  {
+  transform: translate3d(0, 100%, 0);
+  z-index: 99;
+}
+
+#dataRows div.dataRow:nth-child(3)  {
+  transform: translate3d(0, 200%, 0);
+  z-index: 98;
+}
+
+#dataRows div.dataRow:nth-child(4)  {
+  transform: translate3d(0, 300%, 0);
+  z-index: 97;
+}
+
+#dataRows div.dataRow:nth-child(5)  {
+  transform: translate3d(0, 400%, 0);
+  z-index: 96;
+}
+
+#dataRows div.dataRow:nth-child(6)  {
+  transform: translate3d(0, 500%, 0);
+  z-index: 95;
+}
+
+#dataRows div.dataRow:nth-child(7)  {
+  transform: translate3d(0, 600%, 0);
+  z-index: 94;
+}
+
+#dataRows div.dataRow:nth-child(8)  {
+  transform: translate3d(0, 700%, 0);
+  z-index: 93;
+}
+
+#dataRows div.dataRow:nth-child(9)  {
+  transform: translate3d(0, 800%, 0);
+  z-index: 92;
+}
+
+#dataRows div.dataRow:nth-child(10)  {
+  transform: translate3d(0, 900%, 0);
+  z-index: 91;
+}
+
+#dataRows div.dataRow:nth-child(11)  {
+  transform: translate3d(0, 1000%, 0);
+  z-index: 90;
+}
+
+#dataRows div.dataRow:nth-child(12)  {
+  transform: translate3d(0, 1100%, 0);
+  z-index: 89;
 }

--- a/performance/style.css
+++ b/performance/style.css
@@ -126,7 +126,7 @@ div.benchInclude {
 }
 
 .dataRow .benchRate {
-  padding-top:0;
+  padding-top:10px;
 }
 
 .benchRate, .benchSpeed, .benchInclude {

--- a/performance/style.css
+++ b/performance/style.css
@@ -48,7 +48,7 @@
 #resultsContainer {
   width:800px;
   margin:0;
-  margin-bottom:500px;
+  margin-bottom:700px;
 }
 
 #dataRows {
@@ -61,7 +61,7 @@
   width:100%;
 }
 
-.headerRow div, .dataRow div {
+.headerRow div, .dataRow > div {
   margin:0;
   margin-left:-2px;
   margin-right:-2px;
@@ -86,21 +86,22 @@
   padding-top:15px;
 }
 
-.headerRow .benchRate,.headerRow .benchDelta, .headerRow .benchSpeed,.headerRow .benchInclude {
+.headerRow .benchRate, .headerRow .benchSpeed,.headerRow .benchInclude {
   text-align:center;
 }
 
 .dataRow {
-  height:50px;
+  height:70px;
   background-color:white;
   position: absolute;
   top:0;
   transition: all 1s ease-in-out;
 }
 
-.dataRow div {
+.dataRow > div {
   font-size: 1.25em;
-  padding-top:10px;
+  padding-top:20px;
+  overflow: hidden;
 }
 
 .benchName, .benchRate, .benchSpeed, .benchInclude {
@@ -113,21 +114,32 @@ div.benchName {
   border-left: 1px solid black;
 }
 
-.benchRate, .benchDelta {
+.benchRate {
   width:125px;
 }
+
 .benchSpeed {
   width: 175px;
 }
 div.benchInclude {
   width: 50px;
-  border-left:1px solid black;
 }
 
-.benchRate, .benchDelta, .benchSpeed, .benchInclude {
+.dataRow .benchRate {
+  padding-top:0;
+}
+
+.benchRate, .benchSpeed, .benchInclude {
   text-align:center;
 }
 
+.benchRate .value {
+  font-weight:bold;
+}
+
+.benchRate .delta {
+  font-size: .75em;
+}
 
 /* for animating the table sort change. adapted from:
    http://blog.stevensanderson.com/2013/03/15/animating-lists-with-css-3-transitions/


### PR DESCRIPTION
This took some work to figure out.

What happens now: as each library's benchmark is finished a sort happens so it will move to its new place in the list. The items are in the estimated order already, so, a lot of the time the results will show and no sorting animation will occur. Unless you don't include some tests. Then the ones included will move above the ones which aren't.

Also, I had the hand built parsers in their right order in relation to the others and they just appeared when the query param existed. That didn't work with the animation stuff because it places each element based on its position in the parent container. So, there were blank spaces where the hiding hand built ones were. So, I moved them to the end instead. When the user checks their "include" checkbox then they'll sort to the correct place.

Overview:

1. Replaced the `<table>` with a `<div>` built table combined with styles in `styles.css`. This allowed absolute positioning of "rows" so the animation would work. Messing with the positioning of a table's rows is "undefined" by the specs; which means it wouldn't work.
2. created a transition for changes and a transform which positions a row absolutely based on its order in the parent container. So, when *tinysort* changes the order of the elements they transition to their new places. This happens smoothly by first fixing their styles as they are, then sorting, then removing the fixed styles which allows the transition+transform to occur.
3. moved the "relative margin of error" to its own column so it was easier to sort based on the "ops/sec" rate.
4. adapted the new code to match the changes you made, including: 4 spaces indents, extra braces, comma separated vars list is indented so comma lineup with first var name, etc.
5. emptied out values by placing a non-breaking space in there because the "cells" would collapse without some content in there.
6. changed from using IDs to grab cells, to using a combination of classes.

You may want this, or, you may not. It's entirely up to you. It was an interesting challenge I was glad to figure out. 

Also, I called the "relative margin of error" column "Delta". I expect you'll want to change that to something else. I didn't want to spend too much time trying to think of what it should be, and, well, actually using "relative margin of error" seemed way too big. I leave that decision up to you :)

