### PR TITLE
Fixing some capitalization

### DIFF
--- a/docs/tutorial/step1_lexing.md
+++ b/docs/tutorial/step1_lexing.md
@@ -59,7 +59,7 @@ accomplished by marking them with the SKIP group.
 const WhiteSpace = createToken({
          name: "WhiteSpace", 
          pattern: /\s+/,
-         group: chevrotain.lexer.SKIPPED,
+         group: chevrotain.Lexer.SKIPPED,
          line_breaks: true
      });
 ```
@@ -90,7 +90,7 @@ const LessThan = createToken({name: "LessThan", pattern: />/});
 const WhiteSpace = createToken({
         name: "WhiteSpace",
         pattern: /\s+/,
-        group: chevrotain.lexer.SKIPPED,
+        group: chevrotain.Lexer.SKIPPED,
         line_breaks: true
     }); 
 ```


### PR DESCRIPTION
In working through the tutorial it looks like there no `lexer` property of `chevrotain` just `Lexer`