### PR TITLE
Fix issue with tokens that both pop and push a mode

### DIFF
--- a/src/scan/lexer_public.ts
+++ b/src/scan/lexer_public.ts
@@ -465,11 +465,14 @@ export class Lexer {
 
                 // mode handling, must pop before pushing if a Token both acts as both
                 // otherwise it would be a NO-OP
+                // need to save the PUSH_MODE property as if the mode is popped
+                // patternIdxToPopMode is updated to reflect the new mode after popping the stack
+                let pushMode = patternIdxToPushMode[i]
                 if (patternIdxToPopMode[i]) {
                     pop_mode(newToken)
                 }
-                if (patternIdxToPushMode[i]) {
-                    push_mode.call(this, patternIdxToPushMode[i])
+                if (pushMode) {
+                    push_mode.call(this, pushMode)
                 }
             }
             else { // error recovery, drop characters until we identify a valid token's start point
@@ -616,11 +619,14 @@ export class Lexer {
 
                 // mode handling, must pop before pushing if a Token both acts as both
                 // otherwise it would be a NO-OP
+                // need to save the PUSH_MODE property as if the mode is popped
+                // patternIdxToPopMode is updated to reflect the new mode after popping the stack
+                let pushMode = patternIdxToPushMode[i]
                 if (patternIdxToPopMode[i]) {
                     pop_mode(newToken)
                 }
-                if (patternIdxToPushMode[i]) {
-                    push_mode.call(this, patternIdxToPushMode[i])
+                if (pushMode) {
+                    push_mode.call(this, pushMode)
                 }
             }
             else { // error recovery, drop characters until we identify a valid token's start point

--- a/test/scan/lexer_spec.ts
+++ b/test/scan/lexer_spec.ts
@@ -676,6 +676,10 @@ function defineLexerSpecs(contextName, extendToken, tokenMatcher) {
                 const SIGNS = extendToken("SIGNS", /SIGNS/)
                 SIGNS.PUSH_MODE = "signs"
 
+                const SIGNS_AND_EXIT_LETTERS = extendToken("SIGNS_AND_EXIT_LETTERS", /SIGNS_AND_EXIT_LETTERS/)
+                SIGNS_AND_EXIT_LETTERS.PUSH_MODE = "signs"
+                SIGNS_AND_EXIT_LETTERS.POP_MODE = true
+
                 const ExitNumbers = extendToken("ExitNumbers", /EXIT_NUMBERS/)
                 ExitNumbers.POP_MODE = true
 
@@ -689,11 +693,10 @@ function defineLexerSpecs(contextName, extendToken, tokenMatcher) {
                 const Whitespace = extendToken("Whitespace", /(\t| )/)
                 Whitespace.GROUP = Lexer.SKIPPED
 
-
                 let modeLexerDefinition:IMultiModeLexerDefinition = {
                     modes:       {
                         "numbers": [One, Two, Three, ExitNumbers, LETTERS, Whitespace],
-                        "letters": [Alpha, Beta, Gamma, ExitLetters, SIGNS, Whitespace],
+                        "letters": [Alpha, Beta, Gamma, ExitLetters, SIGNS_AND_EXIT_LETTERS, SIGNS, Whitespace],
                         "signs":   [Hash, Caret, Amp, ExitSigns, NUMBERS, Whitespace]
                     },
                     defaultMode: "numbers"
@@ -768,6 +771,19 @@ function defineLexerSpecs(contextName, extendToken, tokenMatcher) {
                         "EXIT_NUMBERS",
                         "2"
                     ])
+                })
+
+                it("Will pop the lexer mode and push a new one if both are defined on the token", () => {
+                  let input = "LETTERS SIGNS_AND_EXIT_LETTERS &"
+                  let lexResult = ModeLexer.tokenize(input)
+                  expect(lexResult.errors).to.be.empty
+
+                  let images = map(lexResult.tokens, (currTok) => getImage(currTok))
+                  expect(images).to.deep.equal([
+                      "LETTERS",
+                      "SIGNS_AND_EXIT_LETTERS",
+                      "&"
+                  ])
                 })
 
                 it("Will detect Token definitions with push modes values that does not exist", () => {


### PR DESCRIPTION
The lexer logic currently does not properly handle tokens that define both `PUSH_MODE` and `POP_MODE` properties.  It will correctly pop the current lexer mode, but this updates `patternIdxToPushMode` to be the mapping of pattern indexes to push modes for the mode after the pop occurs.  Thus, when `patternIdxToPushMode` is checked to see if a mode needs to be pushed after the pop, it will likely check a token from the new mode that was never matched, instead of the original token.

This doesn't just affect tokens with both `PUSH_MODE` and `POP_MODE` properties, but can also cause modes to incorrectly be pushed when a token with a `PUSH_MODE` property occupies the same index as a token with a `POP_MODE` property in another mode.  For example, take the lexer defined in the tests, but switching the order of `ExitLetters` and `SIGNS`:

```typescript
{
    modes:       {
        "numbers": [One, Two, Three, ExitNumbers, LETTERS, Whitespace],
        "letters": [Alpha, Beta, Gamma, SIGNS, ExitLetters, Whitespace],
        "signs":   [Hash, Caret, Amp, ExitSigns, NUMBERS, Whitespace]
    },
    defaultMode: "numbers"
}
```

This shouldn't have any affect since the swapped tokens are unambiguous, but it causes three tests to fail because new lexer modes are pushed when incorrectly when `ExitLetters` is matched.

This pull requests contains a simple fix to temporarily save the current `patternIdxToPushMode` mapping before popping the mode stack.