### PR TITLE
An optional alternate implementation of buildInitDefFunc

### DIFF
--- a/src/parse/cst/cst.ts
+++ b/src/parse/cst/cst.ts
@@ -181,7 +181,14 @@ export function analyzeCst(
         currTopRule.accept(namedCollectorVisitor)
         forEach(namedCollectorVisitor.result, ({ def, key, name }) => {
             let currNestedChildrenNames = buildChildDictionaryDef(def)
-            result.dictDef.put(key, buildInitDefFunc(currNestedChildrenNames, avoidDynamicCodeDuringAnalysis))
+            result.dictDef.put(
+                key,
+                buildInitDefFunc(
+                    currNestedChildrenNames,
+                    avoidDynamicCodeDuringAnalysis
+                )
+            )
+
             result.allRuleNames.push(currTopRule.name + name)
         })
     })
@@ -195,7 +202,7 @@ function buildInitDefFuncNoDynamic(childrenNames: string[]): Function {
     // this workaround uses JSON instead to return clones of the initial object.
 
     let initialObject = {}
-    map(childrenNames, (currName) => {
+    map(childrenNames, currName => {
         initialObject[currName] = []
     })
 
@@ -207,11 +214,14 @@ function buildInitDefFuncNoDynamic(childrenNames: string[]): Function {
     }
 }
 
-function buildInitDefFunc(childrenNames: string[], avoidDynamicCodeDuringAnalysis?: boolean): Function {
+function buildInitDefFunc(
+    childrenNames: string[],
+    avoidDynamicCodeDuringAnalysis?: boolean
+): Function {
     if (avoidDynamicCodeDuringAnalysis) {
         return buildInitDefFuncNoDynamic(childrenNames)
     }
-    
+
     let funcString = `return {\n`
 
     funcString += map(childrenNames, currName => `"${currName}" : []`).join(

--- a/src/parse/parser_public.ts
+++ b/src/parse/parser_public.ts
@@ -204,6 +204,7 @@ const DEFAULT_PARSER_CONFIG: IParserConfig = Object.freeze({
     maxLookahead: 4,
     ignoredIssues: <any>{},
     dynamicTokensEnabled: false,
+    avoidDynamicCodeDuringAnalysis: false,
     // TODO: Document this breaking change, can it be mitigated?
     // TODO: change to true
     outputCst: false,
@@ -523,7 +524,8 @@ export class Parser {
 
             let cstAnalysisResult = analyzeCst(
                 clonedProductions.values(),
-                parserInstance.fullRuleNameToShort
+                parserInstance.fullRuleNameToShort,
+                parserInstance.avoidDynamicCodeDuringAnalysis
             )
             cache
                 .getCstDictDefPerRuleForClass(className)
@@ -559,6 +561,7 @@ export class Parser {
      */
     protected recoveryEnabled: boolean
     protected dynamicTokensEnabled: boolean
+    protected avoidDynamicCodeDuringAnalysis: boolean
     protected maxLookahead: number
     protected ignoredIssues: IgnoredParserIssues
     protected outputCst: boolean
@@ -624,6 +627,10 @@ export class Parser {
         this.dynamicTokensEnabled = has(config, "dynamicTokensEnabled")
             ? config.dynamicTokensEnabled
             : DEFAULT_PARSER_CONFIG.dynamicTokensEnabled
+        
+        this.avoidDynamicCodeDuringAnalysis = has(config, "avoidDynamicCodeDuringAnalysis")
+            ? config.avoidDynamicCodeDuringAnalysis
+            : DEFAULT_PARSER_CONFIG.avoidDynamicCodeDuringAnalysis
 
         this.maxLookahead = has(config, "maxLookahead")
             ? config.maxLookahead

--- a/src/parse/parser_public.ts
+++ b/src/parse/parser_public.ts
@@ -197,6 +197,13 @@ export interface IParserConfig {
      *   - Providing special error messages under certain conditions - missing semicolons
      */
     errorMessageProvider?: IErrorMessageProvider
+
+    /**
+     * During cst analysis, the standard buildInitDefFunc uses "new Function" 
+     * which will trigger unsafe-eval warnings in some web contexts.
+     * You can use this optional flag to avoid the warning.
+     */
+    avoidDynamicCodeDuringAnalysis?: boolean
 }
 
 const DEFAULT_PARSER_CONFIG: IParserConfig = Object.freeze({
@@ -627,8 +634,11 @@ export class Parser {
         this.dynamicTokensEnabled = has(config, "dynamicTokensEnabled")
             ? config.dynamicTokensEnabled
             : DEFAULT_PARSER_CONFIG.dynamicTokensEnabled
-        
-        this.avoidDynamicCodeDuringAnalysis = has(config, "avoidDynamicCodeDuringAnalysis")
+
+        this.avoidDynamicCodeDuringAnalysis = has(
+            config,
+            "avoidDynamicCodeDuringAnalysis"
+        )
             ? config.avoidDynamicCodeDuringAnalysis
             : DEFAULT_PARSER_CONFIG.avoidDynamicCodeDuringAnalysis
 


### PR DESCRIPTION
In the browser, some websites use Content Security Policy (CSP) rules for additional security against attacks like cross-site scripting. Chevrotain currently causes a CSP unsafe-eval error during analyzeCst(), because buildInitDefFunc's "new Function" is essentially an eval. While the error is basically a false positive here, I propose an optional flag that uses an alternate buildInitDefFunc implementation so that a website can use Chevrotain with CSP left enabled.