### PR TITLE
New createToken utility methods.

### DIFF
--- a/examples/grammars/calculator/calculator.js
+++ b/examples/grammars/calculator/calculator.js
@@ -1,26 +1,26 @@
 var chevrotain = require("chevrotain");
 
 // ----------------- lexer -----------------
-var extendToken = chevrotain.extendToken;
+var createToken = chevrotain.createToken;
 var Lexer = chevrotain.Lexer;
 var Parser = chevrotain.Parser;
 
 // using the NA pattern marks this Token class as 'irrelevant' for the Lexer.
-// AdditionOperator defines a Tokens hierarchy but only leafs in this hierarchy define
+// AdditionOperator defines a Tokens hierarchy but only the leafs in this hierarchy define
 // actual Tokens that can appear in the text
-var AdditionOperator = extendToken("AdditionOperator", Lexer.NA);
-var Plus = extendToken("Plus", /\+/, AdditionOperator);
-var Minus = extendToken("Minus", /-/, AdditionOperator);
+var AdditionOperator = createToken({name: "AdditionOperator", pattern: Lexer.NA});
+var Plus = createToken({name: "Plus", pattern: /\+/, parent: AdditionOperator});
+var Minus = createToken({name: "Minus", pattern: /-/, parent: AdditionOperator});
 
