### PR TITLE
Support Custom Error Message for grammar analysis phase.

### DIFF
--- a/examples/parser/custom_errors/custom_errors.js
+++ b/examples/parser/custom_errors/custom_errors.js
@@ -29,7 +29,7 @@ const allTokens = [WhiteSpace, Alpha, Bravo, Charlie]
 const PhoneticLexer = new Lexer(allTokens)
 
 // ----------------- Custom Error Provider ------------
-const defaultErrorProvider = chevrotain.defaultErrorProvider
+const defaultParserErrorProvider = chevrotain.defaultParserErrorProvider
 
 const myErrorProvider = {
     buildMismatchTokenMessage: function(options) {
@@ -39,7 +39,7 @@ const myErrorProvider = {
             return "expecting Bravo at end of " + options.ruleName
         } else {
             // fallback to the default behavior otherwise.
-            return defaultErrorProvider.buildMismatchTokenMessage(options)
+            return defaultParserErrorProvider.buildMismatchTokenMessage(options)
         }
     },
     buildNotAllInputParsedMessage: function(options) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -21,7 +21,7 @@ import {
 } from "./parse/exceptions_public"
 import { clearCache } from "./parse/cache_public"
 import { VERSION } from "./version"
-import { defaultErrorProvider } from "./parse/errors_public"
+import { defaultParserErrorProvider } from "./parse/errors_public"
 import { createSyntaxDiagramsCode } from "./diagrams/render_public"
 import { GAstVisitor } from "./parse/grammar/gast/gast_visitor_public"
 import {
@@ -68,9 +68,9 @@ API.createTokenInstance = createTokenInstance
 
 // Other Utilities
 API.EMPTY_ALT = EMPTY_ALT
-API.defaultErrorProvider = defaultErrorProvider
-
-API.isRecognitionException = isRecognitionException
+// TODO: Breaking Change -> renamed property
+API.defaultParserErrorProvider = defaultParserErrorProvider
+API.defaultGrammarErrorProvider = API.isRecognitionException = isRecognitionException
 API.EarlyExitException = EarlyExitException
 API.MismatchedTokenException = MismatchedTokenException
 API.NotAllInputParsedException = NotAllInputParsedException

--- a/src/api.ts
+++ b/src/api.ts
@@ -21,7 +21,10 @@ import {
 } from "./parse/exceptions_public"
 import { clearCache } from "./parse/cache_public"
 import { VERSION } from "./version"
-import { defaultParserErrorProvider } from "./parse/errors_public"
+import {
+    defaultGrammarErrorProvider,
+    defaultParserErrorProvider
+} from "./parse/errors_public"
 import { createSyntaxDiagramsCode } from "./diagrams/render_public"
 import { GAstVisitor } from "./parse/grammar/gast/gast_visitor_public"
 import {
@@ -70,7 +73,8 @@ API.createTokenInstance = createTokenInstance
 API.EMPTY_ALT = EMPTY_ALT
 // TODO: Breaking Change -> renamed property
 API.defaultParserErrorProvider = defaultParserErrorProvider
-API.defaultGrammarErrorProvider = API.isRecognitionException = isRecognitionException
+API.defaultGrammarErrorProvider = defaultGrammarErrorProvider
+API.isRecognitionException = isRecognitionException
 API.EarlyExitException = EarlyExitException
 API.MismatchedTokenException = MismatchedTokenException
 API.NotAllInputParsedException = NotAllInputParsedException

--- a/src/parse/cst/cst.ts
+++ b/src/parse/cst/cst.ts
@@ -22,6 +22,7 @@ import {
 import {
     Alternation,
     Flat,
+    IOptionallyNamedProduction,
     IProduction,
     NonTerminal,
     Option,
@@ -54,6 +55,7 @@ export interface DefAndKeyAndName {
     def: IProduction[]
     key: number
     name: string
+    orgProd: IOptionallyNamedProduction
 }
 
 export class NamedDSLMethodsCollectorVisitor extends GAstVisitor {
@@ -104,7 +106,7 @@ export class NamedDSLMethodsCollectorVisitor extends GAstVisitor {
                 methodIdx,
                 node.idx
             )
-            this.result.push({ def, key, name: node.name })
+            this.result.push({ def, key, name: node.name, orgProd: node })
         }
     }
 
@@ -156,7 +158,8 @@ export class NamedDSLMethodsCollectorVisitor extends GAstVisitor {
                 this.result.push({
                     def,
                     key,
-                    name: currFlatAlt.name
+                    name: currFlatAlt.name,
+                    orgProd: currFlatAlt
                 })
             }
         })

--- a/src/parse/grammar/gast/gast_resolver_public.ts
+++ b/src/parse/grammar/gast/gast_resolver_public.ts
@@ -1,4 +1,4 @@
-import { Rule } from "./gast_public"
+import { NonTerminal, Rule } from "./gast_public"
 import {
     IgnoredParserIssues,
     IParserDefinitionError

--- a/src/parse/grammar/gast/gast_resolver_public.ts
+++ b/src/parse/grammar/gast/gast_resolver_public.ts
@@ -8,6 +8,10 @@ import { HashTable } from "../../../lang/lang_extensions"
 import { resolveGrammar as orgResolveGrammar } from "../resolver"
 import { TokenType } from "../../../scan/lexer_public"
 import { validateGrammar as orgValidateGrammar } from "../checks"
+import {
+    defaultGrammarErrorProvider,
+    IGrammarErrorMessageProvider
+} from "../../errors_public"
 
 export function resolveGrammar(options: {
     rules: Rule[]
@@ -24,11 +28,17 @@ export function validateGrammar(options: {
     maxLookahead: number
     tokenTypes: TokenType[]
     ignoredIssues: IgnoredParserIssues
+    grammarName: string
+    errMsgProvider?: IGrammarErrorMessageProvider
 }): IParserDefinitionError[] {
     return orgValidateGrammar(
         options.rules,
         options.maxLookahead,
         options.tokenTypes,
-        options.ignoredIssues
+        options.ignoredIssues,
+        options.errMsgProvider
+            ? options.errMsgProvider
+            : defaultGrammarErrorProvider,
+        options.grammarName
     )
 }

--- a/src/parse/parser_public.ts
+++ b/src/parse/parser_public.ts
@@ -99,7 +99,10 @@ import {
     createBaseSemanticVisitorConstructor,
     createBaseVisitorConstructorWithDefaults
 } from "./cst/cst_visitor"
-import { defaultErrorProvider, IErrorMessageProvider } from "./errors_public"
+import {
+    defaultParserErrorProvider,
+    IParserErrorMessageProvider
+} from "./errors_public"
 import {
     ISerializedGast,
     Rule,
@@ -200,7 +203,7 @@ export interface IParserConfig {
      *   - Changing the formatting
      *   - Providing special error messages under certain conditions - missing semicolons
      */
-    errorMessageProvider?: IErrorMessageProvider
+    errorMessageProvider?: IParserErrorMessageProvider
 }
 
 const DEFAULT_PARSER_CONFIG: IParserConfig = Object.freeze({
@@ -211,7 +214,7 @@ const DEFAULT_PARSER_CONFIG: IParserConfig = Object.freeze({
     // TODO: Document this breaking change, can it be mitigated?
     // TODO: change to true
     outputCst: false,
-    errorMessageProvider: defaultErrorProvider
+    errorMessageProvider: defaultParserErrorProvider
 })
 
 export interface IRuleConfig<T> {
@@ -575,7 +578,7 @@ export class Parser {
     protected outputCst: boolean
 
     // adapters
-    protected errorMessageProvider: IErrorMessageProvider
+    protected errorMessageProvider: IParserErrorMessageProvider
 
     protected isBackTrackingStack = []
     protected className: string

--- a/test/parse/grammar/checks_spec.ts
+++ b/test/parse/grammar/checks_spec.ts
@@ -623,7 +623,7 @@ describe("The rule names validation full flow", () => {
             "it must match the pattern"
         )
         expect(() => new InvalidRuleNameParser()).to.throw(
-            "Invalid Grammar rule name"
+            "Invalid grammar rule name"
         )
         expect(() => new InvalidRuleNameParser()).to.throw("שלום")
     })

--- a/test/parse/grammar/checks_spec.ts
+++ b/test/parse/grammar/checks_spec.ts
@@ -17,15 +17,16 @@ import {
 import { createToken, IToken } from "../../../src/scan/tokens_public"
 import { first, forEach, map } from "../../../src/utils/utils"
 import {
-    Repetition,
-    Rule,
-    Terminal,
-    Option,
     Alternation,
-    RepetitionMandatory,
     Flat,
-    NonTerminal
+    NonTerminal,
+    Option,
+    Repetition,
+    RepetitionMandatory,
+    Rule,
+    Terminal
 } from "../../../src/parse/grammar/gast/gast_public"
+import { defaultGrammarErrorProvider } from "../../../src/parse/errors_public"
 
 describe("the grammar validations", () => {
     it("validates every one of the TOP_RULEs in the input", () => {
@@ -103,7 +104,9 @@ describe("the grammar validations", () => {
             [qualifiedNameErr1, qualifiedNameErr2],
             5,
             [],
-            {}
+            {},
+            defaultGrammarErrorProvider,
+            "bamba"
         )
         expect(actualErrors.length).to.equal(4)
 
@@ -114,17 +117,27 @@ describe("the grammar validations", () => {
 
     it("does not allow duplicate grammar rule names", () => {
         let noErrors = validateRuleDoesNotAlreadyExist(
-            "A",
-            ["B", "C"],
-            "className"
+            new Rule({ name: "A", definition: [] }),
+            [
+                new Rule({ name: "B", definition: [] }),
+                new Rule({ name: "C", definition: [] })
+            ],
+            "className",
+            defaultGrammarErrorProvider
         )
         //noinspection BadExpressionStatementJS
         expect(noErrors).to.be.empty
 
         let duplicateErr = validateRuleDoesNotAlreadyExist(
-            "A",
-            ["A", "B", "C"],
-            "className"
+            new Rule({ name: "A", definition: [] }),
+            [
+                new Rule({ name: "A", definition: [] }),
+                new Rule({ name: "A", definition: [] }),
+                new Rule({ name: "B", definition: [] }),
+                new Rule({ name: "C", definition: [] })
+            ],
+            "className",
+            defaultGrammarErrorProvider
         )
         //noinspection BadExpressionStatementJS
         expect(duplicateErr).to.have.length(1)
@@ -137,7 +150,10 @@ describe("the grammar validations", () => {
     })
 
     it("only allows a subset of ECMAScript identifiers as rule names", () => {
-        let res1 = validateRuleName("1baa")
+        let res1 = validateRuleName(
+            new Rule({ name: "1baa", definition: [] }),
+            defaultGrammarErrorProvider
+        )
         expect(res1).to.have.lengthOf(1)
         expect(res1[0]).to.have.property("message")
         expect(res1[0]).to.have.property(
@@ -146,7 +162,10 @@ describe("the grammar validations", () => {
         )
         expect(res1[0]).to.have.property("ruleName", "1baa")
 
-        let res2 = validateRuleName("שלום")
+        let res2 = validateRuleName(
+            new Rule({ name: "שלום", definition: [] }),
+            defaultGrammarErrorProvider
+        )
         expect(res2).to.have.lengthOf(1)
         expect(res2[0]).to.have.property("message")
         expect(res2[0]).to.have.property(
@@ -155,7 +174,10 @@ describe("the grammar validations", () => {
         )
         expect(res2[0]).to.have.property("ruleName", "שלום")
 
-        let res3 = validateRuleName("$bamba")
+        let res3 = validateRuleName(
+            new Rule({ name: "$bamba", definition: [] }),
+            defaultGrammarErrorProvider
+        )
         expect(res3).to.have.lengthOf(1)
         expect(res3[0]).to.have.property("message")
         expect(res3[0]).to.have.property(
@@ -1163,7 +1185,10 @@ describe("The no non-empty lookahead validation", () => {
             definition: [new Alternation({ definition: alternatives })]
         })
 
-        const actual = validateTooManyAlts(ruleWithTooManyAlts)
+        const actual = validateTooManyAlts(
+            ruleWithTooManyAlts,
+            defaultGrammarErrorProvider
+        )
         expect(actual).to.have.lengthOf(1)
         expect(actual[0].type).to.equal(ParserDefinitionErrorType.TOO_MANY_ALTS)
         expect(actual[0].ruleName).to.equal("blah")

--- a/test/parse/grammar/resolver_spec.ts
+++ b/test/parse/grammar/resolver_spec.ts
@@ -2,6 +2,7 @@ import { HashTable } from "../../../src/lang/lang_extensions"
 import { GastRefResolverVisitor } from "../../../src/parse/grammar/resolver"
 import { ParserDefinitionErrorType } from "../../../src/parse/parser_public"
 import { NonTerminal, Rule } from "../../../src/parse/grammar/gast/gast_public"
+import { defaultGrammarErrorProvider } from "../../../src/parse/errors_public"
 
 describe("The RefResolverVisitor", () => {
     it("will fail when trying to resolve a ref to a grammar rule that does not exist", () => {
@@ -9,7 +10,10 @@ describe("The RefResolverVisitor", () => {
         let topLevel = new Rule({ name: "TOP", definition: [ref] })
         let topLevelRules = new HashTable<Rule>()
         topLevelRules.put("TOP", topLevel)
-        let resolver = new GastRefResolverVisitor(topLevelRules)
+        let resolver = new GastRefResolverVisitor(
+            topLevelRules,
+            defaultGrammarErrorProvider
+        )
         resolver.resolveRefs()
         expect(resolver.errors).to.have.lengthOf(1)
         expect(resolver.errors[0].message).to.contain(


### PR DESCRIPTION
This is needed to enable support for custom APIs to create grammars.
I.E code generators or combinator using Chevrotain as the parsing runtime.

Part of #450 