### PR TITLE
Fix error detection example

### DIFF
--- a/docs/tutorial/step2_parsing.md
+++ b/docs/tutorial/step2_parsing.md
@@ -259,7 +259,7 @@ function parseInput(text) {
    let parser = new SelectParser(lexingResult.tokens);
    parser.selectStatement()
 
-   if (parser.parseErrors.length > 0) {
+   if (parser.errors.length > 0) {
       throw new Error("sad sad panda, Parsing errors detected")
    }
 }


### PR DESCRIPTION
Looks like `parseErrors` is actually `undefined` in the current version.