### PR TITLE
Add implementation for "no non-empty lookahead" test (Fixes #401)

### DIFF
--- a/src/parse/grammar/checks.ts
+++ b/src/parse/grammar/checks.ts
@@ -475,7 +475,9 @@ export function validateNoEmptyLookaheads(topLevelRules:gast.Rule[], maxLookahea
             forEach(paths, (path) => {
                 forEach(path, (p) => {
                     if (isEmpty(p)) {
-                        let errMsg = `Empty lookahead paths found in grammar.\n`
+                        let dslName = getProductionDslName(currProd)
+                        let errMsg = `Empty lookahead paths found in <${dslName}${currOccurrence}> within Rule <${currTopRule.name}>.\n` +
+                            `This means that no Tokens are consumed. To fix this, change the rule to consume Tokens.`
                         errors.push({
                             message:  errMsg,
                             type:     ParserDefinitionErrorType.EMTPY_LOOKAHEAD,

--- a/src/parse/grammar/checks.ts
+++ b/src/parse/grammar/checks.ts
@@ -463,7 +463,10 @@ export function validateSomeNonEmptyLookaheadPath(topLevelRules:gast.Rule[], max
             let pathsInsideProduction = paths[0]
             if (isEmpty(flatten(pathsInsideProduction))) {
                 let implicitOccurrence = currProd.implicitOccurrenceIndex
-                let dslName = `${getProductionDslName(currProd)}${implicitOccurrence ? "" : currOccurrence}`
+                let dslName = getProductionDslName(currProd)
+                if (!implicitOccurrence) {
+                    dslName += currOccurrence
+                }
                 let errMsg = `The repetition <${dslName}> within Rule <${currTopRule.name}> can never consume any tokens.\n` +
                     `This could lead to an infinite loop.`
                 errors.push({

--- a/src/parse/grammar/lookahead.ts
+++ b/src/parse/grammar/lookahead.ts
@@ -33,6 +33,9 @@ export function getProdType(prod:gast.IProduction):PROD_TYPE {
     if (prod instanceof gast.Alternation) {
         return PROD_TYPE.ALTERNATION
     }
+    else {
+        throw Error("non exhaustive match")
+    }
 }
 
 export function buildLookaheadFuncForOr(occurrence:number,

--- a/src/parse/grammar/lookahead.ts
+++ b/src/parse/grammar/lookahead.ts
@@ -18,19 +18,19 @@ export function getProdType(prod:gast.IProduction):PROD_TYPE {
     if (prod instanceof gast.Option) {
         return PROD_TYPE.OPTION
     }
-    if (prod instanceof gast.Repetition) {
+    else if (prod instanceof gast.Repetition) {
         return PROD_TYPE.REPETITION
     }
-    if (prod instanceof gast.RepetitionMandatory) {
+    else if (prod instanceof gast.RepetitionMandatory) {
         return PROD_TYPE.REPETITION_MANDATORY
     }
-    if (prod instanceof gast.RepetitionMandatoryWithSeparator) {
+    else if (prod instanceof gast.RepetitionMandatoryWithSeparator) {
         return PROD_TYPE.REPETITION_MANDATORY_WITH_SEPARATOR
     }
-    if (prod instanceof gast.RepetitionWithSeparator) {
+    else if (prod instanceof gast.RepetitionWithSeparator) {
         return PROD_TYPE.REPETITION_WITH_SEPARATOR
     }
-    if (prod instanceof gast.Alternation) {
+    else if (prod instanceof gast.Alternation) {
         return PROD_TYPE.ALTERNATION
     }
     else {

--- a/src/parse/grammar/lookahead.ts
+++ b/src/parse/grammar/lookahead.ts
@@ -14,6 +14,27 @@ export enum PROD_TYPE {
     ALTERNATION
 }
 
+export function getProdType(prod:gast.IProduction):PROD_TYPE {
+    if (prod instanceof gast.Option) {
+        return PROD_TYPE.OPTION
+    }
+    if (prod instanceof gast.Repetition) {
+        return PROD_TYPE.REPETITION
+    }
+    if (prod instanceof gast.RepetitionMandatory) {
+        return PROD_TYPE.REPETITION_MANDATORY
+    }
+    if (prod instanceof gast.RepetitionMandatoryWithSeparator) {
+        return PROD_TYPE.REPETITION_MANDATORY_WITH_SEPARATOR
+    }
+    if (prod instanceof gast.RepetitionWithSeparator) {
+        return PROD_TYPE.REPETITION_WITH_SEPARATOR
+    }
+    if (prod instanceof gast.Alternation) {
+        return PROD_TYPE.ALTERNATION
+    }
+}
+
 export function buildLookaheadFuncForOr(occurrence:number,
                                         ruleGrammar:gast.Rule,
                                         k:number,

--- a/src/parse/parser_public.ts
+++ b/src/parse/parser_public.ts
@@ -104,7 +104,7 @@ export enum ParserDefinitionErrorType {
     INVALID_TOKEN_NAME,
     INVALID_NESTED_RULE_NAME,
     DUPLICATE_NESTED_NAME,
-    EMTPY_LOOKAHEAD
+    NO_NON_EMPTY_LOOKAHEAD
 }
 
 export type IgnoredRuleIssues = { [dslNameAndOccurrence:string]:boolean }

--- a/src/parse/parser_public.ts
+++ b/src/parse/parser_public.ts
@@ -103,7 +103,8 @@ export enum ParserDefinitionErrorType {
     CONFLICT_TOKENS_RULES_NAMESPACE,
     INVALID_TOKEN_NAME,
     INVALID_NESTED_RULE_NAME,
-    DUPLICATE_NESTED_NAME
+    DUPLICATE_NESTED_NAME,
+    EMTPY_LOOKAHEAD
 }
 
 export type IgnoredRuleIssues = { [dslNameAndOccurrence:string]:boolean }

--- a/test/parse/grammar/checks_spec.ts
+++ b/test/parse/grammar/checks_spec.ts
@@ -712,9 +712,9 @@ describe("The no non-empty lookahead validation", () => {
                 (<any>Parser).performSelfAnalysis(this)
             }
 
-            public someRule = this.RULE("someRule", () => this.AT_LEAST_ONE1(this.block))
+            public someRule = this.RULE("someRule", () => this.AT_LEAST_ONE(this.block))
         }
-        expect(() => new EmptyLookaheadParserAtLeastOne()).to.throw("The repetition <AT_LEAST_ONE1>")
+        expect(() => new EmptyLookaheadParserAtLeastOne()).to.throw("The repetition <AT_LEAST_ONE>")
         expect(() => new EmptyLookaheadParserAtLeastOne()).to.throw("<someRule> can never consume any tokens")
     })
 

--- a/test/parse/grammar/checks_spec.ts
+++ b/test/parse/grammar/checks_spec.ts
@@ -712,9 +712,9 @@ describe("The no non-empty lookahead validation", () => {
                 (<any>Parser).performSelfAnalysis(this)
             }
 
-            public someRule = this.RULE("someRule", () => this.AT_LEAST_ONE(this.block))
+            public someRule = this.RULE("someRule", () => this.AT_LEAST_ONE1(this.block))
         }
-        expect(() => new EmptyLookaheadParserAtLeastOne()).to.throw("The repetition <AT_LEAST_ONE>")
+        expect(() => new EmptyLookaheadParserAtLeastOne()).to.throw("The repetition <AT_LEAST_ONE1>")
         expect(() => new EmptyLookaheadParserAtLeastOne()).to.throw("<someRule> can never consume any tokens")
     })
 

--- a/test/parse/grammar/checks_spec.ts
+++ b/test/parse/grammar/checks_spec.ts
@@ -695,3 +695,25 @@ describe("The invalid token name validation", () => {
             .to.throw("Invalid Grammar Token name: ->במבה<- it must match the pattern: ->/^[a-zA-Z_]\\w*$/<-")
     })
 })
+
+describe("The empty lookahead validation", () => {
+
+        it("will throw an error when an empty lookahead is provided", () => {
+            class EmptyLookaheadParser extends Parser {
+
+                constructor(input:Token[] = []) {
+                    super(input, [PlusTok, StarTok]);
+                    (<any>Parser).performSelfAnalysis(this)
+                }
+
+                public start = this.RULE("sourceElements", () => this.AT_LEAST_ONE(this.block)) // missing SUBRULE
+                public block = this.RULE("block", () => {
+                    this.CONSUME(PlusTok)
+                    this.OPTION(() => this.AT_LEAST_ONE(this.SUBRULE(this.block)))
+                    this.CONSUME(StarTok)
+                })
+
+            }
+            expect(() => new EmptyLookaheadParser()).to.throw("Empty lookahead")
+        })
+})

--- a/test/parse/grammar/checks_spec.ts
+++ b/test/parse/grammar/checks_spec.ts
@@ -700,7 +700,7 @@ describe("The no non-empty lookahead validation", () => {
 
     class EmptyLookaheadParser extends Parser {
         constructor(input:Token[] = []) {
-            super(input, [PlusTok]);
+            super(input, [PlusTok])
         }
 
         public block = this.RULE("block", () => this.CONSUME(PlusTok))

--- a/test/parse/grammar/checks_spec.ts
+++ b/test/parse/grammar/checks_spec.ts
@@ -696,24 +696,71 @@ describe("The invalid token name validation", () => {
     })
 })
 
-describe("The empty lookahead validation", () => {
+describe("The no non-empty lookahead validation", () => {
 
-        it("will throw an error when an empty lookahead is provided", () => {
-            class EmptyLookaheadParser extends Parser {
+    class EmptyLookaheadParser extends Parser {
+        constructor(input:Token[] = []) {
+            super(input, [PlusTok]);
+        }
 
-                constructor(input:Token[] = []) {
-                    super(input, [PlusTok, StarTok]);
-                    (<any>Parser).performSelfAnalysis(this)
-                }
-
-                public start = this.RULE("sourceElements", () => this.AT_LEAST_ONE(this.block)) // missing SUBRULE
-                public block = this.RULE("block", () => {
-                    this.CONSUME(PlusTok)
-                    this.OPTION(() => this.AT_LEAST_ONE(this.SUBRULE(this.block)))
-                    this.CONSUME(StarTok)
-                })
-
+        public block = this.RULE("block", () => this.CONSUME(PlusTok))
+    }
+    it("will throw an error when there are no non-empty lookaheads for AT_LEAST_ONE", () => {
+        class EmptyLookaheadParserAtLeastOne extends EmptyLookaheadParser {
+            constructor(input:Token[] = []) {
+                super(input);
+                (<any>Parser).performSelfAnalysis(this)
             }
-            expect(() => new EmptyLookaheadParser()).to.throw("Empty lookahead")
-        })
+
+            public someRule = this.RULE("someRule", () => this.AT_LEAST_ONE(this.block))
+        }
+        expect(() => new EmptyLookaheadParserAtLeastOne()).to.throw("The repetition <AT_LEAST_ONE>")
+        expect(() => new EmptyLookaheadParserAtLeastOne()).to.throw("<someRule> can never consume any tokens")
+    })
+
+    it("will throw an error when there are no non-empty lookaheads for AT_LEAST_ONE_SEP", () => {
+        class EmptyLookaheadParserAtLeastOneSep extends EmptyLookaheadParser {
+            constructor(input:Token[] = []) {
+                super(input);
+                (<any>Parser).performSelfAnalysis(this)
+            }
+
+            public someRule = this.RULE("someRule", () => this.AT_LEAST_ONE_SEP5({
+                SEP: PlusTok,
+                DEF: this.block
+            }))
+        }
+        expect(() => new EmptyLookaheadParserAtLeastOneSep()).to.throw("The repetition <AT_LEAST_ONE_SEP5>")
+        expect(() => new EmptyLookaheadParserAtLeastOneSep()).to.throw("within Rule <someRule>")
+    })
+
+    it("will throw an error when there are no non-empty lookaheads for MANY", () => {
+        class EmptyLookaheadParserMany extends EmptyLookaheadParser {
+            constructor(input:Token[] = []) {
+                super(input);
+                (<any>Parser).performSelfAnalysis(this)
+            }
+
+            public someRule = this.RULE("someRule", () => this.MANY2(this.block))
+        }
+        expect(() => new EmptyLookaheadParserMany()).to.throw("The repetition <MANY2>")
+        expect(() => new EmptyLookaheadParserMany()).to.throw("<someRule> can never consume any tokens")
+    })
+
+
+    it("will throw an error when there are no non-empty lookaheads for MANY_SEP", () => {
+        class EmptyLookaheadParserManySep extends EmptyLookaheadParser {
+            constructor(input:Token[] = []) {
+                super(input);
+                (<any>Parser).performSelfAnalysis(this)
+            }
+
+            public someRule = this.RULE("someRule", () => this.MANY_SEP3({
+                SEP: PlusTok,
+                DEF: this.block
+            }))
+        }
+        expect(() => new EmptyLookaheadParserManySep()).to.throw("The repetition <MANY_SEP3>")
+        expect(() => new EmptyLookaheadParserManySep()).to.throw("within Rule <someRule>")
+    })
 })

--- a/test/parse/grammar/lookahead_spec.ts
+++ b/test/parse/grammar/lookahead_spec.ts
@@ -7,7 +7,9 @@ import {
     buildLookaheadForMany,
     lookAheadSequenceFromAlternatives,
     buildAlternativesLookAheadFunc,
-    buildSingleAlternativeLookaheadFunction
+    buildSingleAlternativeLookaheadFunction,
+    getProdType,
+    PROD_TYPE
 } from "../../../src/parse/grammar/lookahead"
 import {map} from "../../../src/utils/utils"
 import {
@@ -218,6 +220,31 @@ function defineLookaheadSpecs(contextName, extendToken, createToken, tokenMatche
         ], CommaTok, 2)
 
     ])
+
+    describe("getProdType", () => {
+        it("handles `Option`", () => {
+            expect(getProdType(new Option([]))).to.equal(PROD_TYPE.OPTION)
+        })
+        it("handles `Repetition`", () => {
+            expect(getProdType(new Repetition([]))).to.equal(PROD_TYPE.REPETITION)
+        })
+        it("handles `RepetitionMandatory`", () => {
+            expect(getProdType(new RepetitionMandatory([]))).to.equal(PROD_TYPE.REPETITION_MANDATORY)
+        })
+        it("handles `RepetitionWithSeparator`", () => {
+            expect(getProdType(new RepetitionWithSeparator([], null))).to.equal(PROD_TYPE.REPETITION_WITH_SEPARATOR)
+        })
+        it("handles `RepetitionMandatoryWithSeparator`", () => {
+            expect(getProdType(new RepetitionMandatoryWithSeparator([], null))).to.equal(PROD_TYPE.REPETITION_MANDATORY_WITH_SEPARATOR)
+        })
+        it("handles `Alternation`", () => {
+            expect(getProdType(new Alternation([]))).to.equal(PROD_TYPE.ALTERNATION)
+        })
+        it("handles other productions", () => {
+            expect(() => getProdType(new NonTerminal("whatever", null))).to.throw("non exhaustive match")
+            expect(() => getProdType(new Terminal(IdentTok))).to.throw("non exhaustive match")
+        })
+    })
 
     context("lookahead " + contextName, () => {
 

--- a/test/parse/grammar/lookahead_spec.ts
+++ b/test/parse/grammar/lookahead_spec.ts
@@ -240,10 +240,6 @@ function defineLookaheadSpecs(contextName, extendToken, createToken, tokenMatche
         it("handles `Alternation`", () => {
             expect(getProdType(new Alternation([]))).to.equal(PROD_TYPE.ALTERNATION)
         })
-        it("handles other productions", () => {
-            expect(() => getProdType(new NonTerminal("whatever", null))).to.throw("non exhaustive match")
-            expect(() => getProdType(new Terminal(IdentTok))).to.throw("non exhaustive match")
-        })
     })
 
     context("lookahead " + contextName, () => {


### PR DESCRIPTION
This PR adds a test to check if there are empty lookaheads, and makes chevrotain throw an error if there are.

There is currently some thoughts about tackling this the other way around and instead check if there are non-empty productions in repetitions, and throw an error if there are none. (See #401)