### PR TITLE
Lookahead Bug Fixs:

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,4 +5,7 @@
     <option name="languageLevel" value="ES6" />
   </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_3" assert-keyword="false" jdk-15="false" />
+  <component name="WebPackConfiguration">
+    <option name="path" value="$PROJECT_DIR$/webpack.config.js" />
+  </component>
 </project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
     require five tokens of lookahead. A smaller default avoids these potential slow downs while still allows
     override in unique cases which require a large lookahead.
     
+#### Bug Fixes
+- [Separator DSL methods lookahead issue.](https://github.com/SAP/chevrotain/issues/391)
     
 
 ## 0.28.3 (5-1-2017)

--- a/examples/language_services/tslint.json
+++ b/examples/language_services/tslint.json
@@ -9,7 +9,6 @@
       "spaces"
     ],
     "label-position": true,
-    "label-undefined": true,
     "max-line-length": [
       true,
       140
@@ -27,7 +26,6 @@
     "no-construct": true,
     "no-debugger": true,
     "no-var-keyword": true,
-    "no-duplicate-key": true,
     "no-duplicate-variable": true,
     "no-eval": true,
     "no-string-literal": true,
@@ -35,7 +33,6 @@
     "no-trailing-whitespace": true,
     "no-unused-expression": true,
     "no-unused-variable": false,
-    "no-unreachable": true,
     "no-use-before-declare": true,
     "one-line": [
       true,


### PR DESCRIPTION
* Lookahead calculation does not take into account the separator in X_SEP
  DSL Methods.

* Possible Incorrect lookahead calculation in case of optional productions.

Fixes #391.