-var MultiplicationOperator = extendToken("MultiplicationOperator", Lexer.NA);
-var Multi = extendToken("Multi", /\*/, MultiplicationOperator);
-var Div = extendToken("Div", /\//, MultiplicationOperator);
+var MultiplicationOperator = createToken({name: "MultiplicationOperator", pattern: Lexer.NA});
+var Multi = createToken({name: "Multi", pattern: /\*/, parent: MultiplicationOperator});
+var Div = createToken({name: "Div", pattern: /\//, parent: MultiplicationOperator});
 
-var LParen = extendToken("LParen", /\(/);
-var RParen = extendToken("RParen", /\)/);
-var NumberLiteral = extendToken("NumberLiteral", /[1-9]\d*/);
-var WhiteSpace = extendToken("WhiteSpace", /\s+/);
-WhiteSpace.GROUP = Lexer.SKIPPED; // marking WhiteSpace as 'SKIPPED' makes the lexer skip it.
+var LParen = createToken({name: "LParen", pattern: /\(/});
+var RParen = createToken({name: "RParen", pattern: /\)/});
+var NumberLiteral = createToken({name: "NumberLiteral", pattern: /[1-9]\d*/});
+// marking WhiteSpace as 'SKIPPED' makes the lexer skip it.
+var WhiteSpace = createToken({name: "WhiteSpace", pattern: /\s+/, group: Lexer.SKIPPED});
 
 var allTokens = [WhiteSpace, // whitespace is normally very common so it should be placed first to speed up the lexer's performance
     Plus, Minus, Multi, Div, LParen, RParen, NumberLiteral, AdditionOperator, MultiplicationOperator];

--- a/examples/grammars/json/json.js
+++ b/examples/grammars/json/json.js
@@ -1,24 +1,23 @@
 var chevrotain = require("chevrotain");
 
 // ----------------- lexer -----------------
-var extendToken = chevrotain.extendToken;
+var createToken = chevrotain.createToken;
 var Lexer = chevrotain.Lexer;
 var Parser = chevrotain.Parser;
 
 // In ES6, custom inheritance implementation (such as 'extendToken(...)') can be replaced with simple "class X extends Y"...
-var True = extendToken("True", /true/);
-var False = extendToken("False", /false/);
-var Null = extendToken("Null", /null/);
-var LCurly = extendToken("LCurly", /{/);
-var RCurly = extendToken("RCurly", /}/);
-var LSquare = extendToken("LSquare", /\[/);
-var RSquare = extendToken("RSquare", /]/);
-var Comma = extendToken("Comma", /,/);
-var Colon = extendToken("Colon", /:/);
-var StringLiteral = extendToken("StringLiteral", /"(?:[^\\"]+|\\(?:[bfnrtv"\\/]|u[0-9a-fA-F]{4}))*"/);
-var NumberLiteral = extendToken("NumberLiteral", /-?(0|[1-9]\d*)(\.\d+)?([eE][+-]?\d+)?/);
-var WhiteSpace = extendToken("WhiteSpace", /\s+/);
-WhiteSpace.GROUP = Lexer.SKIPPED; // marking WhiteSpace as 'SKIPPED' makes the lexer skip it.
+var True = createToken({name: "True", pattern: /true/});
+var False = createToken({name: "False", pattern: /false/});
+var Null = createToken({name: "Null", pattern: /null/});
+var LCurly = createToken({name: "LCurly", pattern: /{/});
+var RCurly = createToken({name: "RCurly", pattern: /}/});
+var LSquare = createToken({name: "LSquare", pattern: /\[/});
+var RSquare = createToken({name: "RSquare", pattern: /]/});
+var Comma = createToken({name: "Comma", pattern: /,/});
+var Colon = createToken({name: "Colon", pattern: /:/});
+var StringLiteral = createToken({name: "StringLiteral", pattern: /"(?:[^\\"]+|\\(?:[bfnrtv"\\/]|u[0-9a-fA-F]{4}))*"/});
+var NumberLiteral = createToken({name: "NumberLiteral", pattern: /-?(0|[1-9]\d*)(\.\d+)?([eE][+-]?\d+)?/});
+var WhiteSpace = createToken({name: "WhiteSpace", pattern: /\s+/, group: Lexer.SKIPPED});
 
 var allTokens = [WhiteSpace, NumberLiteral, StringLiteral, LCurly, RCurly, LSquare, RSquare, Comma, Colon, True, False, Null];
 var JsonLexer = new Lexer(allTokens);

--- a/examples/grammars/xml/xml_es6.js
+++ b/examples/grammars/xml/xml_es6.js
@@ -172,7 +172,6 @@ class XmlParserES6 extends chevrotain.Parser {
             })
 
             $.MANY(() => {
-                // @formatter:off
                 $.OR([
                     {ALT: () => { $.SUBRULE($.element)}},
                     {ALT: () => { $.SUBRULE($.reference)}},
@@ -180,7 +179,6 @@ class XmlParserES6 extends chevrotain.Parser {
                     {ALT: () => { $.CONSUME(PROCESSING_INSTRUCTION)}},
                     {ALT: () => { $.CONSUME(Comment)}}
                 ]);
-                // @formatter:on
 
                 $.OPTION2(() => {
                     $.SUBRULE2($.chardata);
@@ -195,29 +193,29 @@ class XmlParserES6 extends chevrotain.Parser {
                 $.SUBRULE($.attribute);
             })
 
-            // @formatter:off
             $.OR([
-                {ALT: () => {
-                    $.CONSUME(CLOSE);
-                    $.SUBRULE($.content);
-                    $.CONSUME(SLASH_OPEN);
-                    $.CONSUME2(Name);
-                    $.CONSUME2(CLOSE);
-                }},
-                {ALT: () => {
-                    $.CONSUME(SLASH_CLOSE);
-                }}
+                {
+                    ALT: () => {
+                        $.CONSUME(CLOSE);
+                        $.SUBRULE($.content);
+                        $.CONSUME(SLASH_OPEN);
+                        $.CONSUME2(Name);
+                        $.CONSUME2(CLOSE);
+                    }
+                },
+                {
+                    ALT: () => {
+                        $.CONSUME(SLASH_CLOSE);
+                    }
+                }
             ]);
-            // @formatter:on
         });
 
         $.reference = $.RULE("reference", () => {
-            // @formatter:off
             $.OR([
                 {ALT: () => { $.CONSUME(EntityRef)}},
                 {ALT: () => { $.CONSUME(CharRef)}}
             ]);
-            // @formatter:on
         });
 
         $.attribute = $.RULE("attribute", () => {
@@ -227,22 +225,18 @@ class XmlParserES6 extends chevrotain.Parser {
         });
 
         $.chardata = $.RULE("chardata", () => {
-            // @formatter:off
             $.OR([
                 {ALT: () => { $.CONSUME(TEXT)}},
                 {ALT: () => { $.CONSUME(SEA_WS)}}
             ]);
-            // @formatter:on
         });
 
         $.misc = $.RULE("misc", () => {
-            // @formatter:off
             $.OR([
                 {ALT: () => { $.CONSUME(Comment)}},
                 {ALT: () => { $.CONSUME(PROCESSING_INSTRUCTION)}},
                 {ALT: () => { $.CONSUME(SEA_WS)}}
             ]);
-            // @formatter:on
         });
 
         // very important to call this after all the rules have been defined.

--- a/examples/implementation_languages/ecma5/ecma5_json.js
+++ b/examples/implementation_languages/ecma5/ecma5_json.js
@@ -1,24 +1,23 @@
 var chevrotain = require("chevrotain")
 
 // ----------------- lexer -----------------
-var extendToken = chevrotain.extendToken
+var createToken = chevrotain.createToken
 var Lexer = chevrotain.Lexer
 var Parser = chevrotain.Parser
 
 // In ES5 there are no classes, therefore utility methods must be used to create Token "classes".
-var True = extendToken("True", /true/)
-var False = extendToken("False", /false/)
-var Null = extendToken("Null", /null/)
-var LCurly = extendToken("LCurly", /{/)
-var RCurly = extendToken("RCurly", /}/)
-var LSquare = extendToken("LSquare", /\[/)
-var RSquare = extendToken("RSquare", /]/)
-var Comma = extendToken("Comma", /,/)
-var Colon = extendToken("Colon", /:/)
-var StringLiteral = extendToken("StringLiteral", /"(?:[^\\"]+|\\(?:[bfnrtv"\\/]|u[0-9a-fA-F]{4}))*"/)
-var NumberLiteral = extendToken("NumberLiteral", /-?(0|[1-9]\d*)(\.\d+)?([eE][+-]?\d+)?/)
-var WhiteSpace = extendToken("WhiteSpace", /\s+/)
-WhiteSpace.GROUP = Lexer.SKIPPED // marking WhiteSpace as 'SKIPPED' makes the lexer skip it.
+var True = createToken({name: "True", pattern: /true/})
+var False = createToken({name: "False", pattern: /false/})
+var Null = createToken({name: "Null", pattern: /null/})
+var LCurly = createToken({name: "LCurly", pattern: /{/})
+var RCurly = createToken({name: "RCurly", pattern: /}/})
+var LSquare = createToken({name: "LSquare", pattern: /\[/})
+var RSquare = createToken({name: "RSquare", pattern: /]/})
+var Comma = createToken({name: "Comma", pattern: /,/})
+var Colon = createToken({name: "Colon", pattern: /:/})
+var StringLiteral = createToken({name: "StringLiteral", pattern: /"(?:[^\\"]+|\\(?:[bfnrtv"\\/]|u[0-9a-fA-F]{4}))*"/});
+var NumberLiteral = createToken({name: "NumberLiteral", pattern: /-?(0|[1-9]\d*)(\.\d+)?([eE][+-]?\d+)?/});
+var WhiteSpace = createToken({name: "WhiteSpace", pattern: /\s+/, group: Lexer.SKIPPED})
 
 var allTokens = [WhiteSpace, NumberLiteral, StringLiteral, LCurly, RCurly, LSquare, RSquare, Comma, Colon, True, False, Null]
 var JsonLexer = new Lexer(allTokens)

--- a/examples/lexer/keywords_vs_identifiers/keywords_vs_identifiers.js
+++ b/examples/lexer/keywords_vs_identifiers/keywords_vs_identifiers.js
@@ -1,18 +1,20 @@
 var chevrotain = require("chevrotain");
-var extendToken = chevrotain.extendToken;
+var createToken = chevrotain.createToken;
 var Lexer = chevrotain.Lexer;
 
 // using extendToken utility to create the Token constructors and hierarchy
-var Identifier = extendToken("Identifier", /[a-zA-z]\w+/);
-var Keyword = extendToken("Keyword", Lexer.NA);
-// LONGER_ALT will make the Lexer perfer a longer Identifier over a Keyword.
-Keyword.LONGER_ALT = Identifier;
+var Identifier = createToken({name: "Identifier", pattern: /[a-zA-z]\w+/});
+var Keyword = createToken({
+    name: "Keyword",
+    // LONGER_ALT will make the Lexer prefer a longer Identifier over a Keyword.
+    pattern: Lexer.NA,
+    longer_alt: Identifier
+});
 
-var While = extendToken("While", /while/, Keyword);
-var For = extendToken("For", /for/, Keyword);
-var Do = extendToken("Do", /do/, Keyword);
-var Whitespace = extendToken("Whitespace", /\s+/);
-Whitespace.GROUP = Lexer.SKIPPED;
+var While = createToken({name: "While", pattern: /while/, parent: Keyword});
+var For = createToken({name: "For", pattern: /for/, parent: Keyword});
+var Do = createToken({name: "Do", pattern: /do/, parent: Keyword});
+var Whitespace = createToken({name: "Whitespace", pattern: /\s+/, group: Lexer.SKIPPED});
 
 keywordsVsIdentifiersLexer = new Lexer(
     [

--- a/examples/lexer/multi_mode_lexer/multi_mode_lexer.js
+++ b/examples/lexer/multi_mode_lexer/multi_mode_lexer.js
@@ -1,46 +1,39 @@
 var chevrotain = require("chevrotain");
-var extendToken = chevrotain.extendToken;
+var createToken = chevrotain.createToken;
 var Lexer = chevrotain.Lexer;
 
 // numbers Tokens
-var One = extendToken("One", /1/);
-var Two = extendToken("Two", /2/);
-var Three = extendToken("Three", /3/);
+var One = createToken({name: "One", pattern: /1/});
+var Two = createToken({name: "Two", pattern: /2/});
+var Three = createToken({name: "Three", pattern: /3/});
 
 // Letter Tokens
-var Alpha = extendToken("Alpha", /A/);
-var Beta = extendToken("Beta", /B/);
-var Gamma = extendToken("Gamma", /G/);
+var Alpha = createToken({name: "Alpha", pattern: /A/});
+var Beta = createToken({name: "Beta", pattern: /B/});
+var Gamma = createToken({name: "Gamma", pattern: /G/});
 
 // signs Tokens
-var Hash = extendToken("Hash", /#/);
-var Caret = extendToken("Caret", /\^/);
-var Amp = extendToken("Amp", /&/);
+var Hash = createToken({name: "Hash", pattern: /#/});
+var Caret = createToken({name: "Caret", pattern: /\^/});
+var Amp = createToken({name: "Amp", pattern: /&/});
 
 
 // Tokens which control entering a new mode.
-var EnterNumbers = extendToken("EnterNumbers", /NUMBERS/);
-EnterNumbers.PUSH_MODE = "numbers_mode";
+var EnterNumbers = createToken({name: "EnterNumbers", pattern: /NUMBERS/, push_mode: "numbers_mode"});
 
-var EnterLetters = extendToken("EnterLetters", /LETTERS/);
-EnterLetters.PUSH_MODE = "Letter_mode";
+var EnterLetters = createToken({name: "EnterLetters", pattern: /LETTERS/, push_mode: "letter_mode"});
 
-var EnterSigns = extendToken("EnterSigns", /SIGNS/);
-EnterSigns.PUSH_MODE = "signs_mode";
-
+var EnterSigns = createToken({name: "EnterSigns", pattern: /SIGNS/, push_mode: "signs_mode"});
 
 // Tokens which control exiting modes
-var ExitNumbers = extendToken("ExitNumbers", /EXIT_NUMBERS/);
-ExitNumbers.POP_MODE = true;
+var ExitNumbers = createToken({name: "ExitNumbers", pattern: /EXIT_NUMBERS/, pop_mode: true});
 
-var ExitLetter = extendToken("ExitLetter", /EXIT_LETTERS/);
-ExitLetter.POP_MODE = true;
+var ExitLetter = createToken({name: "ExitLetter", pattern: /EXIT_LETTERS/, pop_mode: true});
 
-var ExitSigns = extendToken("ExitSigns", /EXIT_SIGNS/);
-ExitSigns.POP_MODE = true;
+var ExitSigns = createToken({name: "ExitSigns", pattern: /EXIT_SIGNS/, pop_mode: true});
 
 
-var Whitespace = extendToken("Whitespace", /(\t| )/);
+var Whitespace = createToken({name: "Whitespace", pattern: /(\t| )/});
 Whitespace.GROUP = Lexer.SKIPPED;
 
 // Each key defines a Lexer mode's name.
@@ -53,10 +46,10 @@ var multiModeLexerDefinition = {
             Two,
             Three,
             ExitNumbers, // encountering an ExitNumbers Token will cause the lexer to revert to the previous mode
-            EnterLetters, // switch to "Letter_mode" after encountering "ENTER_Letter" while in "numbers_mode"
+            EnterLetters, // switch to "letter_mode" after encountering "ENTER_Letter" while in "numbers_mode"
             Whitespace
         ],
-        "Letter_mode":  [
+        "letter_mode":  [
             Alpha,
             Beta,
             Gamma,

--- a/examples/lexer/token_groups/token_groups.js
+++ b/examples/lexer/token_groups/token_groups.js
@@ -1,24 +1,33 @@
 var chevrotain = require("chevrotain");
-var extendToken = chevrotain.extendToken;
+var createToken = chevrotain.createToken;
 var Lexer = chevrotain.Lexer;
 
 // using extendToken utility to create the Token constructors and hierarchy
-var If = extendToken("if", /if/);
-var Else = extendToken("else", /else/);
-var Return = extendToken("return", /return/);
-var LParen = extendToken("LParen", /\(/);
-var RParen = extendToken("RParen", /\)/);
-var IntegerLiteral = extendToken("IntegerLiteral", /\d+/);
+var If = createToken({name: "if", pattern: /if/});
+var Else = createToken({name: "else", pattern: /else/});
+var Return = createToken({name: "return", pattern: /return/});
+var LParen = createToken({name: "LParen", pattern: /\(/});
+var RParen = createToken({name: "RParen", pattern: /\)/});
+var IntegerLiteral = createToken({name: "IntegerLiteral", pattern: /\d+/});
 
-var Whitespace = extendToken("Whitespace", /\s+/);
-Whitespace.GROUP = Lexer.SKIPPED; // the Lexer.SKIPPED group is a special group that will cause the lexer to "ignore"
-                                  // certain Tokens. these tokens are still consumed from the text, they just don't appear in the
-                                  // lexer's output. the is especially useful for ignoring whitespace and in some use cases comments too.
+var Whitespace = createToken({
+    name: "Whitespace",
+    pattern: /\s+/,
+    // the Lexer.SKIPPED group is a special group that will cause the lexer to "ignore"
+    // certain Tokens. these tokens are still consumed from the text, they just don't appear in the
+    // lexer's output. the is especially useful for ignoring whitespace and in some use cases comments too.
+    group: Lexer.SKIPPED
+});
 
-var Comment = extendToken("Comment", /\/\/.+/);
-Comment.GROUP = "singleLineComments"; // a Token's group may be a 'free' String, in that case the lexer's result will contain
-                                      // an additional array of all the tokens matched for each group under the 'group' object
-                                      // for example in this case: lexResult.groups["singleLineComments"]
+
+var Comment = createToken({
+    name: "Comment",
+    pattern: /\/\/.+/,
+    // a Token's group may be a 'free' String, in that case the lexer's result will contain
+    // an additional array of all the tokens matched for each group under the 'group' object
+    // for example in this case: lexResult.groups["singleLineComments"]
+    group: "singleLineComments"});
+
 
 TokenGroupsLexer = new Lexer(
     [

--- a/examples/lexer/token_types/token_types.js
+++ b/examples/lexer/token_types/token_types.js
@@ -15,33 +15,32 @@ var SIMPLE_LAZY = "SimpleLazy"
 
 function createLexer(tokensType) {
 
-    var extendToken
-    // dynamically choose which "extendToken" to use.
+    var createToken
+    // dynamically choose which "createToken" to use.
     switch (tokensType) {
         case REGULAR :
-            extendToken = chevrotain.extendToken
+            createToken = chevrotain.createToken
             break;
         case LAZY :
-            extendToken = chevrotain.extendLazyToken
+            createToken = chevrotain.createLazyToken
             break;
         case SIMPLE_LAZY :
-            extendToken = chevrotain.extendSimpleLazyToken
+            createToken = chevrotain.createSimpleLazyToken
             break;
     }
 
-    var True = extendToken("True", /true/)
-    var False = extendToken("False", /false/)
-    var Null = extendToken("Null", /null/)
-    var LCurly = extendToken("LCurly", /{/)
-    var RCurly = extendToken("RCurly", /}/)
-    var LSquare = extendToken("LSquare", /\[/)
-    var RSquare = extendToken("RSquare", /]/)
-    var Comma = extendToken("Comma", /,/)
-    var Colon = extendToken("Colon", /:/)
-    var StringLiteral = extendToken("StringLiteral", /"(?:[^\\"]+|\\(?:[bfnrtv"\\/]|u[0-9a-fA-F]{4}))*"/)
-    var NumberLiteral = extendToken("NumberLiteral", /-?(0|[1-9]\d*)(\.\d+)?([eE][+-]?\d+)?/)
-    var WhiteSpace = extendToken("WhiteSpace", /\s+/)
-    WhiteSpace.GROUP = Lexer.SKIPPED // marking WhiteSpace as 'SKIPPED' makes the lexer skip it.
+    var True = createToken({name: "True", pattern: /true/});
+    var False = createToken({name: "False", pattern: /false/});
+    var Null = createToken({name: "Null", pattern: /null/});
+    var LCurly = createToken({name: "LCurly", pattern: /{/});
+    var RCurly = createToken({name: "RCurly", pattern: /}/});
+    var LSquare = createToken({name: "LSquare", pattern: /\[/});
+    var RSquare = createToken({name: "RSquare", pattern: /]/});
+    var Comma = createToken({name: "Comma", pattern: /,/});
+    var Colon = createToken({name: "Colon", pattern: /:/});
+    var StringLiteral = createToken({name: "StringLiteral", pattern: /"(?:[^\\"]+|\\(?:[bfnrtv"\\/]|u[0-9a-fA-F]{4}))*"/});
+    var NumberLiteral = createToken({name: "NumberLiteral", pattern: /-?(0|[1-9]\d*)(\.\d+)?([eE][+-]?\d+)?/});
+    var WhiteSpace = createToken({name: "WhiteSpace", pattern: /\s+/, group: Lexer.SKIPPED});
 
     var allTokens = [WhiteSpace, NumberLiteral, StringLiteral, LCurly, RCurly, LSquare, RSquare, Comma, Colon, True, False, Null]
     var jsonLexer = new Lexer(allTokens)

--- a/examples/parser/content_assist/experimental_content_assist_in_parser_flow.js
+++ b/examples/parser/content_assist/experimental_content_assist_in_parser_flow.js
@@ -36,21 +36,20 @@ var _ = require("lodash");
 
 var Lexer = chevrotain.Lexer;
 var Parser = chevrotain.Parser;
-var extendToken = chevrotain.extendToken;
+var createToken = chevrotain.createToken;
 
 // all keywords (from/select/where/...) extend a base Keyword class, thus
 // they will be easy to identify for the purpose of content assist.
-var Keyword = extendToken("Keyword", Lexer.NA);
-var Select = extendToken("Select", /SELECT/, Keyword);
-var From = extendToken("From", /FROM/, Keyword);
-var Where = extendToken("Where", /WHERE/, Keyword);
-var Comma = extendToken("Comma", /,/);
-var Identifier = extendToken("Identifier", /\w+/);
-var Integer = extendToken("Integer", /0|[1-9]\d+/);
-var GreaterThan = extendToken("GreaterThan", /</);
-var LessThan = extendToken("LessThan", />/);
-var WhiteSpace = extendToken("WhiteSpace", /\s+/);
-WhiteSpace.GROUP = Lexer.SKIPPED;
+var Keyword = createToken({name: "Keyword", pattern: Lexer.NA});
+var Select = createToken({name: "Select", pattern: /SELECT/, parent: Keyword});
+var From = createToken({name: "From", pattern: /FROM/, parent: Keyword});
+var Where = createToken({name: "Where", pattern: /WHERE/, parent: Keyword});
+var Comma = createToken({name: "Comma", pattern: /,/});
+var Identifier = createToken({name: "Identifier", pattern: /\w+/});
+var Integer = createToken({name: "Integer", pattern: /0|[1-9]\d+/});
+var GreaterThan = createToken({name: "GreaterThan", pattern: /</});
+var LessThan = createToken({name: "LessThan", pattern: />/});
+var WhiteSpace = createToken({name: "WhiteSpace", pattern: /\s+/, group: Lexer.SKIPPED});
 
 var allTokens = [WhiteSpace, Select, From, Where, Comma, Identifier, Integer, GreaterThan, LessThan];
 var SelectLexer = new Lexer(allTokens);

--- a/examples/parser/content_assist/official_feature_content_assist.js
+++ b/examples/parser/content_assist/official_feature_content_assist.js
@@ -14,22 +14,21 @@ const chevrotain = require('chevrotain');
 
 const Lexer = chevrotain.Lexer;
 const Parser = chevrotain.Parser;
-const extendToken = chevrotain.extendToken;
+const createToken = chevrotain.createToken;
 const EMPTY_ALT = chevrotain.EMPTY_ALT
 const getImage = chevrotain.getImage
 
-const Keyword = extendToken('Keyword', Lexer.NA);
+const Keyword = createToken({name: 'Keyword', pattern: Lexer.NA});
 
-const Private = extendToken('Private', /private/, Keyword);
-const Public = extendToken('Public', /public/, Keyword);
-const Static = extendToken('Static', /static/, Keyword);
-const Declare = extendToken('Declare', /declare/, Keyword);
-const Call = extendToken('Call', /call/, Keyword);
-const Enum = extendToken('Enum', /enum/, Keyword);
-const Function = extendToken('Function', /function/, Keyword);
-const Identifier = extendToken("Identifier", /\w+/);
-const WhiteSpace = extendToken('WhiteSpace', /\s+/);
-WhiteSpace.GROUP = Lexer.SKIPPED;
+const Private = createToken({name: 'Private', pattern: /private/, parent: Keyword});
+const Public = createToken({name: 'Public', pattern: /public/, parent: Keyword});
+const Static = createToken({name: 'Static', pattern: /static/, parent: Keyword});
+const Declare = createToken({name: 'Declare', pattern: /declare/, parent: Keyword});
+const Call = createToken({name: 'Call', pattern: /call/, parent: Keyword});
+const Enum = createToken({name: 'Enum', pattern: /enum/, parent: Keyword});
+const Function = createToken({name: 'Function', pattern: /function/, parent: Keyword});
+const Identifier = createToken({name: "Identifier", pattern: /\w+/});
+const WhiteSpace = createToken({name: 'WhiteSpace', pattern: /\s+/, group: Lexer.SKIPPED});
 
 const allTokens = [WhiteSpace, Call, Private, Public, Static, Enum, Declare, Function, Identifier];
 const StatementsLexer = new Lexer(allTokens);

--- a/examples/parser/dynamic_tokens/dynamic_delimiters.js
+++ b/examples/parser/dynamic_tokens/dynamic_delimiters.js
@@ -14,21 +14,19 @@
 var chevrotain = require("../../../lib/chevrotain");
 
 // ----------------- lexer -----------------
-var extendToken = chevrotain.extendToken;
+var createToken = chevrotain.createToken;
 var Lexer = chevrotain.Lexer;
 var Parser = chevrotain.Parser;
 
 
-var LSquare = extendToken("LSquare", /\[/);
-var RSquare = extendToken("RSquare", /]/);
+var LSquare = createToken({name: "LSquare", pattern: /\[/});
+var RSquare = createToken({name: "RSquare", pattern: /]/});
 
 // base delimiter classes
-var BaseDelimiter = extendToken("BaseDelimiter", Lexer.NA)
-var Comma = extendToken("Comma", /,/, BaseDelimiter);
-var NumberLiteral = extendToken("NumberLiteral", /\d+/);
-var WhiteSpace = extendToken("WhiteSpace", /\s+/);
-WhiteSpace.GROUP = Lexer.SKIPPED; // marking WhiteSpace as 'SKIPPED' makes the lexer skip it.
-
+var BaseDelimiter = createToken({name: "BaseDelimiter", pattern: Lexer.NA});
+var Comma = createToken({name: "Comma", pattern: /,/, parent: BaseDelimiter});
+var NumberLiteral = createToken({name: "NumberLiteral", pattern: /\d+/});
+var WhiteSpace = createToken({name: "WhiteSpace", pattern: /\s+/, group: Lexer.SKIPPED});
 
 var allTokens = [
     WhiteSpace,
@@ -93,7 +91,7 @@ module.exports = function(text, dynamicDelimiterRegExp) {
     }
 
     // dynamically create Token classes which extend the BaseXXXDelimiters
-    var dynamicDelimiter = extendToken("dynamicDelimiter", dynamicDelimiterRegExp, BaseDelimiter)
+    var dynamicDelimiter = createToken({name: "dynamicDelimiter", pattern: dynamicDelimiterRegExp, parent: BaseDelimiter})
 
     // dynamically create a Lexer which can Lex all our language including the dynamic delimiters.
     var dynamicDelimiterLexer = new Lexer(allTokens.concat([dynamicDelimiter]));

--- a/examples/parser/inheritance/inheritance.js
+++ b/examples/parser/inheritance/inheritance.js
@@ -12,36 +12,36 @@ var chevrotain = require("chevrotain");
 // ----------------- lexer -----------------
 var Lexer = chevrotain.Lexer;
 var Parser = chevrotain.Parser;
-var extendToken = chevrotain.extendToken;
+var createToken = chevrotain.createToken;
 
-var RelationWord = extendToken("RelationWord", Lexer.NA);
+var RelationWord = createToken({name: "RelationWord", pattern: Lexer.NA});
 
 // Token inheritance CONSUME(RelationWord) will work on any Token extending RelationWord
-var And = extendToken("And", /and/, RelationWord);
-var Before = extendToken("Before", /before/, RelationWord);
-var After = extendToken("After", /after/, RelationWord);
-var Und = extendToken("Und", /und/, RelationWord);
-var Vor = extendToken("Vor", /vor/, RelationWord);
-var Nach = extendToken("Nach", /nach/, RelationWord);
+var And = createToken({name: "And", pattern: /and/, parent: RelationWord});
+var Before = createToken({name: "Before", pattern: /before/, parent: RelationWord});
+var After = createToken({name: "After", pattern: /after/, parent: RelationWord});
+var Und = createToken({name: "Und", pattern: /und/, parent: RelationWord});
+var Vor = createToken({name: "Vor", pattern: /vor/, parent: RelationWord});
+var Nach = createToken({name: "Nach", pattern: /nach/, parent: RelationWord});
 
 /// English Tokens
-var Cook = extendToken("Cook", /cooking|cook/);
-var Some = extendToken("Some", /some/);
-var Sausages = extendToken("Sausages", /sausages/);
-var Clean = extendToken("Clean", /clean/);
-var The = extendToken("The", /the/);
-var Room = extendToken("Room", /room/);
+var Cook = createToken({name: "Cook", pattern: /cooking|cook/});
+var Some = createToken({name: "Some", pattern: /some/});
+var Sausages = createToken({name: "Sausages", pattern: /sausages/});
+var Clean = createToken({name: "Clean", pattern: /clean/});
+var The = createToken({name: "The", pattern: /the/});
+var Room = createToken({name: "Room", pattern: /room/});
 
 // German Tokens
-var Kochen = extendToken("Kochen", /kochen/);
-var Wurstchen = extendToken("Wurstchen", /wurstchen/);
-var Wurst = extendToken("Wurst", /wurst/);
-var Raum = extendToken("Raum", /raum/);
-var Auf = extendToken("Auf", /auf/);
-var Den = extendToken("Den", /den/);
+var Kochen = createToken({name: "Kochen", pattern: /kochen/});
+var Wurstchen = createToken({name: "Wurstchen", pattern: /wurstchen/});
+var Wurst = createToken({name: "Wurst", pattern: /wurst/});
+var Raum = createToken({name: "Raum", pattern: /raum/});
+var Auf = createToken({name: "Auf", pattern: /auf/});
+var Den = createToken({name: "Den", pattern: /den/});
 
 
-var WhiteSpace = extendToken("WhiteSpace", /\s+/);
+var WhiteSpace = createToken({name: "WhiteSpace", pattern: /\s+/});
 WhiteSpace.GROUP = Lexer.SKIPPED;
 
 var englishTokens = [WhiteSpace, RelationWord, And, Before, After, Cook,

--- a/examples/parser/minification/unminified.js
+++ b/examples/parser/minification/unminified.js
@@ -12,23 +12,22 @@
     }
 }(this, function(chevrotain) {
     // ----------------- lexer -----------------
-    var extendToken = chevrotain.extendToken
+    var createToken = chevrotain.createToken
     var Lexer = chevrotain.Lexer
     var Parser = chevrotain.Parser
 
-    var True = extendToken("True", /true/)
-    var False = extendToken("False", /false/)
-    var Null = extendToken("Null", /null/)
-    var LCurly = extendToken("LCurly", /{/)
-    var RCurly = extendToken("RCurly", /}/)
-    var LSquare = extendToken("LSquare", /\[/)
-    var RSquare = extendToken("RSquare", /]/)
-    var Comma = extendToken("Comma", /,/)
-    var Colon = extendToken("Colon", /:/)
-    var StringLiteral = extendToken("StringLiteral", /"(?:[^\\"]+|\\(?:[bfnrtv"\\/]|u[0-9a-fA-F]{4}))*"/)
-    var NumberLiteral = extendToken("NumberLiteral", /-?(0|[1-9]\d*)(\.\d+)?([eE][+-]?\d+)?/)
-    var WhiteSpace = extendToken("WhiteSpace", /\s+/)
-    WhiteSpace.GROUP = Lexer.SKIPPED // marking WhiteSpace as 'SKIPPED' makes the lexer skip it.
+    var True = createToken({name: "True", pattern: /true/})
+    var False = createToken({name: "False", pattern: /false/})
+    var Null = createToken({name: "Null", pattern: /null/})
+    var LCurly = createToken({name: "LCurly", pattern: /{/})
+    var RCurly = createToken({name: "RCurly", pattern: /}/})
+    var LSquare = createToken({name: "LSquare", pattern: /\[/})
+    var RSquare = createToken({name: "RSquare", pattern: /]/})
+    var Comma = createToken({name: "Comma", pattern: /,/})
+    var Colon = createToken({name: "Colon", pattern: /:/})
+    var StringLiteral = createToken({name: "StringLiteral", pattern: /"(?:[^\\"]+|\\(?:[bfnrtv"\\/]|u[0-9a-fA-F]{4}))*"/})
+    var NumberLiteral = createToken({name: "NumberLiteral", pattern: /-?(0|[1-9]\d*)(\.\d+)?([eE][+-]?\d+)?/})
+    var WhiteSpace = createToken({name: "WhiteSpace", pattern: /\s+/, group: Lexer.SKIPPED})
 
     var allTokens = [WhiteSpace, NumberLiteral, StringLiteral, LCurly, RCurly, LSquare, RSquare, Comma, Colon, True, False, Null]
     var JsonLexer = new Lexer(allTokens)
@@ -44,12 +43,10 @@
         var $ = this
 
         this.RULE("json", function() {
-            // @formatter:off
-        $.OR([
-            { ALT: function () { $.SUBRULE($.object) }},
-            { ALT: function () { $.SUBRULE($.array) }}
-        ])
-        // @formatter:on
+            $.OR([
+                {ALT: function() { $.SUBRULE($.object) }},
+                {ALT: function() { $.SUBRULE($.array) }}
+            ])
         })
 
         this.RULE("object", function() {
@@ -82,19 +79,17 @@
             $.CONSUME(RSquare)
         })
 
-        // @formatter:off
-    this.RULE("value", function () {
-        $.OR([
-            { ALT: function () { $.CONSUME(StringLiteral) }},
-            { ALT: function () { $.CONSUME(NumberLiteral) }},
-            { ALT: function () { $.SUBRULE($.object) }},
-            { ALT: function () { $.SUBRULE($.array) }},
-            { ALT: function () { $.CONSUME(True) }},
-            { ALT: function () { $.CONSUME(False) }},
-            { ALT: function () { $.CONSUME(Null) }}
-        ], "a value")
-    })
-    // @formatter:on
+        this.RULE("value", function() {
+            $.OR([
+                {ALT: function() { $.CONSUME(StringLiteral) }},
+                {ALT: function() { $.CONSUME(NumberLiteral) }},
+                {ALT: function() { $.SUBRULE($.object) }},
+                {ALT: function() { $.SUBRULE($.array) }},
+                {ALT: function() { $.CONSUME(True) }},
+                {ALT: function() { $.CONSUME(False) }},
+                {ALT: function() { $.CONSUME(Null) }}
+            ])
+        })
 
         // very important to call this after all the rules have been defined.
         // otherwise the parser may not work correctly as it will lack information

--- a/examples/parser/multi_start_rules/multi_start_rules.js
+++ b/examples/parser/multi_start_rules/multi_start_rules.js
@@ -10,16 +10,15 @@
 var chevrotain = require("chevrotain");
 
 // ----------------- lexer -----------------
-var extendToken = chevrotain.extendToken;
+var createToken = chevrotain.createToken;
 var Lexer = chevrotain.Lexer;
 var Parser = chevrotain.Parser;
 
-var Alpha = extendToken("Alpha", /A/);
-var Bravo = extendToken("Bravo", /B/);
-var Charlie = extendToken("Charlie", /C/);
+var Alpha = createToken({name: "Alpha", pattern: /A/});
+var Bravo = createToken({name: "Bravo", pattern: /B/});
+var Charlie = createToken({name: "Charlie", pattern: /C/});
 
-var WhiteSpace = extendToken("WhiteSpace", /\s+/);
-WhiteSpace.GROUP = Lexer.SKIPPED; // marking WhiteSpace as 'SKIPPED' makes the lexer skip it.
+var WhiteSpace = createToken({name: "WhiteSpace", pattern: /\s+/, group:Lexer.SKIPPED});
 
 var allTokens = [
     WhiteSpace, // whitespace is normally very common so it should be placed first to speed up the lexer's performance

--- a/examples/parser/parametrized_rules/parametrized.js
+++ b/examples/parser/parametrized_rules/parametrized.js
@@ -16,7 +16,7 @@ var Token = chevrotain.Token
 // ----------------- lexer -----------------
 var Lexer = chevrotain.Lexer
 var Parser = chevrotain.Parser
-var extendToken = chevrotain.extendToken
+var createToken = chevrotain.createToken
 
 class Hello extends Token {}
 Hello.PATTERN = /hello/
@@ -37,7 +37,8 @@ Wonderful.PATTERN = /wonderful/
 class Amazing extends Token {}
 Amazing.PATTERN = /amazing/
 
-var WhiteSpace = extendToken("WhiteSpace", /\s+/)
+class WhiteSpace extends Token {}
+WhiteSpace.PATTERN = /\s+/
 WhiteSpace.GROUP = Lexer.SKIPPED
 
 var allTokens = [WhiteSpace, Hello, World,

--- a/examples/parser/predicate_lookahead/predicate_lookahead.js
+++ b/examples/parser/predicate_lookahead/predicate_lookahead.js
@@ -1,15 +1,15 @@
 var chevrotain = require("chevrotain");
 
 // ----------------- lexer -----------------
-var extendToken = chevrotain.extendToken;
+var createToken = chevrotain.createToken;
 var Lexer = chevrotain.Lexer;
 var Parser = chevrotain.Parser;
 
-var One = extendToken("One", /1/);
-var Two = extendToken("Two", /2/);
-var Three = extendToken("Three", /3/);
+var One = createToken({name: "One", pattern: /1/});
+var Two = createToken({name: "Two", pattern: /2/});
+var Three = createToken({name: "Three", pattern: /3/});
 
-var WhiteSpace = extendToken("WhiteSpace", /\s+/);
+var WhiteSpace = createToken({name: "WhiteSpace", pattern: /\s+/});
 WhiteSpace.GROUP = Lexer.SKIPPED; // marking WhiteSpace as 'SKIPPED' makes the lexer skip it.
 
 var allTokens = [

--- a/examples/parser/versioning/versioning.js
+++ b/examples/parser/versioning/versioning.js
@@ -7,18 +7,17 @@ var chevrotain = require("chevrotain");
 // ----------------- lexer -----------------
 var Lexer = chevrotain.Lexer;
 var Parser = chevrotain.Parser;
-var extendToken = chevrotain.extendToken;
+var createToken = chevrotain.createToken;
 
-var Select = extendToken("Select", /SELECT/i);
-var From = extendToken("From", /FROM/i);
-var Where = extendToken("Where", /WHERE/i);
-var Comma = extendToken("Comma", /,/);
-var Identifier = extendToken("Identifier", /\w+/);
-var Integer = extendToken("Integer", /0|[1-9]\d+/);
-var GreaterThan = extendToken("GreaterThan", /</);
-var LessThan = extendToken("LessThan", />/);
-var WhiteSpace = extendToken("WhiteSpace", /\s+/);
-WhiteSpace.GROUP = Lexer.SKIPPED;
+var Select = createToken({name: "Select", pattern: /SELECT/i});
+var From = createToken({name: "From", pattern: /FROM/i});
+var Where = createToken({name: "Where", pattern: /WHERE/i});
+var Comma = createToken({name: "Comma", pattern: /,/});
+var Identifier = createToken({name: "Identifier", pattern: /\w+/});
+var Integer = createToken({name: "Integer", pattern: /0|[1-9]\d+/});
+var GreaterThan = createToken({name: "GreaterThan", pattern: /</});
+var LessThan = createToken({name: "LessThan", pattern: />/});
+var WhiteSpace = createToken({name: "WhiteSpace", pattern: /\s+/, group: Lexer.SKIPPED});
 
 var allTokens = [WhiteSpace, Select, From, Where, Comma,
     Identifier, Integer, GreaterThan, LessThan];

--- a/src/api.ts
+++ b/src/api.ts
@@ -19,7 +19,10 @@ import {
     getTokenConstructor,
     tokenMatcher,
     SimpleLazyToken,
-    LazyToken
+    LazyToken,
+    createToken,
+    createLazyToken,
+    createSimpleLazyToken
 } from "./scan/tokens_public"
 import {exceptions} from "./parse/exceptions_public"
 import {gast} from "./parse/grammar/gast_public"
@@ -54,6 +57,9 @@ API.extendSimpleLazyToken = extendSimpleLazyToken
 API.tokenName = tokenName
 API.tokenLabel = tokenLabel
 API.tokenMatcher = tokenMatcher
+API.createToken = createToken
+API.createLazyToken = createLazyToken
+API.createSimpleLazyToken = createSimpleLazyToken
 
 // Tokens getters
 API.getImage = getImage

--- a/src/scan/lexer.ts
+++ b/src/scan/lexer.ts
@@ -90,7 +90,7 @@ export function analyzeTokenClasses(tokenClasses:TokenConstructor[]):IAnalyzeRes
 
     let emptyGroups = reduce(onlyRelevantClasses, (acc, clazz:any) => {
         let groupName = clazz.GROUP
-        if (isString(groupName)) {
+        if (isString(groupName) && !(groupName === Lexer.SKIPPED)) {
             acc[groupName] = []
         }
         return acc

--- a/src/scan/lexer_public.ts
+++ b/src/scan/lexer_public.ts
@@ -28,6 +28,8 @@ export interface TokenConstructor extends Function {
     PATTERN?:RegExp
     LABEL?:string
     LONGER_ALT?:TokenConstructor
+    POP_MODE?:boolean
+    PUSH_MODE?:string
 
     tokenType?:number
     extendingTokenTypes?:number[]
@@ -80,10 +82,8 @@ export interface IMultiModeLexerDefinition {
 
 export class Lexer {
 
-    public static SKIPPED = {
-        description: "This marks a skipped Token pattern, this means each token identified by it will" +
-                     "be consumed and then throw into oblivion, this can be used to for example: skip whitespace."
-    }
+    public static SKIPPED = "This marks a skipped Token pattern, this means each token identified by it will" +
+                     "be consumed and then thrown into oblivion, this can be used to for example to completely ignore whitespace."
 
     public static NA = /NOT_APPLICABLE/
     public lexerDefinitionErrors:ILexerDefinitionError[] = []

--- a/test/scan/lexer_spec.ts
+++ b/test/scan/lexer_spec.ts
@@ -292,6 +292,7 @@ function defineLexerSpecs(contextName, extendToken, tokenMatcher) {
                     "\telse return 2"
 
                 let lexResult = ifElseLexer.tokenize(input)
+                expect(lexResult.groups).to.be.empty
 
                 expect(getImage(lexResult.tokens[0])).to.equal("if")
                 expect(getStartOffset(lexResult.tokens[0])).to.equal(0)

--- a/test/scan/token_spec.ts
+++ b/test/scan/token_spec.ts
@@ -1,143 +1,353 @@
-import {extendToken, tokenName, tokenLabel, Token, tokenMatcher, extendLazyToken, extendSimpleLazyToken} from "../../src/scan/tokens_public"
-import {createSimpleLazyToken, augmentTokenClasses} from "../../src/scan/tokens"
+import {
+    extendToken,
+    tokenName,
+    tokenLabel,
+    Token,
+    tokenMatcher,
+    extendLazyToken,
+    extendSimpleLazyToken,
+    createToken,
+    createLazyToken,
+    createSimpleLazyToken
+} from "../../src/scan/tokens_public"
+import {Lexer} from "../../src/scan/lexer_public"
 
-let TrueLiteral = extendToken("TrueLiteral")
-class FalseLiteral extends Token {}
+import {createSimpleLazyToken as simpleLazyInstanceHelper, augmentTokenClasses} from "../../src/scan/tokens"
+
 
 describe("The Chevrotain Tokens namespace", () => {
-    "use strict"
 
-    it("exports a utility function that returns a token's name", () => {
-        // FalseLiteral was created with an anonymous function as its constructor yet tokenName(...)
-        // should still work correctly on it if the 'tokenName' property has been set on its constructor.
-        expect(tokenName(FalseLiteral)).to.equal("FalseLiteral")
-        expect(tokenName(TrueLiteral)).to.equal("TrueLiteral")
-    })
+    context("extendToken", () => {
 
-    let A = extendToken("A")
-    let B = extendToken("B", A)
-    B.GROUP = "Special"
+        let TrueLiteral = extendToken("TrueLiteral")
+        class FalseLiteral extends Token {}
 
-    let C = extendToken("C", /\d+/, B)
-    let D = extendToken("D", /\w+/, B)
-    let Plus = extendToken("Plus", /\+/)
-    Plus.LABEL = "+"
+        it("exports a utility function that returns a token's name", () => {
+            // FalseLiteral was created with an anonymous function as its constructor yet tokenName(...)
+            // should still work correctly on it if the 'tokenName' property has been set on its constructor.
+            expect(tokenName(FalseLiteral)).to.equal("FalseLiteral")
+            expect(tokenName(TrueLiteral)).to.equal("TrueLiteral")
+        })
 
-    it("provides an offset property for backwards compatibility", () => {
-        let token = new A("Hello", 5, 4, 1)
-        expect((<any>token).offset).to.equal(5);
-        (<any>token).offset = 666
-        expect((<any>token).offset).to.equal(666)
-    })
-
-    it("provides an extendToken utility - creating an instance", () => {
-        let aInstance = new A("Hello", 0, 1, 1)
-        expect(aInstance.image).to.equal("Hello")
-        expect(aInstance.startOffset).to.equal(0)
-        expect(aInstance.startLine).to.equal(1)
-        expect(aInstance.endLine).to.equal(1)
-        expect(aInstance.startColumn).to.equal(1)
-        expect(aInstance.endColumn).to.equal(5)
-    })
-
-    it("provides an extendToken utility - creating a subclass instance", () => {
-        let aInstance = new C("world", 0, 1, 1)
-        expect(aInstance.image).to.equal("world")
-        expect(aInstance.startOffset).to.equal(0)
-        expect(aInstance.startLine).to.equal(1)
-        expect(aInstance.endLine).to.equal(1)
-        expect(aInstance.startColumn).to.equal(1)
-        expect(aInstance.endColumn).to.equal(5)
-    })
-
-    it("provides an extendToken utility - inheritance chain", () => {
-        let dInstance = new D("world", 0, 1, 1)
-        expect(dInstance).to.be.an.instanceof(A)
-        expect(dInstance).to.be.an.instanceof(B)
-        expect(dInstance).not.to.be.an.instanceof(C)
-
-        let cInstance = new C("666", 0, 1, 1)
-        expect(cInstance).to.be.an.instanceof(A)
-        expect(cInstance).to.be.an.instanceof(B)
-
-        let bInstance = new B("666", 0, 1, 1)
-        expect(bInstance).to.be.an.instanceof(A)
-    })
-
-    it("provides an extendToken utility - static properties inheritance", () => {
-        expect(D.GROUP).to.equal("Special")
-        expect(C.GROUP).to.equal("Special")
-    })
-
-    it("Allows customization of the label", () => {
-        // Default to class name
-        expect(tokenLabel(B)).to.equal("B")
-        // Unless there's a LABEL property
-        expect(tokenLabel(Plus)).to.equal("+")
-    })
-
-    it("provides a utility to verify if a token instance matches a Token Type", () => {
-        let ATokRegular = extendToken("ATokRegular")
-        let BTokRegular = extendToken("BTokRegular")
-        let AInstanceRegular = new ATokRegular("a", -1, -1, -1, -1, -1)
-        let BInstanceRegular = new BTokRegular("b", -1, -1, -1, -1, -1)
-
-        expect(tokenMatcher(AInstanceRegular, ATokRegular)).to.be.true
-        expect(tokenMatcher(AInstanceRegular, BTokRegular)).to.be.false
-        expect(tokenMatcher(BInstanceRegular, BTokRegular)).to.be.true
-        expect(tokenMatcher(BInstanceRegular, ATokRegular)).to.be.false
-
-        let ATokLazy = extendLazyToken("ATokLazy")
-        let BTokLazy = extendLazyToken("BTokLazy")
-        let AInstanceLazy = new ATokLazy(0, 0, {})
-        let BInstanceLazy = new BTokLazy(0, 0, {})
-
-        expect(tokenMatcher(AInstanceLazy, ATokLazy)).to.be.true
-        expect(tokenMatcher(AInstanceLazy, BTokLazy)).to.be.false
-        expect(tokenMatcher(BInstanceLazy, BTokLazy)).to.be.true
-        expect(tokenMatcher(BInstanceLazy, ATokLazy)).to.be.false
-
-        let ATokSimple = extendSimpleLazyToken("ATokSimple")
-        let BTokSimple = extendSimpleLazyToken("BTokSimple")
-        augmentTokenClasses([ATokSimple, BTokSimple])
-        let AInstanceSimple = createSimpleLazyToken(0, 1, ATokSimple, {lineToOffset: [], orgText: ""})
-        let BInstanceSimple = createSimpleLazyToken(0, 1, BTokSimple, {lineToOffset: [], orgText: ""})
-
-        expect(tokenMatcher(AInstanceSimple, ATokSimple)).to.be.true
-        expect(tokenMatcher(AInstanceSimple, BTokSimple)).to.be.false
-        expect(tokenMatcher(BInstanceSimple, BTokSimple)).to.be.true
-        expect(tokenMatcher(BInstanceSimple, ATokSimple)).to.be.false
-    })
-
-    it("Will augment Token Constructors with additional metadata basic", () => {
         let A = extendToken("A")
-        let B = extendToken("B")
+        let B = extendToken("B", A)
+        B.GROUP = "Special"
 
-        expect(A.tokenType).to.be.greaterThan(0)
-        expect(B.tokenType).to.be.greaterThan(A.tokenType)
+        let C = extendToken("C", /\d+/, B)
+        let D = extendToken("D", /\w+/, B)
+        let Plus = extendToken("Plus", /\+/)
+        Plus.LABEL = "+"
 
-        expect(A.extendingTokenTypes).to.be.an.instanceOf(Array)
-        expect(A.extendingTokenTypes).to.be.empty
-        expect(B.extendingTokenTypes).to.be.an.instanceOf(Array)
-        expect(B.extendingTokenTypes).to.be.empty
+        it("provides an offset property for backwards compatibility", () => {
+            let token = new A("Hello", 5, 4, 1)
+            expect((<any>token).offset).to.equal(5);
+            (<any>token).offset = 666
+            expect((<any>token).offset).to.equal(666)
+        })
+
+        it("provides an extendToken utility - creating an instance", () => {
+            let aInstance = new A("Hello", 0, 1, 1)
+            expect(aInstance.image).to.equal("Hello")
+            expect(aInstance.startOffset).to.equal(0)
+            expect(aInstance.startLine).to.equal(1)
+            expect(aInstance.endLine).to.equal(1)
+            expect(aInstance.startColumn).to.equal(1)
+            expect(aInstance.endColumn).to.equal(5)
+        })
+
+        it("provides an extendToken utility - creating a subclass instance", () => {
+            let aInstance = new C("world", 0, 1, 1)
+            expect(aInstance.image).to.equal("world")
+            expect(aInstance.startOffset).to.equal(0)
+            expect(aInstance.startLine).to.equal(1)
+            expect(aInstance.endLine).to.equal(1)
+            expect(aInstance.startColumn).to.equal(1)
+            expect(aInstance.endColumn).to.equal(5)
+        })
+
+        it("provides an extendToken utility - inheritance chain", () => {
+            let dInstance = new D("world", 0, 1, 1)
+            expect(dInstance).to.be.an.instanceof(A)
+            expect(dInstance).to.be.an.instanceof(B)
+            expect(dInstance).not.to.be.an.instanceof(C)
+
+            let cInstance = new C("666", 0, 1, 1)
+            expect(cInstance).to.be.an.instanceof(A)
+            expect(cInstance).to.be.an.instanceof(B)
+
+            let bInstance = new B("666", 0, 1, 1)
+            expect(bInstance).to.be.an.instanceof(A)
+        })
+
+        it("provides an extendToken utility - static properties inheritance", () => {
+            expect(D.GROUP).to.equal("Special")
+            expect(C.GROUP).to.equal("Special")
+        })
+
+        it("Allows customization of the label", () => {
+            // Default to class name
+            expect(tokenLabel(B)).to.equal("B")
+            // Unless there's a LABEL property
+            expect(tokenLabel(Plus)).to.equal("+")
+        })
+
+        it("provides a utility to verify if a token instance matches a Token Type", () => {
+            let ATokRegular = extendToken("ATokRegular")
+            let BTokRegular = extendToken("BTokRegular")
+            let AInstanceRegular = new ATokRegular("a", -1, -1, -1, -1, -1)
+            let BInstanceRegular = new BTokRegular("b", -1, -1, -1, -1, -1)
+
+            expect(tokenMatcher(AInstanceRegular, ATokRegular)).to.be.true
+            expect(tokenMatcher(AInstanceRegular, BTokRegular)).to.be.false
+            expect(tokenMatcher(BInstanceRegular, BTokRegular)).to.be.true
+            expect(tokenMatcher(BInstanceRegular, ATokRegular)).to.be.false
+
+            let ATokLazy = extendLazyToken("ATokLazy")
+            let BTokLazy = extendLazyToken("BTokLazy")
+            let AInstanceLazy = new ATokLazy(0, 0, {})
+            let BInstanceLazy = new BTokLazy(0, 0, {})
+
+            expect(tokenMatcher(AInstanceLazy, ATokLazy)).to.be.true
+            expect(tokenMatcher(AInstanceLazy, BTokLazy)).to.be.false
+            expect(tokenMatcher(BInstanceLazy, BTokLazy)).to.be.true
+            expect(tokenMatcher(BInstanceLazy, ATokLazy)).to.be.false
+
+            let ATokSimple = extendSimpleLazyToken("ATokSimple")
+            let BTokSimple = extendSimpleLazyToken("BTokSimple")
+            augmentTokenClasses([ATokSimple, BTokSimple])
+            let AInstanceSimple = simpleLazyInstanceHelper(0, 1, ATokSimple, {lineToOffset: [], orgText: ""})
+            let BInstanceSimple = simpleLazyInstanceHelper(0, 1, BTokSimple, {lineToOffset: [], orgText: ""})
+
+            expect(tokenMatcher(AInstanceSimple, ATokSimple)).to.be.true
+            expect(tokenMatcher(AInstanceSimple, BTokSimple)).to.be.false
+            expect(tokenMatcher(BInstanceSimple, BTokSimple)).to.be.true
+            expect(tokenMatcher(BInstanceSimple, ATokSimple)).to.be.false
+        })
+
+        it("Will augment Token Constructors with additional metadata basic", () => {
+            let A = extendToken("A")
+            let B = extendToken("B")
+
+            expect(A.tokenType).to.be.greaterThan(0)
+            expect(B.tokenType).to.be.greaterThan(A.tokenType)
+
+            expect(A.extendingTokenTypes).to.be.an.instanceOf(Array)
+            expect(A.extendingTokenTypes).to.be.empty
+            expect(B.extendingTokenTypes).to.be.an.instanceOf(Array)
+            expect(B.extendingTokenTypes).to.be.empty
+        })
+
+        it("Will augment Token Constructors with additional metadata - inheritance", () => {
+            let A = extendToken("A")
+            let A1 = extendToken("A1", A)
+            let A2 = extendToken("A2", A1)
+
+            expect(A.tokenType).to.be.greaterThan(0)
+            expect(A1.tokenType).to.be.greaterThan(A.tokenType)
+            expect(A2.tokenType).to.be.greaterThan(A1.tokenType)
+
+            expect(A.extendingTokenTypes).to.contain(A1.tokenType)
+            expect(A.extendingTokenTypes).to.contain(A2.tokenType)
+            expect(A.extendingTokenTypes).to.have.lengthOf(2)
+
+            expect(A1.extendingTokenTypes).to.contain(A2.tokenType)
+            expect(A1.extendingTokenTypes).to.have.lengthOf(1)
+
+            expect(A2.extendingTokenTypes).to.be.empty
+        })
     })
 
-    it("Will augment Token Constructors with additional metadata - inheritance", () => {
-        let A = extendToken("A")
-        let A1 = extendToken("A1", A)
-        let A2 = extendToken("A2", A1)
+    context("createToken", () => {
+        "use strict"
 
-        expect(A.tokenType).to.be.greaterThan(0)
-        expect(A1.tokenType).to.be.greaterThan(A.tokenType)
-        expect(A2.tokenType).to.be.greaterThan(A1.tokenType)
+        let TrueLiteral = createToken({name: "TrueLiteral"})
+        class FalseLiteral extends Token {}
 
-        expect(A.extendingTokenTypes).to.contain(A1.tokenType)
-        expect(A.extendingTokenTypes).to.contain(A2.tokenType)
-        expect(A.extendingTokenTypes).to.have.lengthOf(2)
+        it("exports a utility function that returns a token's name", () => {
+            // FalseLiteral was created with an anonymous function as its constructor yet tokenName(...)
+            // should still work correctly on it if the 'tokenName' property has been set on its constructor.
+            expect(tokenName(FalseLiteral)).to.equal("FalseLiteral")
+            expect(tokenName(TrueLiteral)).to.equal("TrueLiteral")
+        })
 
-        expect(A1.extendingTokenTypes).to.contain(A2.tokenType)
-        expect(A1.extendingTokenTypes).to.have.lengthOf(1)
+        let A = createToken({name: "A"})
+        let B = createToken({name: "B", parent: A})
 
-        expect(A2.extendingTokenTypes).to.be.empty
+        B.GROUP = "Special"
+
+        let C = createToken({name: "C", pattern: /\d+/, parent: B})
+        let D = createToken({name: "D", pattern: /\w+/, parent: B})
+        let Plus = createToken({name: "Plus", pattern: /\+/})
+        Plus.LABEL = "+"
+
+        it("provides an offset property for backwards compatibility", () => {
+            let token = new A("Hello", 5, 4, 1)
+            expect((<any>token).offset).to.equal(5);
+            (<any>token).offset = 666
+            expect((<any>token).offset).to.equal(666)
+        })
+
+        it("provides an extendToken utility - creating an instance", () => {
+            let aInstance = new A("Hello", 0, 1, 1)
+            expect(aInstance.image).to.equal("Hello")
+            expect(aInstance.startOffset).to.equal(0)
+            expect(aInstance.startLine).to.equal(1)
+            expect(aInstance.endLine).to.equal(1)
+            expect(aInstance.startColumn).to.equal(1)
+            expect(aInstance.endColumn).to.equal(5)
+        })
+
+        it("provides an extendToken utility - creating a subclass instance", () => {
+            let aInstance = new C("world", 0, 1, 1)
+            expect(aInstance.image).to.equal("world")
+            expect(aInstance.startOffset).to.equal(0)
+            expect(aInstance.startLine).to.equal(1)
+            expect(aInstance.endLine).to.equal(1)
+            expect(aInstance.startColumn).to.equal(1)
+            expect(aInstance.endColumn).to.equal(5)
+        })
+
+        it("provides an extendToken utility - inheritance chain", () => {
+            let dInstance = new D("world", 0, 1, 1)
+            expect(dInstance).to.be.an.instanceof(A)
+            expect(dInstance).to.be.an.instanceof(B)
+            expect(dInstance).not.to.be.an.instanceof(C)
+
+            let cInstance = new C("666", 0, 1, 1)
+            expect(cInstance).to.be.an.instanceof(A)
+            expect(cInstance).to.be.an.instanceof(B)
+
+            let bInstance = new B("666", 0, 1, 1)
+            expect(bInstance).to.be.an.instanceof(A)
+        })
+
+        it("provides an extendToken utility - static properties inheritance", () => {
+            expect(D.GROUP).to.equal("Special")
+            expect(C.GROUP).to.equal("Special")
+        })
+
+        it("Allows customization of the label", () => {
+            // Default to class name
+            expect(tokenLabel(B)).to.equal("B")
+            // Unless there's a LABEL property
+            expect(tokenLabel(Plus)).to.equal("+")
+        })
+
+        it("provides a utility to verify if a token instance matches a Token Type", () => {
+            let ATokRegular = createToken({name: "ATokRegular"})
+            let BTokRegular = createToken({name: "BTokRegular"})
+            let AInstanceRegular = new ATokRegular("a", -1, -1, -1, -1, -1)
+            let BInstanceRegular = new BTokRegular("b", -1, -1, -1, -1, -1)
+
+            expect(tokenMatcher(AInstanceRegular, ATokRegular)).to.be.true
+            expect(tokenMatcher(AInstanceRegular, BTokRegular)).to.be.false
+            expect(tokenMatcher(BInstanceRegular, BTokRegular)).to.be.true
+            expect(tokenMatcher(BInstanceRegular, ATokRegular)).to.be.false
+
+
+            let ATokLazy = createLazyToken({name: "ATokLazy"})
+            let BTokLazy = createLazyToken({name: "BTokLazy"})
+            let AInstanceLazy = new ATokLazy(0, 0, {})
+            let BInstanceLazy = new BTokLazy(0, 0, {})
+
+            expect(tokenMatcher(AInstanceLazy, ATokLazy)).to.be.true
+            expect(tokenMatcher(AInstanceLazy, BTokLazy)).to.be.false
+            expect(tokenMatcher(BInstanceLazy, BTokLazy)).to.be.true
+            expect(tokenMatcher(BInstanceLazy, ATokLazy)).to.be.false
+
+            let ATokSimple = createSimpleLazyToken({name: "ATokSimple"})
+            let BTokSimple = createSimpleLazyToken({name: "BTokSimple"})
+            augmentTokenClasses([ATokSimple, BTokSimple])
+            let AInstanceSimple = simpleLazyInstanceHelper(0, 1, ATokSimple, {lineToOffset: [], orgText: ""})
+            let BInstanceSimple = simpleLazyInstanceHelper(0, 1, BTokSimple, {lineToOffset: [], orgText: ""})
+
+            expect(tokenMatcher(AInstanceSimple, ATokSimple)).to.be.true
+            expect(tokenMatcher(AInstanceSimple, BTokSimple)).to.be.false
+            expect(tokenMatcher(BInstanceSimple, BTokSimple)).to.be.true
+            expect(tokenMatcher(BInstanceSimple, ATokSimple)).to.be.false
+        })
+
+        it("Will augment Token Constructors with additional metadata basic", () => {
+            let A = createToken({name: "A"})
+            let B = createToken({name: "B"})
+
+            expect(A.tokenType).to.be.greaterThan(0)
+            expect(B.tokenType).to.be.greaterThan(A.tokenType)
+
+            expect(A.extendingTokenTypes).to.be.an.instanceOf(Array)
+            expect(A.extendingTokenTypes).to.be.empty
+            expect(B.extendingTokenTypes).to.be.an.instanceOf(Array)
+            expect(B.extendingTokenTypes).to.be.empty
+        })
+
+        it("Will augment Token Constructors with additional metadata - inheritance", () => {
+            let A = createLazyToken({name: "A"})
+            let A1 = createLazyToken({name: "A1", parent: A})
+            let A2 = createLazyToken({name: "A2", parent: A1})
+
+            expect(A.tokenType).to.be.greaterThan(0)
+            expect(A1.tokenType).to.be.greaterThan(A.tokenType)
+            expect(A2.tokenType).to.be.greaterThan(A1.tokenType)
+
+            expect(A.extendingTokenTypes).to.contain(A1.tokenType)
+            expect(A.extendingTokenTypes).to.contain(A2.tokenType)
+            expect(A.extendingTokenTypes).to.have.lengthOf(2)
+
+            expect(A1.extendingTokenTypes).to.contain(A2.tokenType)
+            expect(A1.extendingTokenTypes).to.have.lengthOf(1)
+
+            expect(A2.extendingTokenTypes).to.be.empty
+        })
+
+        it("Will augment Token Constructors with additional metadata - inheritance + Simple", () => {
+            let A = createSimpleLazyToken({name: "A"})
+            let A1 = createSimpleLazyToken({name: "A1", parent: A})
+            let A2 = createSimpleLazyToken({name: "A2", parent: A1})
+
+            expect(A.tokenType).to.be.greaterThan(0)
+            expect(A1.tokenType).to.be.greaterThan(A.tokenType)
+            expect(A2.tokenType).to.be.greaterThan(A1.tokenType)
+
+            expect(A.extendingTokenTypes).to.contain(A1.tokenType)
+            expect(A.extendingTokenTypes).to.contain(A2.tokenType)
+            expect(A.extendingTokenTypes).to.have.lengthOf(2)
+
+            expect(A1.extendingTokenTypes).to.contain(A2.tokenType)
+            expect(A1.extendingTokenTypes).to.have.lengthOf(1)
+
+            expect(A2.extendingTokenTypes).to.be.empty
+        })
+
+        it("can define a token Label via the createToken utilities", () => {
+            let A = createToken({name: "A", label: "bamba"})
+            expect(tokenLabel(A)).to.equal("bamba")
+        })
+
+        it("can define a POP_MODE via the createToken utilities", () => {
+            let A = createToken({name: "A", pop_mode: true})
+            expect(A).to.haveOwnProperty("POP_MODE")
+            expect(A.POP_MODE).to.be.true
+        })
+
+        it("can define a PUSH_MODE via the createToken utilities", () => {
+            let A = createToken({name: "A", push_mode: "attribute"})
+            expect(A).to.haveOwnProperty("PUSH_MODE")
+            expect(A.PUSH_MODE).to.equal("attribute")
+        })
+
+        it("can define a LONGER_ALT via the createToken utilities", () => {
+            let A = createToken({name: "A"})
+            let B = createToken({name: "B", longer_alt: A})
+            expect(B).to.haveOwnProperty("LONGER_ALT")
+            expect(B.LONGER_ALT).to.equal(A)
+        })
+
+        it("can define a token group via the createToken utilities", () => {
+            let A = createToken({name: "A", group: Lexer.SKIPPED})
+            expect(A).to.haveOwnProperty("GROUP")
+            expect(A.GROUP).to.equal(Lexer.SKIPPED)
+        })
     })
+
+
 })

--- a/test/utils/matchers.ts
+++ b/test/utils/matchers.ts
@@ -1,5 +1,6 @@
 import {createLazyTokenInstance, createSimpleLazyToken} from "../../src/scan/tokens"
 import {LazyToken, SimpleLazyToken, ISimpleTokenOrIToken} from "../../src/scan/tokens_public"
+import {TokenConstructor} from "../../src/scan/lexer_public"
 export function setEquality(actual:any[], expected:any[]):void {
     expect(actual).to.deep.include.members(expected)
     expect(expected).to.deep.include.members(actual)

--- a/test_integration/sanity/json_parser_spec.js
+++ b/test_integration/sanity/json_parser_spec.js
@@ -8,31 +8,28 @@
 }(this, function(chevrotain) {
 
     // ----------------- lexer -----------------
-    var extendToken = chevrotain.extendToken
+    var createToken = chevrotain.createToken
     var Lexer = chevrotain.Lexer
     var Parser = chevrotain.Parser
 
-    // In ES6, custom inheritance implementation (such as 'extendToken(...)') can be replaced with simple "class X extends Y"...
-    var True = extendToken("True", /true/)
-    var False = extendToken("False", /false/)
-    var Null = extendToken("Null", /null/)
-    var LCurly = extendToken("LCurly", /{/)
-    var RCurly = extendToken("RCurly", /}/)
-    var LSquare = extendToken("LSquare", /\[/)
-    var RSquare = extendToken("RSquare", /]/)
-    var Comma = extendToken("Comma", /,/)
-    var Colon = extendToken("Colon", /:/)
-    var StringLiteral = extendToken("StringLiteral", /"(?:[^\\"]+|\\(?:[bfnrtv"\\/]|u[0-9a-fA-F]{4}))*"/)
-    var NumberLiteral = extendToken("NumberLiteral", /-?(0|[1-9]\d*)(\.\d+)?([eE][+-]?\d+)?/)
-    var WhiteSpace = extendToken("WhiteSpace", /\s+/)
-    WhiteSpace.GROUP = Lexer.SKIPPED // marking WhiteSpace as 'SKIPPED' makes the lexer skip it.
+    // In ES6, custom inheritance implementation (such as 'createToken({name:...)') can be replaced with simple "class X extends Y"...
+    var True = createToken({name: "True", pattern: /true/})
+    var False = createToken({name: "False", pattern: /false/})
+    var Null = createToken({name: "Null", pattern: /null/})
+    var LCurly = createToken({name: "LCurly", pattern: /{/})
+    var RCurly = createToken({name: "RCurly", pattern: /}/})
+    var LSquare = createToken({name: "LSquare", pattern: /\[/})
+    var RSquare = createToken({name: "RSquare", pattern: /]/})
+    var Comma = createToken({name: "Comma", pattern: /,/})
+    var Colon = createToken({name: "Colon", pattern: /:/})
+    var StringLiteral = createToken({name: "StringLiteral", pattern: /"(?:[^\\"]+|\\(?:[bfnrtv"\\/]|u[0-9a-fA-F]{4}))*"/})
+    var NumberLiteral = createToken({name: "NumberLiteral", pattern: /-?(0|[1-9]\d*)(\.\d+)?([eE][+-]?\d+)?/})
+    var WhiteSpace = createToken({name: "WhiteSpace", pattern: /\s+/, group: Lexer.SKIPPED})
 
     var allTokens = [WhiteSpace, NumberLiteral, StringLiteral, LCurly, RCurly, LSquare, RSquare, Comma, Colon, True, False, Null]
     var JsonLexer = new Lexer(allTokens)
 
-
     // ----------------- parser -----------------
-
     function JsonParser(input) {
         // invoke super constructor
         Parser.call(this, input, allTokens)
@@ -41,12 +38,10 @@
         var $ = this
 
         this.json = this.RULE("json", function() {
-            // @formatter:off
-        $.OR([
-            { ALT: function () { $.SUBRULE($.object) }},
-            { ALT: function () { $.SUBRULE($.array) }}
-        ])
-        // @formatter:on
+            $.OR([
+                {ALT: function() { $.SUBRULE($.object) }},
+                {ALT: function() { $.SUBRULE($.array) }}
+            ])
         })
 
         this.object = this.RULE("object", function() {
@@ -79,19 +74,17 @@
             $.CONSUME(RSquare)
         })
 
-        // @formatter:off
-    this.value = this.RULE("value", function () {
-        $.OR([
-            { ALT: function () { $.CONSUME(StringLiteral) }},
-            { ALT: function () { $.CONSUME(NumberLiteral) }},
-            { ALT: function () { $.SUBRULE($.object) }},
-            { ALT: function () { $.SUBRULE($.array) }},
-            { ALT: function () { $.CONSUME(True) }},
-            { ALT: function () { $.CONSUME(False) }},
-            { ALT: function () { $.CONSUME(Null) }}
-        ], "a value")
-    })
-    // @formatter:on
+        this.value = this.RULE("value", function() {
+            $.OR([
+                {ALT: function() { $.CONSUME(StringLiteral) }},
+                {ALT: function() { $.CONSUME(NumberLiteral) }},
+                {ALT: function() { $.SUBRULE($.object) }},
+                {ALT: function() { $.SUBRULE($.array) }},
+                {ALT: function() { $.CONSUME(True) }},
+                {ALT: function() { $.CONSUME(False) }},
+                {ALT: function() { $.CONSUME(Null) }}
+            ])
+        })
 
         // very important to call this after all the rules have been defined.
         // otherwise the parser may not work correctly as it will lack information


### PR DESCRIPTION
The old extendToken utilities have been deprecated
as their API did not allow to support multiple optional arguments easily.

fixes #156
fixes #329