### PR TITLE
Less verbose and error prone syntax to define Grammar rules.

### DIFF
--- a/examples/grammars/calculator/calculator.js
+++ b/examples/grammars/calculator/calculator.js
@@ -33,14 +33,14 @@ function Calculator(input) {
 
     var $ = this;
 
-    this.expression = $.RULE("expression", function() {
+    $.RULE("expression", function() {
         return $.SUBRULE($.additionExpression)
     });
 
     //  lowest precedence thus it is first in the rule chain
     // The precedence of binary expressions is determined by how far down the Parse Tree
     // The binary expression appears.
-    this.additionExpression = $.RULE("additionExpression", function() {
+    $.RULE("additionExpression", function() {
         var value, op, rhsVal;
 
         // parsing part
@@ -63,7 +63,7 @@ function Calculator(input) {
     });
 
 
-    this.multiplicationExpression = $.RULE("multiplicationExpression", function() {
+    $.RULE("multiplicationExpression", function() {
         var value, op, rhsVal;
 
         // parsing part
@@ -85,7 +85,7 @@ function Calculator(input) {
     });
 
 
-    this.atomicExpression = $.RULE("atomicExpression", function() {
+    $.RULE("atomicExpression", function() {
         // @formatter:off
             return $.OR([
                 // parenthesisExpression has the highest precedence and thus it appears
@@ -96,7 +96,7 @@ function Calculator(input) {
             // @formatter:on
     });
 
-    this.parenthesisExpression = $.RULE("parenthesisExpression", function() {
+    $.RULE("parenthesisExpression", function() {
         var expValue;
 
         $.CONSUME(LParen);
@@ -134,8 +134,8 @@ module.exports = function(text) {
     var value = parser.expression();
 
     return {
-        value:      value,
-        lexResult:  lexResult,
+        value:       value,
+        lexResult:   lexResult,
         parseErrors: parser.errors
     };
 };

--- a/examples/grammars/json/json.js
+++ b/examples/grammars/json/json.js
@@ -106,7 +106,7 @@ JsonParserES5.prototype.constructor = JsonParserES5;
 // reuse the same parser instance.
 var parser = new JsonParserES5([]);
 
-module.exports = function (text) {
+module.exports = function(text) {
     var lexResult = JsonLexer.tokenize(text);
 
     // setting a new input will RESET the parser instance's state.

--- a/examples/grammars/json/json_es6.js
+++ b/examples/grammars/json/json_es6.js
@@ -60,7 +60,7 @@ class JsonParserES6 extends chevrotain.Parser {
     // so the parsing rules are defined inside the constructor, as each parsing rule must be initialized by
     // invoking RULE(...)
     // see: https://github.com/jeffmo/es-class-fields-and-static-properties
-    constructor(input) { 
+    constructor(input) {
         super(input, allTokens,
             // by default the error recovery / fault tolerance capabilities are disabled
             // use this flag to enable them
@@ -135,7 +135,7 @@ class JsonParserES6 extends chevrotain.Parser {
 // reuse the same parser instance.
 var parser = new JsonParserES6([]);
 
-module.exports = function (text) {
+module.exports = function(text) {
     var lexResult = JsonLexer.tokenize(text);
     // setting a new input will RESET the parser instance's state.
     parser.input = lexResult.tokens;

--- a/examples/grammars/xml/xml_es6.js
+++ b/examples/grammars/xml/xml_es6.js
@@ -257,7 +257,7 @@ class XmlParserES6 extends chevrotain.Parser {
 // reuse the same parser instance.
 var parser = new XmlParserES6([]);
 
-module.exports = function (text) {
+module.exports = function(text) {
     var lexResult = XmlLexer.tokenize(text);
     // setting a new input will RESET the parser instance's state.
     parser.input = lexResult.tokens;

--- a/examples/language_services/gruntfile.js
+++ b/examples/language_services/gruntfile.js
@@ -45,7 +45,7 @@ module.exports = function(grunt) {
                 src:     ['src/**/*.ts', 'test/**/*.ts', 'typings/**/*.d.ts'],
                 outDir:  'bin/',
                 options: {
-                    module : "commonjs",
+                    module:         "commonjs",
                     declaration:    false,
                     removeComments: false,
                     sourceMap:      true

--- a/examples/lexer/multi_mode_lexer/multi_mode_lexer.js
+++ b/examples/lexer/multi_mode_lexer/multi_mode_lexer.js
@@ -47,7 +47,7 @@ Whitespace.GROUP = Lexer.SKIPPED;
 // And each value is an array of Tokens which are valid in this Lexer mode.
 var multiModeLexerDefinition = {
 
-    modes : {
+    modes: {
         "numbers_mode": [
             One,
             Two,
@@ -74,7 +74,7 @@ var multiModeLexerDefinition = {
         ]
     },
 
-    defaultMode : "numbers_mode"
+    defaultMode: "numbers_mode"
 };
 
 // Our new lexer now support 3 different modes

--- a/examples/parser/content_assist/experimental_content_assist_in_parser_flow.js
+++ b/examples/parser/content_assist/experimental_content_assist_in_parser_flow.js
@@ -66,7 +66,7 @@ class SelectParser extends chevrotain.Parser {
         var $ = this;
 
 
-        this.selectStatement = $.RULE("selectStatement", function() {
+        $.RULE("selectStatement", function() {
             $.SUBRULE($.selectClause);
             $.SUBRULE($.fromClause);
             $.OPTION(function() {
@@ -75,7 +75,7 @@ class SelectParser extends chevrotain.Parser {
         });
 
 
-        this.selectClause = $.RULE("selectClause", function() {
+        $.RULE("selectClause", function() {
             $.CONSUME(Select);
             $.CONSUME(Identifier);
             $.MANY(function() {
@@ -85,26 +85,26 @@ class SelectParser extends chevrotain.Parser {
         });
 
 
-        this.fromClause = $.RULE("fromClause", function() {
+        $.RULE("fromClause", function() {
             $.CONSUME(From);
             $.CONSUME(Identifier);
         });
 
 
-        this.whereClause = $.RULE("whereClause", function() {
+        $.RULE("whereClause", function() {
             $.CONSUME(Where);
             $.SUBRULE($.expression);
         });
 
 
-        this.expression = $.RULE("expression", function() {
+        $.RULE("expression", function() {
             $.SUBRULE($.atomicExpression);
             $.SUBRULE($.relationalOperator);
             $.SUBRULE2($.atomicExpression);
         });
 
 
-        this.atomicExpression = $.RULE("atomicExpression", function() {
+        $.RULE("atomicExpression", function() {
             $.OR([
                 {ALT: function() { $.CONSUME(Integer)}},
                 {ALT: function() { $.CONSUME(Identifier)}}
@@ -112,7 +112,7 @@ class SelectParser extends chevrotain.Parser {
         });
 
 
-        this.relationalOperator = $.RULE("relationalOperator", function() {
+        $.RULE("relationalOperator", function() {
             $.OR([
                 {ALT: function() { $.CONSUME(GreaterThan)}},
                 {ALT: function() { $.CONSUME(LessThan)}}

--- a/examples/parser/content_assist/official_feature_content_assist.js
+++ b/examples/parser/content_assist/official_feature_content_assist.js
@@ -41,13 +41,13 @@ class StatementsParser extends Parser {
 
         let $ = this;
 
-        this.startRule = $.RULE('startRule', () => {
+        $.RULE('startRule', () => {
             $.MANY(() => {
                 $.SUBRULE($.stmt);
             });
         });
 
-        this.stmt = $.RULE('stmt', () => {
+        $.RULE('stmt', () => {
             $.OR([
                 {ALT: () => $.SUBRULE($.functionInvocation)},
                 {ALT: () => $.SUBRULE($.functionStmt)},
@@ -55,13 +55,13 @@ class StatementsParser extends Parser {
             ]);
         });
 
-        this.functionInvocation = $.RULE('functionInvocation', () => {
+        $.RULE('functionInvocation', () => {
             $.CONSUME(Call);
             $.CONSUME(Identifier);
         });
 
         // e.g: "private static function foo"
-        this.functionStmt = $.RULE('functionStmt', () => {
+        $.RULE('functionStmt', () => {
             $.SUBRULE($.visibility);
             $.OPTION(() => {
                 $.CONSUME(Static);
@@ -71,13 +71,13 @@ class StatementsParser extends Parser {
         });
 
         // e.g "public enum MONTHS"
-        this.enumStmt = $.RULE('enumStmt', () => {
+        $.RULE('enumStmt', () => {
             $.SUBRULE($.visibility);
             $.CONSUME(Enum);
             $.CONSUME(Identifier);
         });
 
-        this.visibility = $.RULE('visibility', () => {
+        $.RULE('visibility', () => {
             $.OR([
                 {ALT: () => $.CONSUME(Private)},
                 {ALT: () => $.CONSUME(Public)},

--- a/examples/parser/inheritance/inheritance.js
+++ b/examples/parser/inheritance/inheritance.js
@@ -62,7 +62,7 @@ function AbstractCommandsParser(input, tokens) {
     var $ = this;
 
 
-    this.commands = $.RULE("commands", function() {
+    $.RULE("commands", function() {
         $.SUBRULE($.command);
 
         $.MANY(function() {
@@ -71,7 +71,7 @@ function AbstractCommandsParser(input, tokens) {
         })
     });
 
-    this.command = $.RULE("command", function() {
+    $.RULE("command", function() {
         // The cook and clean commands must be implemented in each sub grammar
         $.OR([
             // @formatter:off
@@ -95,7 +95,7 @@ function EnglishCommandsParser(input) {
     var $ = this;
 
     // implementing the 'cookCommand' referenced in the AbstractCommandsParser
-    this.cookCommand = $.RULE("cookCommand", function() {
+    $.RULE("cookCommand", function() {
         $.CONSUME(Cook);
         $.OPTION(function() {
             $.CONSUME(Some);
@@ -105,7 +105,7 @@ function EnglishCommandsParser(input) {
     });
 
     // implementing the 'cleanCommand' referenced in the AbstractCommandsParser
-    this.cleanCommand = $.RULE("cleanCommand", function() {
+    $.RULE("cleanCommand", function() {
         $.CONSUME(Clean);
         $.CONSUME(The);
         $.CONSUME(Room);
@@ -127,7 +127,7 @@ function GermanCommandsParser(input) {
     var $ = this;
 
     // implementing the 'cookCommand' referenced in the AbstractCommandsParser
-    this.cookCommand = $.RULE("cookCommand", function() {
+    $.RULE("cookCommand", function() {
         $.CONSUME(Kochen);
         $.OR([
             // @formatter:off
@@ -138,7 +138,7 @@ function GermanCommandsParser(input) {
     });
 
     // implementing the 'cleanCommand' referenced in the AbstractCommandsParser
-    this.cleanCommand = $.RULE("cleanCommand", function() {
+    $.RULE("cleanCommand", function() {
         $.CONSUME(Raum);
         $.CONSUME(Den);
         $.CONSUME2(Raum);

--- a/examples/parser/multi_start_rules/multi_start_rules.js
+++ b/examples/parser/multi_start_rules/multi_start_rules.js
@@ -36,7 +36,7 @@ function MultiStartParser(input) {
 
     var $ = this;
 
-    this.firstRule = $.RULE("firstRule", function() {
+    $.RULE("firstRule", function() {
         $.CONSUME(Alpha);
 
         $.OPTION(function() {
@@ -44,7 +44,7 @@ function MultiStartParser(input) {
         })
     });
 
-    this.secondRule = $.RULE("secondRule", function() {
+    $.RULE("secondRule", function() {
         $.CONSUME(Bravo);
 
         $.OPTION(function() {
@@ -52,7 +52,7 @@ function MultiStartParser(input) {
         })
     });
 
-    this.thirdRule = $.RULE("thirdRule", function() {
+    $.RULE("thirdRule", function() {
         $.CONSUME(Charlie);
     });
 

--- a/examples/parser/predicate_lookahead/predicate_lookahead.js
+++ b/examples/parser/predicate_lookahead/predicate_lookahead.js
@@ -51,7 +51,7 @@ function PredicateLookaheadParser(input) {
 
     var $ = this;
 
-    this.customPredicateRule = $.RULE("customPredicateRule", function() {
+    $.RULE("customPredicateRule", function() {
         // @formatter:off
         return $.OR([
             // In this example we disable some of the alternatives depending on the value of the

--- a/examples/parser/predicate_lookahead/predicate_lookahead_spec.js
+++ b/examples/parser/predicate_lookahead/predicate_lookahead_spec.js
@@ -2,9 +2,9 @@ var parse = require("./predicate_lookahead").parse;
 var setMaxAllowed = require("./predicate_lookahead").setMaxAllowed;
 var expect = require("chai").expect;
 
-describe("The Chevrotain support for custom lookahead predicates", function () {
+describe("The Chevrotain support for custom lookahead predicates", function() {
 
-    it("can limit the available alternatives in an OR by an some external input number", function () {
+    it("can limit the available alternatives in an OR by an some external input number", function() {
         setMaxAllowed(3);
         expect(parse("1").value).to.equal(1);
         expect(parse("2").value).to.equal(2);

--- a/examples/parser/versioning/versioning.js
+++ b/examples/parser/versioning/versioning.js
@@ -36,7 +36,7 @@ function SelectParserVersion1(input, isInvokedByChildConstructor) {
     var $ = this;
 
 
-    this.selectStatement = $.RULE("selectStatement", function() {
+    $.RULE("selectStatement", function() {
         $.SUBRULE($.selectClause)
         $.SUBRULE($.fromClause)
         $.OPTION(function() {
@@ -45,7 +45,7 @@ function SelectParserVersion1(input, isInvokedByChildConstructor) {
     });
 
 
-    this.selectClause = $.RULE("selectClause", function() {
+    $.RULE("selectClause", function() {
         $.CONSUME(Select);
         $.AT_LEAST_ONE_SEP(Comma, function() {
             $.CONSUME(Identifier);
@@ -54,19 +54,19 @@ function SelectParserVersion1(input, isInvokedByChildConstructor) {
 
 
     // fromClause in version1 allows only a single column name.
-    this.fromClause = $.RULE("fromClause", function() {
+    $.RULE("fromClause", function() {
         $.CONSUME(From);
         $.CONSUME(Identifier);
     });
 
 
-    this.whereClause = $.RULE("whereClause", function() {
+    $.RULE("whereClause", function() {
         $.CONSUME(Where)
         $.SUBRULE($.expression)
     });
 
 
-    this.expression = $.RULE("expression", function() {
+    $.RULE("expression", function() {
         $.SUBRULE($.atomicExpression);
         $.SUBRULE($.relationalOperator);
         $.SUBRULE2($.atomicExpression); // note the '2' suffix to distinguish
@@ -74,7 +74,7 @@ function SelectParserVersion1(input, isInvokedByChildConstructor) {
     });
 
 
-    this.atomicExpression = $.RULE("atomicExpression", function() {
+    $.RULE("atomicExpression", function() {
         $.OR([
             // @formatter:off
             { ALT: function() {$.CONSUME(Integer)}},
@@ -84,7 +84,7 @@ function SelectParserVersion1(input, isInvokedByChildConstructor) {
     });
 
 
-    this.relationalOperator = $.RULE("relationalOperator", function() {
+    $.RULE("relationalOperator", function() {
         $.OR([
             // @formatter:off
             {ALT: function() {$.CONSUME(GreaterThan)}},
@@ -164,7 +164,7 @@ module.exports = function(text, version) {
     parser.input = lexResult.tokens;
     var value = parser.selectStatement();
 
-     return {
+    return {
         value:       value, // this is a pure grammar, the value will always be <undefined>
         lexErrors:   lexResult.errors,
         parseErrors: parser.errors

--- a/src/parse/parser_public.ts
+++ b/src/parse/parser_public.ts
@@ -1200,7 +1200,9 @@ export class Parser {
             }
         }
 
-        return this.defineRule(name, implementation, config)
+        let ruleImplementation = this.defineRule(name, implementation, config)
+        this[name] = ruleImplementation
+        return ruleImplementation
     }
 
     /**


### PR DESCRIPTION
instead of

this.Statement = this.RULE("Statement", () => {...} )

Just

this.RULE("Statement", () => {...})

This change is backward compatiable, the old syntax still works...
This simpliy makes it so that the RULE method also creates a property on the "this"
and assigns the rule implemntation to that property.