### PR TITLE
CST upgrades for v3.0

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,3 +1,27 @@
+## 3.0.0
+
+- A CST Node's children dictionary no longer contains empty arrays
+  for unmatched terminals and non-terminals. This means that some existence checks
+  conditions in the CST visitor must be refactored, for example:
+  
+  ```javascript
+  class MyVisitor extends SomeBaseVisitor {
+      atomicExpression(ctx) {
+          // BAD - will fail due to "TypeError: Cannot read property '0' of undefined"
+          if (ctx.Integer[0]) {
+              return ctx.Integer[0].image
+          }
+          // GOOD - safe check
+          else if (ctx.Identifier) {
+              // if a property exists it's value is guaranteed to have at least one element.
+              return ctx.Identifier[0].image
+          }
+      }
+  }
+  ```
+
+
+
 ## 2.0.0
 
 - The creation of TokenTypes using the class keyword syntax has been soft deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## X.Y.Z (INSERT_DATE_HERE)
+
+#### Breaking Changes
+
+- [See BREAKING_CHANGES.md](https://github.com/SAP/chevrotain/blob/master/BREAKING_CHANGES.md#300)
+
+#### Major Changes
+
+- [Optional Labels for CST Nodes](https://github.com/SAP/chevrotain/issues/668)
+
+- [Performance Improvements for CST Creation](https://github.com/SAP/chevrotain/issues/572)
+
+#### Minor Changes
+
+- The CST creation no longer relies on "new Function()" calls and can thus be used
+  in environments with [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) enabled.
+
+
+
 ## 2.0.2 (2-21-2018)
 
 #### Bug Fixes
@@ -5,11 +24,13 @@
 - [Runtime Error During re-sync Recovery](https://github.com/SAP/chevrotain/issues/668).
 
 
+
 ## 2.0.1 (2-11-2018)
 
 #### Bug Fixes
 
 - Removed redundant dependency.
+
 
 
 ## 2.0.0 (2-11-2018)

--- a/benchmark_web/parsers/css/css_dev.html
+++ b/benchmark_web/parsers/css/css_dev.html
@@ -7,12 +7,13 @@
 <body>
 
 <script src="../worker_api.js"></script>
+<script src="../options.js"></script>
 
 <script>
     // relative ti thr worker impel file
     initWorker({
         startRule:     "stylesheet",
-        parserConfig:  {outputCst: true},
+        parserConfig:  window.globalOptions.dev,
         importScripts: [
             "../../lib/chevrotain.js",
             "https://unpkg.com/xregexp@3.2.0/xregexp-all.js",

--- a/benchmark_web/parsers/css/css_latest.html
+++ b/benchmark_web/parsers/css/css_latest.html
@@ -7,12 +7,13 @@
 <body>
 
 <script src="../worker_api.js"></script>
+<script src="../options.js"></script>
 
 <script>
     // relative to the worker impel file
     initWorker({
         startRule:     "stylesheet",
-        // parserConfig:  {outputCst: true},
+        parserConfig:  window.globalOptions.latest,
         importScripts: [
             "https://unpkg.com/chevrotain/lib/chevrotain.js",
             "https://unpkg.com/xregexp@3.2.0/xregexp-all.js",

--- a/benchmark_web/parsers/css/css_latest.html
+++ b/benchmark_web/parsers/css/css_latest.html
@@ -12,7 +12,7 @@
     // relative to the worker impel file
     initWorker({
         startRule:     "stylesheet",
-        parserConfig:  {outputCst: true},
+        // parserConfig:  {outputCst: true},
         importScripts: [
             "https://unpkg.com/chevrotain/lib/chevrotain.js",
             "https://unpkg.com/xregexp@3.2.0/xregexp-all.js",

--- a/benchmark_web/parsers/ecma5/ecma5_dev.html
+++ b/benchmark_web/parsers/ecma5/ecma5_dev.html
@@ -7,12 +7,13 @@
 <body>
 
 <script src="../worker_api.js"></script>
+<script src="../options.js"></script>
 
 <script>
     // relative to the worker impel file
     initWorker({
         startRule:     "Program",
-        parserConfig:  {outputCst: true},
+        parserConfig:  window.globalOptions.dev,
         importScripts: [
             "../../lib/chevrotain.js",
             "https://unpkg.com/acorn@5.1.2/dist/acorn.js",

--- a/benchmark_web/parsers/ecma5/ecma5_latest.html
+++ b/benchmark_web/parsers/ecma5/ecma5_latest.html
@@ -12,7 +12,7 @@
     // relative to the worker impel file
     initWorker({
         startRule:     "Program",
-        parserConfig:  {outputCst: true},
+        // parserConfig:  {outputCst: true},
         importScripts: [
             "https://unpkg.com/chevrotain/lib/chevrotain.js",
             "https://unpkg.com/acorn@5.1.2/dist/acorn.js",

--- a/benchmark_web/parsers/ecma5/ecma5_latest.html
+++ b/benchmark_web/parsers/ecma5/ecma5_latest.html
@@ -7,12 +7,13 @@
 <body>
 
 <script src="../worker_api.js"></script>
+<script src="../options.js"></script>
 
 <script>
     // relative to the worker impel file
     initWorker({
         startRule:     "Program",
-        // parserConfig:  {outputCst: true},
+        parserConfig:  window.globalOptions.latest,
         importScripts: [
             "https://unpkg.com/chevrotain/lib/chevrotain.js",
             "https://unpkg.com/acorn@5.1.2/dist/acorn.js",

--- a/benchmark_web/parsers/json/json_dev.html
+++ b/benchmark_web/parsers/json/json_dev.html
@@ -7,12 +7,13 @@
 <body>
 
 <script src="../worker_api.js"></script>
+<script src="../options.js"></script>
 
 <script>
     // relative ti thr worker impel file
     initWorker({
         startRule:     "json",
-        parserConfig:  {outputCst: true},
+        parserConfig:  window.globalOptions.dev,
         importScripts: [
             "../../lib/chevrotain.js",
             "./json/json_parser.js",

--- a/benchmark_web/parsers/json/json_latest.html
+++ b/benchmark_web/parsers/json/json_latest.html
@@ -12,7 +12,7 @@
     // relative to the worker impel file
     initWorker({
         startRule:     "json",
-        parserConfig:  {outputCst: true},
+        // parserConfig:  {outputCst: true},
         importScripts: [
             "https://unpkg.com/chevrotain/lib/chevrotain.js",
             "./json/json_parser.js",

--- a/benchmark_web/parsers/json/json_latest.html
+++ b/benchmark_web/parsers/json/json_latest.html
@@ -7,12 +7,13 @@
 <body>
 
 <script src="../worker_api.js"></script>
+<script src="../options.js"></script>
 
 <script>
     // relative to the worker impel file
     initWorker({
         startRule:     "json",
-        // parserConfig:  {outputCst: true},
+        parserConfig:  window.globalOptions.latest,
         importScripts: [
             "https://unpkg.com/chevrotain/lib/chevrotain.js",
             "./json/json_parser.js",

--- a/benchmark_web/parsers/options.js
+++ b/benchmark_web/parsers/options.js
@@ -1,0 +1,4 @@
+window.globalOptions = {
+    dev: {},
+    latest: {}
+}

--- a/benchmark_web/parsers/options.js
+++ b/benchmark_web/parsers/options.js
@@ -1,4 +1,4 @@
 window.globalOptions = {
-    dev: {},
-    latest: {}
+    dev: { outputCst: true },
+    latest: { outputCst: true }
 }

--- a/docs/01_Tutorial/step2_parsing.md
+++ b/docs/01_Tutorial/step2_parsing.md
@@ -231,10 +231,12 @@ class SelectParser extends Parser {
              $.SUBRULE($.expression)
          }) 
     
+         // The "rhs" and "lhs" (Right/Left Hand Side) labels will provide easy 
+         // to use names during CST Visitor (step 3a). 
          $.RULE("expression", () => {
-             $.SUBRULE($.atomicExpression)
+             $.SUBRULE($.atomicExpression, { LABEL: "lhs" })
              $.SUBRULE($.relationalOperator)
-             $.SUBRULE2($.atomicExpression) // note the '2' suffix to distinguish
+             $.SUBRULE2($.atomicExpression, { LABEL: "rhs" }) // note the '2' suffix to distinguish
                            // from the 'SUBRULE(atomicExpression)'
                            // 2 lines above.
          })

--- a/docs/01_Tutorial/step3a_adding_actions_visitor.md
+++ b/docs/01_Tutorial/step3a_adding_actions_visitor.md
@@ -32,7 +32,7 @@ class SelectParser extends chevrotain.Parser {
 
     constructor(input) {
         // The "outputCst" flag will cause the parser to create a CST structure on rule invocation
-        super(input, allTokens, {outputCst: true})
+        super(input, allTokens, { outputCst: true })
         
         /* rule definitions... */
         
@@ -236,10 +236,10 @@ class SQLToAstVisitor extends BaseSQLVisitor {
     }
     
     expression(ctx) {
-        const lhs = this.visit(ctx.atomicExpression[0])
-        // The second [1] atomicExpression is the right hand side
-        const rhs = this.visit(ctx.atomicExpression[1])
+        // Note the usage of the "rhs" and "lhs" labels defined in step 2 in the expression rule.
+        const lhs = this.visit(ctx.lhs[0])
         const operator = this.visit(ctx.relationalOperator)
+        const rhs = this.visit(ctx.rhs[0])
         
         return {
             type: "EXPRESSION", 

--- a/docs/01_Tutorial/step3a_adding_actions_visitor.md
+++ b/docs/01_Tutorial/step3a_adding_actions_visitor.md
@@ -251,7 +251,7 @@ class SQLToAstVisitor extends BaseSQLVisitor {
     
     // these two visitor methods will return a string.
     atomicExpression(ctx) {
-        if (ctx.Integer[0]) {
+        if (ctx.Integer) {
             return ctx.Integer[0].image
         }
         else {
@@ -260,7 +260,7 @@ class SQLToAstVisitor extends BaseSQLVisitor {
     }
     
     relationalOperator(ctx) {
-        if (ctx.GreaterThan[0]) {
+        if (ctx.GreaterThan) {
             return ctx.GreaterThan[0].image
         }
         else {

--- a/examples/grammars/calculator/calculator_pure_grammar.js
+++ b/examples/grammars/calculator/calculator_pure_grammar.js
@@ -207,12 +207,11 @@ class CalculatorInterpreter extends BaseCstVisitor {
     }
 
     atomicExpression(ctx) {
-        if (ctx.parenthesisExpression.length > 0) {
-            // TODO: allow accepting array for less verbose syntax
+        if (ctx.parenthesisExpression) {
             return this.visit(ctx.parenthesisExpression[0])
-        } else if (ctx.NumberLiteral.length > 0) {
+        } else if (ctx.NumberLiteral) {
             return parseInt(ctx.NumberLiteral[0].image, 10)
-        } else if (ctx.powerFunction.length > 0) {
+        } else if (ctx.powerFunction) {
             return this.visit(ctx.powerFunction[0])
         }
     }

--- a/examples/grammars/calculator/calculator_pure_grammar.js
+++ b/examples/grammars/calculator/calculator_pure_grammar.js
@@ -100,21 +100,22 @@ class CalculatorPure extends Parser {
         // The precedence of binary expressions is determined by how far down the Parse Tree
         // The binary expression appears.
         $.RULE("additionExpression", () => {
-            $.SUBRULE($.multiplicationExpression)
+            // using labels can make the CST processing easier
+            $.SUBRULE($.multiplicationExpression, { LABEL: "lhs" })
             $.MANY(() => {
                 // consuming 'AdditionOperator' will consume either Plus or Minus as they are subclasses of AdditionOperator
                 $.CONSUME(AdditionOperator)
                 //  the index "2" in SUBRULE2 is needed to identify the unique position in the grammar during runtime
-                $.SUBRULE2($.multiplicationExpression)
+                $.SUBRULE2($.multiplicationExpression, { LABEL: "rhs" })
             })
         })
 
         $.RULE("multiplicationExpression", () => {
-            $.SUBRULE($.atomicExpression)
+            $.SUBRULE($.atomicExpression, { LABEL: "lhs" })
             $.MANY(() => {
                 $.CONSUME(MultiplicationOperator)
                 //  the index "2" in SUBRULE2 is needed to identify the unique position in the grammar during runtime
-                $.SUBRULE2($.atomicExpression)
+                $.SUBRULE2($.atomicExpression, { LABEL: "rhs" })
             })
         })
 
@@ -170,39 +171,48 @@ class CalculatorInterpreter extends BaseCstVisitor {
         return this.visit(ctx.additionExpression[0])
     }
 
+    // Note the usage if the "rhs" and "lhs" labels to increase the readability.
     additionExpression(ctx) {
-        let lhs = this.visit(ctx.multiplicationExpression[0])
-        let result = lhs
-        for (let i = 1; i < ctx.multiplicationExpression.length; i++) {
-            // There is one less operator than operands
-            let operator = ctx.AdditionOperator[i - 1]
-            let rhs = this.visit(ctx.multiplicationExpression[i])
+        let result = this.visit(ctx.lhs[0])
 
-            if (tokenMatcher(operator, Plus)) {
-                result += rhs
-            } else {
-                // Minus
-                result -= rhs
-            }
+        // "rhs" key may be undefined as the grammar defines it as optional (MANY === zero or more).
+        if (ctx.rhs) {
+            ctx.rhs.forEach((rhsOperand, idx) => {
+                // there will be one operator for each rhs operand
+                let rhsValue = this.visit(rhsOperand)
+                let operator = ctx.AdditionOperator[idx]
+
+                if (tokenMatcher(operator, Plus)) {
+                    result += rhsValue
+                } else {
+                    // Minus
+                    result -= rhsValue
+                }
+            })
         }
+
         return result
     }
 
     multiplicationExpression(ctx) {
-        let lhs = this.visit(ctx.atomicExpression[0])
-        let result = lhs
-        for (let i = 1; i < ctx.atomicExpression.length; i++) {
-            // There is one less operator than operands
-            let operator = ctx.MultiplicationOperator[i - 1]
-            let rhs = this.visit(ctx.atomicExpression[i])
+        let result = this.visit(ctx.lhs[0])
 
-            if (tokenMatcher(operator, Multi)) {
-                result *= rhs
-            } else {
-                // Division
-                result /= rhs
-            }
+        // "rhs" key may be undefined as the grammar defines it as optional (MANY === zero or more).
+        if (ctx.rhs) {
+            ctx.rhs.forEach((rhsOperand, idx) => {
+                // there will be one operator for each rhs operand
+                let rhsValue = this.visit(rhsOperand)
+                let operator = ctx.MultiplicationOperator[idx]
+
+                if (tokenMatcher(operator, Multi)) {
+                    result *= rhsValue
+                } else {
+                    // Division
+                    result /= rhsValue
+                }
+            })
         }
+
         return result
     }
 

--- a/examples/grammars/ecma5/ecma5_parser.js
+++ b/examples/grammars/ecma5/ecma5_parser.js
@@ -526,7 +526,7 @@ class ECMAScript5Parser extends Parser {
                         // 'in' is only possible if there was just one VarDec
                         // TODO: when CST output is enabled this check breaks
                         inPossible = numOfVars === 1
-                        $.SUBRULE($.ForHeaderParts, [inPossible])
+                        $.SUBRULE($.ForHeaderParts, { ARGS: [inPossible] })
                     }
                 },
                 {
@@ -535,7 +535,7 @@ class ECMAScript5Parser extends Parser {
                             const headerExp = $.SUBRULE($.ExpressionNoIn)
                             inPossible = this.canInComeAfterExp(headerExp)
                         })
-                        $.SUBRULE2($.ForHeaderParts, [inPossible])
+                        $.SUBRULE2($.ForHeaderParts, { ARGS: [inPossible] })
                     }
                 }
             ])
@@ -789,7 +789,7 @@ class ECMAScript5Parser extends Parser {
         $.RULE("SourceElements", () => {
             $.MANY(() => {
                 // FunctionDeclaration appearing before statement implements [lookahead != {{, function}] in ExpressionStatement
-                // See Functionhttps://www.ecma-international.org/ecma-262/5.1/index.html#sec-12.4Declaration
+                // See https://www.ecma-international.org/ecma-262/5.1/index.html#sec-12.4Declaration
                 $.OR([
                     { ALT: () => $.SUBRULE($.FunctionDeclaration) },
                     { ALT: () => $.SUBRULE($.Statement) }

--- a/examples/parser/backtracking/backtracking_spec.js
+++ b/examples/parser/backtracking/backtracking_spec.js
@@ -9,18 +9,14 @@ describe("The Backtracking Example", () => {
         expect(parseResult.value.children.withEqualsStatement).to.have.lengthOf(
             1
         )
-        expect(
-            parseResult.value.children.withDefaultStatement
-        ).to.have.lengthOf(0)
+        expect(parseResult.value.children.withDefaultStatement).to.be.undefined
     })
 
     it("can parse a statement with Default and a very long qualified name", () => {
         const input = "element age : a.b.c.d.e.f default 666;"
         const parseResult = parseSample(input)
         expect(parseResult.parseErrors).to.be.empty
-        expect(parseResult.value.children.withEqualsStatement).to.have.lengthOf(
-            0
-        )
+        expect(parseResult.value.children.withEqualsStatement).to.be.undefined
         expect(
             parseResult.value.children.withDefaultStatement
         ).to.have.lengthOf(1)

--- a/examples/parser/parametrized_rules/parametrized.js
+++ b/examples/parser/parametrized_rules/parametrized.js
@@ -54,8 +54,8 @@ class HelloParser extends Parser {
         const $ = this
 
         $.RULE("topRule", mood => {
-            // SUBRULE may be called with a array of arguments which will be passed to the sub-rule's implementation
-            $.SUBRULE($.hello, [mood])
+            // Passing arguments via a SUBRULE is done using a config object
+            $.SUBRULE($.hello, { ARGS: [mood] })
         })
 
         // the <hello> rule's implementation is defined with a <mood> parameter

--- a/examples/tutorial/step1_lexing/step1_lexing.js
+++ b/examples/tutorial/step1_lexing/step1_lexing.js
@@ -70,7 +70,7 @@ module.exports = {
     tokenVocabulary: tokenVocabulary,
 
     lex: function(inputText) {
-        let lexingResult = SelectLexer.tokenize(inputText)
+        const lexingResult = SelectLexer.tokenize(inputText)
 
         if (lexingResult.errors.length > 0) {
             throw Error("Sad Sad Panda, lexing errors detected")

--- a/examples/tutorial/step2_parsing/step2_parsing.js
+++ b/examples/tutorial/step2_parsing/step2_parsing.js
@@ -59,10 +59,12 @@ class SelectParser extends Parser {
             $.SUBRULE($.expression)
         })
 
+        // The "rhs" and "lhs" (Right/Left Hand Side) labels will provide easy
+        // to use names during CST Visitor (step 3a).
         $.RULE("expression", () => {
-            $.SUBRULE($.atomicExpression)
+            $.SUBRULE($.atomicExpression, { LABEL: "lhs" })
             $.SUBRULE($.relationalOperator)
-            $.SUBRULE2($.atomicExpression) // note the '2' suffix to distinguish
+            $.SUBRULE2($.atomicExpression, { LABEL: "rhs" }) // note the '2' suffix to distinguish
             // from the 'SUBRULE(atomicExpression)'
             // 2 lines above.
         })

--- a/examples/tutorial/step3_actions/step3_actions_spec.js
+++ b/examples/tutorial/step3_actions/step3_actions_spec.js
@@ -7,9 +7,9 @@ const toAstEmbedded = require("./step3b_actions_embedded").toAst
 describe("Chevrotain Tutorial", () => {
     context("Step 3a - Actions (semantics) using CST Visitor", () => {
         it("Can convert a simple input to an AST", () => {
-            let inputText =
+            const inputText =
                 "SELECT column1, column2 FROM table2 WHERE column2 > 3"
-            let ast = toAstVisitor(inputText)
+            const ast = toAstVisitor(inputText)
 
             expect(ast).to.deep.equal({
                 type: "SELECT_STMT",
@@ -36,9 +36,9 @@ describe("Chevrotain Tutorial", () => {
 
     context("Step 3a - Actions (semantics) using embedded actions", () => {
         it("Can convert a simple input to an AST", () => {
-            let inputText =
+            const inputText =
                 "SELECT column1, column2 FROM table2 WHERE column2 > 3"
-            let ast = toAstEmbedded(inputText)
+            const ast = toAstEmbedded(inputText)
 
             expect(ast).to.deep.equal({
                 type: "SELECT_STMT",

--- a/examples/tutorial/step3_actions/step3a_actions_visitor.js
+++ b/examples/tutorial/step3_actions/step3a_actions_visitor.js
@@ -87,7 +87,7 @@ class SQLToAstVisitor extends BaseSQLVisitor {
 
     // these two visitor methods will return a string.
     atomicExpression(ctx) {
-        if (ctx.Integer[0]) {
+        if (ctx.Integer) {
             return ctx.Integer[0].image
         } else {
             return ctx.Identifier[0].image
@@ -95,7 +95,7 @@ class SQLToAstVisitor extends BaseSQLVisitor {
     }
 
     relationalOperator(ctx) {
-        if (ctx.GreaterThan[0]) {
+        if (ctx.GreaterThan) {
             return ctx.GreaterThan[0].image
         } else {
             return ctx.LessThan[0].image

--- a/examples/tutorial/step3_actions/step3a_actions_visitor.js
+++ b/examples/tutorial/step3_actions/step3a_actions_visitor.js
@@ -24,15 +24,15 @@ class SQLToAstVisitor extends BaseSQLVisitor {
 
     selectStatement(ctx) {
         // "this.visit" can be used to visit none-terminals and will invoke the correct visit method for the CstNode passed.
-        let select = this.visit(ctx.selectClause)
+        const select = this.visit(ctx.selectClause)
 
         //  "this.visit" can work on either a CstNode or an Array of CstNodes.
         //  If an array is passed (ctx.fromClause is an array) it is equivalent
         //  to passing the first element of that array
-        let from = this.visit(ctx.fromClause)
+        const from = this.visit(ctx.fromClause)
 
         // "whereClause" is optional, "this.visit" will ignore empty arrays (optional)
-        let where = this.visit(ctx.whereClause)
+        const where = this.visit(ctx.whereClause)
 
         return {
             type: "SELECT_STMT",
@@ -45,7 +45,7 @@ class SQLToAstVisitor extends BaseSQLVisitor {
     selectClause(ctx) {
         // Each Terminal or Non-Terminal in a grammar rule are collected into
         // an array with the same name(key) in the ctx object.
-        let columns = ctx.Identifier.map(identToken => identToken.image)
+        const columns = ctx.Identifier.map(identToken => identToken.image)
 
         return {
             type: "SELECT_CLAUSE",
@@ -54,7 +54,7 @@ class SQLToAstVisitor extends BaseSQLVisitor {
     }
 
     fromClause(ctx) {
-        let tableName = ctx.Identifier[0].image
+        const tableName = ctx.Identifier[0].image
 
         return {
             type: "FROM_CLAUSE",
@@ -63,7 +63,7 @@ class SQLToAstVisitor extends BaseSQLVisitor {
     }
 
     whereClause(ctx) {
-        let condition = this.visit(ctx.expression)
+        const condition = this.visit(ctx.expression)
 
         return {
             type: "WHERE_CLAUSE",
@@ -72,10 +72,10 @@ class SQLToAstVisitor extends BaseSQLVisitor {
     }
 
     expression(ctx) {
-        let lhs = this.visit(ctx.atomicExpression[0])
-        // The second [1] atomicExpression is the right hand side
-        let rhs = this.visit(ctx.atomicExpression[1])
-        let operator = this.visit(ctx.relationalOperator)
+        // Note the usage of the "rhs" and "lhs" labels defined in step 2 in the expression rule.
+        const lhs = this.visit(ctx.lhs[0])
+        const operator = this.visit(ctx.relationalOperator)
+        const rhs = this.visit(ctx.rhs[0])
 
         return {
             type: "EXPRESSION",
@@ -108,13 +108,13 @@ const toAstVisitorInstance = new SQLToAstVisitor()
 
 module.exports = {
     toAst: function(inputText) {
-        let lexResult = selectLexer.lex(inputText)
+        const lexResult = selectLexer.lex(inputText)
 
         // ".input" is a setter which will reset the parser's internal's state.
         parserInstance.input = lexResult.tokens
 
         // Automatic CST created when parsing
-        let cst = parserInstance.selectStatement()
+        const cst = parserInstance.selectStatement()
 
         if (parserInstance.errors.length > 0) {
             throw Error(
@@ -123,7 +123,7 @@ module.exports = {
             )
         }
 
-        let ast = toAstVisitorInstance.visit(cst)
+        const ast = toAstVisitorInstance.visit(cst)
 
         return ast
     }

--- a/examples/tutorial/step3_actions/step3b_actions_embedded.js
+++ b/examples/tutorial/step3_actions/step3b_actions_embedded.js
@@ -50,7 +50,7 @@ class SelectParserEmbedded extends Parser {
         })
 
         this.selectClause = $.RULE("selectClause", () => {
-            let columns = []
+            const columns = []
 
             $.CONSUME(Select)
             $.AT_LEAST_ONE_SEP({
@@ -137,13 +137,13 @@ const parserInstance = new SelectParserEmbedded([])
 
 module.exports = {
     toAst: function(inputText) {
-        let lexResult = selectLexer.lex(inputText)
+        const lexResult = selectLexer.lex(inputText)
 
         // ".input" is a setter which will reset the parser's internal's state.
         parserInstance.input = lexResult.tokens
 
         // No semantic actions so this won't return anything yet.
-        let ast = parserInstance.selectStatement()
+        const ast = parserInstance.selectStatement()
 
         if (parserInstance.errors.length > 0) {
             throw Error(

--- a/src/parse/cache.ts
+++ b/src/parse/cache.ts
@@ -66,18 +66,9 @@ export const CLASS_TO_CST_DICT_DEF_PER_RULE = new HashTable<
     HashTable<string[]>
 >()
 
-export function getCstDictDefPerRuleForClass(
-    className: string
-): HashTable<Function> {
-    return getFromNestedHashTable(className, CLASS_TO_CST_DICT_DEF_PER_RULE)
-}
-
 export let CLASS_TO_BASE_CST_VISITOR = new HashTable<Function>()
 export let CLASS_TO_BASE_CST_VISITOR_WITH_DEFAULTS = new HashTable<Function>()
 export let CLASS_TO_ALL_RULE_NAMES = new HashTable<string[]>()
-
-// TODO reflective test to verify this has not changed, for example (OPTION6 added)
-export const MAX_OCCURRENCE_INDEX = 5
 
 function getFromNestedHashTable(className: string, hashTable: HashTable<any>) {
     let result = hashTable.get(className)

--- a/src/parse/parser_public.ts
+++ b/src/parse/parser_public.ts
@@ -538,9 +538,6 @@ export class Parser {
                 clonedProductions.values(),
                 parserInstance.fullRuleNameToShort
             )
-            cache
-                .getCstDictDefPerRuleForClass(className)
-                .putAll(cstAnalysisResult.dictDef)
             cache.CLASS_TO_ALL_RULE_NAMES.put(
                 className,
                 cstAnalysisResult.allRuleNames
@@ -671,9 +668,6 @@ export class Parser {
         this.className = classNameFromInstance(this)
         this.firstAfterRepMap = cache.getFirstAfterRepForClass(this.className)
         this.classLAFuncs = cache.getLookaheadFuncsForClass(this.className)
-        this.cstDictDefForRule = cache.getCstDictDefPerRuleForClass(
-            this.className
-        )
 
         if (!cache.CLASS_TO_DEFINITION_ERRORS.containsKey(this.className)) {
             this.definitionErrors = []
@@ -2659,14 +2653,13 @@ export class Parser {
         nestedName: string,
         shortName: string | number
     ): void {
-        let initDef = this.cstDictDefForRule.get(shortName)
         this.CST_STACK.push({
             name: nestedName,
             fullName:
                 this.shortRuleNameToFull.get(
                     this.getLastExplicitRuleShortName()
                 ) + nestedName,
-            children: initDef()
+            children: {}
         })
     }
 
@@ -2675,10 +2668,9 @@ export class Parser {
         shortName: string | number
     ): void {
         this.LAST_EXPLICIT_RULE_STACK.push(this.RULE_STACK.length - 1)
-        let initDef = this.cstDictDefForRule.get(shortName)
         this.CST_STACK.push({
             name: fullRuleName,
-            children: initDef()
+            children: {}
         })
     }
 
@@ -3506,6 +3498,7 @@ export class Parser {
 
     private cstPostTerminal(tokType: TokenType, consumedToken: IToken): void {
         let currTokTypeName = tokType.tokenName
+        // TODO: would save the "current rootCST be faster than locating it for each terminal?
         let rootCst = this.CST_STACK[this.CST_STACK.length - 1]
         addTerminalToCst(rootCst, consumedToken, currTokTypeName)
     }

--- a/test/parse/cst_spec.ts
+++ b/test/parse/cst_spec.ts
@@ -57,6 +57,46 @@ context("CST", () => {
             .to.be.true
     })
 
+    it("Can output a CST with labels", () => {
+        class CstTerminalParser extends Parser {
+            constructor(input: IToken[] = []) {
+                super(input, ALL_TOKENS, {
+                    outputCst: true
+                })
+                ;(<any>Parser).performSelfAnalysis(this)
+            }
+
+            public testRule = this.RULE("testRule", () => {
+                this.CONSUME(A, { LABEL: "myLabel" })
+                this.CONSUME(B)
+                this.SUBRULE(this.bamba, { LABEL: "myOtherLabel" })
+            })
+
+            public bamba = this.RULE("bamba", () => {
+                this.CONSUME(C)
+            })
+        }
+
+        let input = [
+            createRegularToken(A),
+            createRegularToken(B),
+            createRegularToken(C)
+        ]
+        let parser = new CstTerminalParser(input)
+        let cst = parser.testRule()
+        expect(cst.name).to.equal("testRule")
+        expect(cst.children).to.have.keys("myLabel", "B", "myOtherLabel")
+        expect(tokenStructuredMatcher(cst.children.myLabel[0], A)).to.be.true
+        expect(tokenStructuredMatcher(cst.children.B[0], B)).to.be.true
+        expect(cst.children.myOtherLabel[0].name).to.equal("bamba")
+        expect(
+            tokenStructuredMatcher(
+                cst.children.myOtherLabel[0].children.C[0],
+                C
+            )
+        ).to.be.true
+    })
+
     it("Can output a CST for a Terminal - alternations", () => {
         class CstTerminalAlternationParser extends Parser {
             constructor(input: IToken[] = []) {

--- a/test/parse/cst_spec.ts
+++ b/test/parse/cst_spec.ts
@@ -6,29 +6,373 @@ import { createRegularToken } from "../utils/matchers"
 import { TokenType } from "../../src/scan/lexer_public"
 import { map } from "../../src/utils/utils"
 
-function defineCstSpecs(
-    contextName,
-    createToken,
-    createTokenInstance,
-    tokenMatcher
-) {
-    function createTokenVector(tokTypes: TokenType[]): any[] {
-        return map(tokTypes, curTokType => {
-            return createTokenInstance(curTokType)
+function createTokenVector(tokTypes: TokenType[]): any[] {
+    return map(tokTypes, curTokType => {
+        return createRegularToken(curTokType)
+    })
+}
+
+context("CST", () => {
+    let A = createToken({ name: "A" })
+    let B = createToken({ name: "B" })
+    let C = createToken({ name: "C" })
+    let D = createToken({ name: "D" })
+    let E = createToken({ name: "E" })
+
+    const ALL_TOKENS = [A, B, C, D, E]
+
+    it("Can output a CST for a flat structure", () => {
+        class CstTerminalParser extends Parser {
+            constructor(input: IToken[] = []) {
+                super(input, ALL_TOKENS, {
+                    outputCst: true
+                })
+                ;(<any>Parser).performSelfAnalysis(this)
+            }
+
+            public testRule = this.RULE("testRule", () => {
+                this.CONSUME(A)
+                this.CONSUME(B)
+                this.SUBRULE(this.bamba)
+            })
+
+            public bamba = this.RULE("bamba", () => {
+                this.CONSUME(C)
+            })
+        }
+
+        let input = [
+            createRegularToken(A),
+            createRegularToken(B),
+            createRegularToken(C)
+        ]
+        let parser = new CstTerminalParser(input)
+        let cst = parser.testRule()
+        expect(cst.name).to.equal("testRule")
+        expect(cst.children).to.have.keys("A", "B", "bamba")
+        expect(tokenStructuredMatcher(cst.children.A[0], A)).to.be.true
+        expect(tokenStructuredMatcher(cst.children.B[0], B)).to.be.true
+        expect(cst.children.bamba[0].name).to.equal("bamba")
+        expect(tokenStructuredMatcher(cst.children.bamba[0].children.C[0], C))
+            .to.be.true
+    })
+
+    it("Can output a CST for a Terminal - alternations", () => {
+        class CstTerminalAlternationParser extends Parser {
+            constructor(input: IToken[] = []) {
+                super(input, ALL_TOKENS, {
+                    outputCst: true
+                })
+                ;(<any>Parser).performSelfAnalysis(this)
+            }
+
+            public testRule = this.RULE("testRule", () => {
+                this.OR([
+                    {
+                        ALT: () => {
+                            this.CONSUME(A)
+                        }
+                    },
+                    {
+                        ALT: () => {
+                            this.CONSUME(B)
+                            this.SUBRULE(this.bamba)
+                        }
+                    }
+                ])
+            })
+
+            public bamba = this.RULE("bamba", () => {
+                this.CONSUME(C)
+            })
+        }
+
+        let input = [createRegularToken(A)]
+        let parser = new CstTerminalAlternationParser(input)
+        let cst = parser.testRule()
+        expect(cst.name).to.equal("testRule")
+        expect(cst.children).to.have.keys("A")
+        expect(tokenStructuredMatcher(cst.children.A[0], A)).to.be.true
+        expect(cst.children.bamba).to.be.undefined
+    })
+
+    it("Can output a CST for a Terminal - alternations - single", () => {
+        class CstTerminalAlternationSingleAltParser extends Parser {
+            constructor(input: IToken[] = []) {
+                super(input, ALL_TOKENS, {
+                    outputCst: true
+                })
+                ;(<any>Parser).performSelfAnalysis(this)
+            }
+
+            public testRule = this.RULE("testRule", () => {
+                this.OR([
+                    {
+                        ALT: () => {
+                            this.CONSUME(A)
+                            this.CONSUME(B)
+                        }
+                    }
+                ])
+            })
+        }
+
+        let input = [createRegularToken(A), createRegularToken(B)]
+        let parser = new CstTerminalAlternationSingleAltParser(input)
+        let cst = parser.testRule()
+        expect(cst.name).to.equal("testRule")
+        expect(cst.children).to.have.keys("A", "B")
+        expect(tokenStructuredMatcher(cst.children.A[0], A)).to.be.true
+        expect(tokenStructuredMatcher(cst.children.B[0], B)).to.be.true
+    })
+
+    it("Can output a CST for a Terminal with multiple occurrences", () => {
+        class CstMultiTerminalParser extends Parser {
+            constructor(input: IToken[] = []) {
+                super(input, ALL_TOKENS, {
+                    outputCst: true
+                })
+                ;(<any>Parser).performSelfAnalysis(this)
+            }
+
+            public testRule = this.RULE("testRule", () => {
+                this.CONSUME(A)
+                this.CONSUME(B)
+                this.CONSUME2(A)
+            })
+        }
+
+        let input = [
+            createRegularToken(A),
+            createRegularToken(B),
+            createRegularToken(A)
+        ]
+        let parser = new CstMultiTerminalParser(input)
+        let cst = parser.testRule()
+        expect(cst.name).to.equal("testRule")
+        expect(cst.children).to.have.keys("A", "B")
+        expect(cst.children.A).to.have.length(2)
+        expect(tokenStructuredMatcher(cst.children.A[0], A)).to.be.true
+        expect(tokenStructuredMatcher(cst.children.A[1], A)).to.be.true
+        expect(tokenStructuredMatcher(cst.children.B[0], B)).to.be.true
+    })
+
+    it("Can output a CST for a Terminal with multiple occurrences - iteration", () => {
+        class CstMultiTerminalWithManyParser extends Parser {
+            constructor(input: IToken[] = []) {
+                super(input, ALL_TOKENS, {
+                    outputCst: true
+                })
+                ;(<any>Parser).performSelfAnalysis(this)
+            }
+
+            public testRule = this.RULE("testRule", () => {
+                this.MANY(() => {
+                    this.CONSUME(A)
+                    this.SUBRULE(this.bamba)
+                })
+                this.CONSUME(B)
+            })
+
+            public bamba = this.RULE("bamba", () => {
+                this.CONSUME(C)
+            })
+        }
+
+        let input = [
+            createRegularToken(A),
+            createRegularToken(C),
+            createRegularToken(A),
+            createRegularToken(C),
+            createRegularToken(A),
+            createRegularToken(C),
+            createRegularToken(B)
+        ]
+        let parser = new CstMultiTerminalWithManyParser(input)
+        let cst = parser.testRule()
+        expect(cst.name).to.equal("testRule")
+        expect(cst.children).to.have.keys("A", "B", "bamba")
+        expect(cst.children.A).to.have.length(3)
+        expect(tokenStructuredMatcher(cst.children.A[0], A)).to.be.true
+        expect(tokenStructuredMatcher(cst.children.A[1], A)).to.be.true
+        expect(tokenStructuredMatcher(cst.children.A[2], A)).to.be.true
+        expect(tokenStructuredMatcher(cst.children.B[0], B)).to.be.true
+        expect(cst.children.bamba).to.have.length(3)
+        expect(tokenStructuredMatcher(cst.children.bamba[0].children.C[0], C))
+            .to.be.true
+        expect(tokenStructuredMatcher(cst.children.bamba[1].children.C[0], C))
+            .to.be.true
+        expect(tokenStructuredMatcher(cst.children.bamba[2].children.C[0], C))
+            .to.be.true
+    })
+
+    context("Can output a CST for an optional terminal", () => {
+        class CstOptionalTerminalParser extends Parser {
+            constructor(input: IToken[] = []) {
+                super(input, ALL_TOKENS, {
+                    outputCst: true
+                })
+                Parser.performSelfAnalysis(this)
+            }
+
+            public ruleWithOptional = this.RULE("ruleWithOptional", () => {
+                this.OPTION(() => {
+                    this.CONSUME(A)
+                    this.SUBRULE(this.bamba)
+                })
+                this.CONSUME(B)
+            })
+
+            public bamba = this.RULE("bamba", () => {
+                this.CONSUME(C)
+            })
+        }
+
+        it("path taken", () => {
+            let input = [
+                createRegularToken(A),
+                createRegularToken(C),
+                createRegularToken(B)
+            ]
+            let parser = new CstOptionalTerminalParser(input)
+            let cst = parser.ruleWithOptional()
+            expect(cst.name).to.equal("ruleWithOptional")
+            expect(cst.children).to.have.keys("A", "B", "bamba")
+            expect(tokenStructuredMatcher(cst.children.A[0], A)).to.be.true
+            expect(cst.children.bamba[0].name).to.equal("bamba")
+            expect(
+                tokenStructuredMatcher(cst.children.bamba[0].children.C[0], C)
+            ).to.be.true
+            expect(tokenStructuredMatcher(cst.children.B[0], B)).to.be.true
         })
-    }
 
-    context("CST " + contextName, () => {
-        let A = createToken({ name: "A" })
-        let B = createToken({ name: "B" })
-        let C = createToken({ name: "C" })
-        let D = createToken({ name: "D" })
-        let E = createToken({ name: "E" })
+        it("path NOT taken", () => {
+            let input = [createRegularToken(B)]
+            let parser = new CstOptionalTerminalParser(input)
+            let cst = parser.ruleWithOptional()
+            expect(cst.name).to.equal("ruleWithOptional")
+            expect(cst.children).to.have.keys("B")
+            expect(cst.children.A).to.be.undefined
+            expect(cst.children.bamba).to.be.undefined
+            expect(tokenStructuredMatcher(cst.children.B[0], B)).to.be.true
+        })
+    })
 
-        const ALL_TOKENS = [A, B, C, D, E]
+    it("Can output a CST for a Terminal with multiple occurrences - iteration mandatory", () => {
+        class CstMultiTerminalWithAtLeastOneParser extends Parser {
+            constructor(input: IToken[] = []) {
+                super(input, ALL_TOKENS, {
+                    outputCst: true
+                })
+                ;(<any>Parser).performSelfAnalysis(this)
+            }
 
-        it("Can output a CST for a flat structure", () => {
-            class CstTerminalParser extends Parser {
+            public testRule = this.RULE("testRule", () => {
+                this.AT_LEAST_ONE(() => {
+                    this.CONSUME(A)
+                })
+                this.CONSUME(B)
+            })
+        }
+
+        let input = [
+            createRegularToken(A),
+            createRegularToken(A),
+            createRegularToken(A),
+            createRegularToken(B)
+        ]
+        let parser = new CstMultiTerminalWithAtLeastOneParser(input)
+        let cst = parser.testRule()
+        expect(cst.name).to.equal("testRule")
+        expect(cst.children).to.have.keys("A", "B")
+        expect(cst.children.A).to.have.length(3)
+        expect(tokenStructuredMatcher(cst.children.A[0], A)).to.be.true
+        expect(tokenStructuredMatcher(cst.children.A[1], A)).to.be.true
+        expect(tokenStructuredMatcher(cst.children.A[2], A)).to.be.true
+        expect(tokenStructuredMatcher(cst.children.B[0], B)).to.be.true
+    })
+
+    it("Can output a CST for a Terminal with multiple occurrences - iteration SEP", () => {
+        class CstMultiTerminalWithManySepParser extends Parser {
+            constructor(input: IToken[] = []) {
+                super(input, ALL_TOKENS, {
+                    outputCst: true
+                })
+                ;(<any>Parser).performSelfAnalysis(this)
+            }
+
+            public testRule = this.RULE("testRule", () => {
+                this.MANY_SEP({
+                    SEP: C,
+                    DEF: () => {
+                        this.CONSUME(A)
+                    }
+                })
+                this.CONSUME(B)
+            })
+        }
+
+        let input = [
+            createRegularToken(A),
+            createRegularToken(C),
+            createRegularToken(A),
+            createRegularToken(B)
+        ]
+        let parser = new CstMultiTerminalWithManySepParser(input)
+        let cst = parser.testRule()
+        expect(cst.name).to.equal("testRule")
+        expect(cst.children).to.have.keys("A", "B", "C")
+        expect(cst.children.A).to.have.length(2)
+        expect(tokenStructuredMatcher(cst.children.A[0], A)).to.be.true
+        expect(tokenStructuredMatcher(cst.children.A[1], A)).to.be.true
+        expect(tokenStructuredMatcher(cst.children.B[0], B)).to.be.true
+
+        expect(cst.children.C).to.have.length(1)
+        expect(tokenStructuredMatcher(cst.children.C[0], C)).to.be.true
+    })
+
+    it("Can output a CST for a Terminal with multiple occurrences - iteration SEP mandatory", () => {
+        class CstMultiTerminalWithAtLeastOneSepParser extends Parser {
+            constructor(input: IToken[] = []) {
+                super(input, ALL_TOKENS, {
+                    outputCst: true
+                })
+                ;(<any>Parser).performSelfAnalysis(this)
+            }
+
+            public testRule = this.RULE("testRule", () => {
+                this.AT_LEAST_ONE_SEP({
+                    SEP: C,
+                    DEF: () => {
+                        this.CONSUME(A)
+                    }
+                })
+                this.CONSUME(B)
+            })
+        }
+
+        let input = [
+            createRegularToken(A),
+            createRegularToken(C),
+            createRegularToken(A),
+            createRegularToken(B)
+        ]
+        let parser = new CstMultiTerminalWithAtLeastOneSepParser(input)
+        let cst = parser.testRule()
+        expect(cst.name).to.equal("testRule")
+        expect(cst.children).to.have.keys("A", "B", "C")
+        expect(cst.children.A).to.have.length(2)
+        expect(tokenStructuredMatcher(cst.children.A[0], A)).to.be.true
+        expect(tokenStructuredMatcher(cst.children.A[1], A)).to.be.true
+        expect(tokenStructuredMatcher(cst.children.B[0], B)).to.be.true
+
+        expect(cst.children.C).to.have.length(1)
+        expect(tokenStructuredMatcher(cst.children.C[0], C)).to.be.true
+    })
+
+    context("nested rules", () => {
+        context("Can output cst when using OPTION", () => {
+            class CstOptionalNestedTerminalParser extends Parser {
                 constructor(input: IToken[] = []) {
                     super(input, ALL_TOKENS, {
                         outputCst: true
@@ -36,10 +380,15 @@ function defineCstSpecs(
                     ;(<any>Parser).performSelfAnalysis(this)
                 }
 
-                public testRule = this.RULE("testRule", () => {
-                    this.CONSUME(A)
+                public ruleWithOptional = this.RULE("ruleWithOptional", () => {
+                    this.OPTION({
+                        NAME: "$nestedOption",
+                        DEF: () => {
+                            this.CONSUME(A)
+                            this.SUBRULE(this.bamba)
+                        }
+                    })
                     this.CONSUME(B)
-                    this.SUBRULE(this.bamba)
                 })
 
                 public bamba = this.RULE("bamba", () => {
@@ -47,24 +396,48 @@ function defineCstSpecs(
                 })
             }
 
-            let input = [
-                createTokenInstance(A),
-                createTokenInstance(B),
-                createTokenInstance(C)
-            ]
-            let parser = new CstTerminalParser(input)
-            let cst = parser.testRule()
-            expect(cst.name).to.equal("testRule")
-            expect(cst.children).to.have.keys("A", "B", "bamba")
-            expect(tokenMatcher(cst.children.A[0], A)).to.be.true
-            expect(tokenMatcher(cst.children.B[0], B)).to.be.true
-            expect(cst.children.bamba[0].name).to.equal("bamba")
-            expect(tokenMatcher(cst.children.bamba[0].children.C[0], C)).to.be
-                .true
+            it("path taken", () => {
+                let input = [
+                    createRegularToken(A),
+                    createRegularToken(C),
+                    createRegularToken(B)
+                ]
+                let parser = new CstOptionalNestedTerminalParser(input)
+                let cst = parser.ruleWithOptional()
+                expect(cst.name).to.equal("ruleWithOptional")
+                expect(cst.children).to.have.keys("$nestedOption", "B")
+                let $nestedOptionCst = cst.children.$nestedOption[0]
+                expect(
+                    tokenStructuredMatcher($nestedOptionCst.children.A[0], A)
+                ).to.be.true
+                expect($nestedOptionCst.children.bamba[0].name).to.equal(
+                    "bamba"
+                )
+                expect(
+                    tokenStructuredMatcher(
+                        $nestedOptionCst.children.bamba[0].children.C[0],
+                        C
+                    )
+                ).to.be.true
+                expect(tokenStructuredMatcher(cst.children.B[0], B)).to.be.true
+            })
+
+            it("path NOT taken", () => {
+                let input = [createRegularToken(B)]
+                let parser = new CstOptionalNestedTerminalParser(input)
+                let cst = parser.ruleWithOptional()
+                expect(cst.name).to.equal("ruleWithOptional")
+                // nested rule is equivalent to an optionally empty rule call
+                expect(cst.children).to.have.keys("B", "$nestedOption")
+                let $nestedOptionCst = cst.children.$nestedOption[0]
+                expect($nestedOptionCst.children.A).to.be.undefined
+                expect($nestedOptionCst.children.bamba).to.be.undefined
+                expect(tokenStructuredMatcher(cst.children.B[0], B)).to.be.true
+            })
         })
 
-        it("Can output a CST for a Terminal - alternations", () => {
-            class CstTerminalAlternationParser extends Parser {
+        it("Can output a CST when using OR with nested named Alternatives", () => {
+            class CstAlternationNestedAltParser extends Parser {
                 constructor(input: IToken[] = []) {
                     super(input, ALL_TOKENS, {
                         outputCst: true
@@ -75,6 +448,7 @@ function defineCstSpecs(
                 public testRule = this.RULE("testRule", () => {
                     this.OR([
                         {
+                            NAME: "$first_alternative",
                             ALT: () => {
                                 this.CONSUME(A)
                             }
@@ -93,178 +467,20 @@ function defineCstSpecs(
                 })
             }
 
-            let input = [createTokenInstance(A)]
-            let parser = new CstTerminalAlternationParser(input)
+            let input = [createRegularToken(A)]
+            let parser = new CstAlternationNestedAltParser(input)
             let cst = parser.testRule()
             expect(cst.name).to.equal("testRule")
-            expect(cst.children).to.have.keys("A", "B", "bamba")
-            expect(tokenMatcher(cst.children.A[0], A)).to.be.true
-            expect(cst.children.bamba[0]).to.be.undefined
-        })
-
-        it("Can output a CST for a Terminal - alternations - single", () => {
-            class CstTerminalAlternationSingleAltParser extends Parser {
-                constructor(input: IToken[] = []) {
-                    super(input, ALL_TOKENS, {
-                        outputCst: true
-                    })
-                    ;(<any>Parser).performSelfAnalysis(this)
-                }
-
-                public testRule = this.RULE("testRule", () => {
-                    this.OR([
-                        {
-                            ALT: () => {
-                                this.CONSUME(A)
-                                this.CONSUME(B)
-                            }
-                        }
-                    ])
-                })
-            }
-
-            let input = [createTokenInstance(A), createTokenInstance(B)]
-            let parser = new CstTerminalAlternationSingleAltParser(input)
-            let cst = parser.testRule()
-            expect(cst.name).to.equal("testRule")
-            expect(cst.children).to.have.keys("A", "B")
-            expect(tokenMatcher(cst.children.A[0], A)).to.be.true
-            expect(tokenMatcher(cst.children.B[0], B)).to.be.true
-        })
-
-        it("Can output a CST for a Terminal with multiple occurrences", () => {
-            class CstMultiTerminalParser extends Parser {
-                constructor(input: IToken[] = []) {
-                    super(input, ALL_TOKENS, {
-                        outputCst: true
-                    })
-                    ;(<any>Parser).performSelfAnalysis(this)
-                }
-
-                public testRule = this.RULE("testRule", () => {
-                    this.CONSUME(A)
-                    this.CONSUME(B)
-                    this.CONSUME2(A)
-                })
-            }
-
-            let input = [
-                createTokenInstance(A),
-                createTokenInstance(B),
-                createTokenInstance(A)
-            ]
-            let parser = new CstMultiTerminalParser(input)
-            let cst = parser.testRule()
-            expect(cst.name).to.equal("testRule")
-            expect(cst.children).to.have.keys("A", "B")
-            expect(cst.children.A).to.have.length(2)
-            expect(tokenMatcher(cst.children.A[0], A)).to.be.true
-            expect(tokenMatcher(cst.children.A[1], A)).to.be.true
-            expect(tokenMatcher(cst.children.B[0], B)).to.be.true
-        })
-
-        it("Can output a CST for a Terminal with multiple occurrences - iteration", () => {
-            class CstMultiTerminalWithManyParser extends Parser {
-                constructor(input: IToken[] = []) {
-                    super(input, ALL_TOKENS, {
-                        outputCst: true
-                    })
-                    ;(<any>Parser).performSelfAnalysis(this)
-                }
-
-                public testRule = this.RULE("testRule", () => {
-                    this.MANY(() => {
-                        this.CONSUME(A)
-                        this.SUBRULE(this.bamba)
-                    })
-                    this.CONSUME(B)
-                })
-
-                public bamba = this.RULE("bamba", () => {
-                    this.CONSUME(C)
-                })
-            }
-
-            let input = [
-                createTokenInstance(A),
-                createTokenInstance(C),
-                createTokenInstance(A),
-                createTokenInstance(C),
-                createTokenInstance(A),
-                createTokenInstance(C),
-                createTokenInstance(B)
-            ]
-            let parser = new CstMultiTerminalWithManyParser(input)
-            let cst = parser.testRule()
-            expect(cst.name).to.equal("testRule")
-            expect(cst.children).to.have.keys("A", "B", "bamba")
-            expect(cst.children.A).to.have.length(3)
-            expect(tokenMatcher(cst.children.A[0], A)).to.be.true
-            expect(tokenMatcher(cst.children.A[1], A)).to.be.true
-            expect(tokenMatcher(cst.children.A[2], A)).to.be.true
-            expect(tokenMatcher(cst.children.B[0], B)).to.be.true
-            expect(cst.children.bamba).to.have.length(3)
-            expect(tokenMatcher(cst.children.bamba[0].children.C[0], C)).to.be
+            expect(cst.children).to.have.keys("$first_alternative")
+            let firstAltCst = cst.children.$first_alternative[0]
+            expect(tokenStructuredMatcher(firstAltCst.children.A[0], A)).to.be
                 .true
-            expect(tokenMatcher(cst.children.bamba[1].children.C[0], C)).to.be
-                .true
-            expect(tokenMatcher(cst.children.bamba[2].children.C[0], C)).to.be
-                .true
+            expect(cst.children.bamba).to.be.undefined
+            expect(cst.children.B).to.be.undefined
         })
 
-        context("Can output a CST for an optional terminal", () => {
-            class CstOptionalTerminalParser extends Parser {
-                constructor(input: IToken[] = []) {
-                    super(input, ALL_TOKENS, {
-                        outputCst: true
-                    })
-                    ;(<any>Parser).performSelfAnalysis(this)
-                }
-
-                public ruleWithOptional = this.RULE("ruleWithOptional", () => {
-                    this.OPTION(() => {
-                        this.CONSUME(A)
-                        this.SUBRULE(this.bamba)
-                    })
-                    this.CONSUME(B)
-                })
-
-                public bamba = this.RULE("bamba", () => {
-                    this.CONSUME(C)
-                })
-            }
-
-            it("path taken", () => {
-                let input = [
-                    createTokenInstance(A),
-                    createTokenInstance(C),
-                    createTokenInstance(B)
-                ]
-                let parser = new CstOptionalTerminalParser(input)
-                let cst = parser.ruleWithOptional()
-                expect(cst.name).to.equal("ruleWithOptional")
-                expect(cst.children).to.have.keys("A", "B", "bamba")
-                expect(tokenMatcher(cst.children.A[0], A)).to.be.true
-                expect(cst.children.bamba[0].name).to.equal("bamba")
-                expect(tokenMatcher(cst.children.bamba[0].children.C[0], C)).to
-                    .be.true
-                expect(tokenMatcher(cst.children.B[0], B)).to.be.true
-            })
-
-            it("path NOT taken", () => {
-                let input = [createTokenInstance(B)]
-                let parser = new CstOptionalTerminalParser(input)
-                let cst = parser.ruleWithOptional()
-                expect(cst.name).to.equal("ruleWithOptional")
-                expect(cst.children).to.have.keys("A", "B", "bamba")
-                expect(cst.children.A[0]).to.be.undefined
-                expect(cst.children.bamba[0]).to.be.undefined
-                expect(tokenMatcher(cst.children.B[0], B)).to.be.true
-            })
-        })
-
-        it("Can output a CST for a Terminal with multiple occurrences - iteration mandatory", () => {
-            class CstMultiTerminalWithAtLeastOneParser extends Parser {
+        it("Can output a CST when using OR", () => {
+            class CstAlternationNestedParser extends Parser {
                 constructor(input: IToken[] = []) {
                     super(input, ALL_TOKENS, {
                         outputCst: true
@@ -273,188 +489,10 @@ function defineCstSpecs(
                 }
 
                 public testRule = this.RULE("testRule", () => {
-                    this.AT_LEAST_ONE(() => {
-                        this.CONSUME(A)
-                    })
-                    this.CONSUME(B)
-                })
-            }
-
-            let input = [
-                createTokenInstance(A),
-                createTokenInstance(A),
-                createTokenInstance(A),
-                createTokenInstance(B)
-            ]
-            let parser = new CstMultiTerminalWithAtLeastOneParser(input)
-            let cst = parser.testRule()
-            expect(cst.name).to.equal("testRule")
-            expect(cst.children).to.have.keys("A", "B")
-            expect(cst.children.A).to.have.length(3)
-            expect(tokenMatcher(cst.children.A[0], A)).to.be.true
-            expect(tokenMatcher(cst.children.A[1], A)).to.be.true
-            expect(tokenMatcher(cst.children.A[2], A)).to.be.true
-            expect(tokenMatcher(cst.children.B[0], B)).to.be.true
-        })
-
-        it("Can output a CST for a Terminal with multiple occurrences - iteration SEP", () => {
-            class CstMultiTerminalWithManySepParser extends Parser {
-                constructor(input: IToken[] = []) {
-                    super(input, ALL_TOKENS, {
-                        outputCst: true
-                    })
-                    ;(<any>Parser).performSelfAnalysis(this)
-                }
-
-                public testRule = this.RULE("testRule", () => {
-                    this.MANY_SEP({
-                        SEP: C,
-                        DEF: () => {
-                            this.CONSUME(A)
-                        }
-                    })
-                    this.CONSUME(B)
-                })
-            }
-
-            let input = [
-                createTokenInstance(A),
-                createTokenInstance(C),
-                createTokenInstance(A),
-                createTokenInstance(B)
-            ]
-            let parser = new CstMultiTerminalWithManySepParser(input)
-            let cst = parser.testRule()
-            expect(cst.name).to.equal("testRule")
-            expect(cst.children).to.have.keys("A", "B", "C")
-            expect(cst.children.A).to.have.length(2)
-            expect(tokenMatcher(cst.children.A[0], A)).to.be.true
-            expect(tokenMatcher(cst.children.A[1], A)).to.be.true
-            expect(tokenMatcher(cst.children.B[0], B)).to.be.true
-
-            expect(cst.children.C).to.have.length(1)
-            expect(tokenMatcher(cst.children.C[0], C)).to.be.true
-        })
-
-        it("Can output a CST for a Terminal with multiple occurrences - iteration SEP mandatory", () => {
-            class CstMultiTerminalWithAtLeastOneSepParser extends Parser {
-                constructor(input: IToken[] = []) {
-                    super(input, ALL_TOKENS, {
-                        outputCst: true
-                    })
-                    ;(<any>Parser).performSelfAnalysis(this)
-                }
-
-                public testRule = this.RULE("testRule", () => {
-                    this.AT_LEAST_ONE_SEP({
-                        SEP: C,
-                        DEF: () => {
-                            this.CONSUME(A)
-                        }
-                    })
-                    this.CONSUME(B)
-                })
-            }
-
-            let input = [
-                createTokenInstance(A),
-                createTokenInstance(C),
-                createTokenInstance(A),
-                createTokenInstance(B)
-            ]
-            let parser = new CstMultiTerminalWithAtLeastOneSepParser(input)
-            let cst = parser.testRule()
-            expect(cst.name).to.equal("testRule")
-            expect(cst.children).to.have.keys("A", "B", "C")
-            expect(cst.children.A).to.have.length(2)
-            expect(tokenMatcher(cst.children.A[0], A)).to.be.true
-            expect(tokenMatcher(cst.children.A[1], A)).to.be.true
-            expect(tokenMatcher(cst.children.B[0], B)).to.be.true
-
-            expect(cst.children.C).to.have.length(1)
-            expect(tokenMatcher(cst.children.C[0], C)).to.be.true
-        })
-
-        context("nested rules", () => {
-            context("Can output cst when using OPTION", () => {
-                class CstOptionalNestedTerminalParser extends Parser {
-                    constructor(input: IToken[] = []) {
-                        super(input, ALL_TOKENS, {
-                            outputCst: true
-                        })
-                        ;(<any>Parser).performSelfAnalysis(this)
-                    }
-
-                    public ruleWithOptional = this.RULE(
-                        "ruleWithOptional",
-                        () => {
-                            this.OPTION({
-                                NAME: "$nestedOption",
-                                DEF: () => {
-                                    this.CONSUME(A)
-                                    this.SUBRULE(this.bamba)
-                                }
-                            })
-                            this.CONSUME(B)
-                        }
-                    )
-
-                    public bamba = this.RULE("bamba", () => {
-                        this.CONSUME(C)
-                    })
-                }
-
-                it("path taken", () => {
-                    let input = [
-                        createTokenInstance(A),
-                        createTokenInstance(C),
-                        createTokenInstance(B)
-                    ]
-                    let parser = new CstOptionalNestedTerminalParser(input)
-                    let cst = parser.ruleWithOptional()
-                    expect(cst.name).to.equal("ruleWithOptional")
-                    expect(cst.children).to.have.keys("$nestedOption", "B")
-                    let $nestedOptionCst = cst.children.$nestedOption[0]
-                    expect(tokenMatcher($nestedOptionCst.children.A[0], A)).to
-                        .be.true
-                    expect($nestedOptionCst.children.bamba[0].name).to.equal(
-                        "bamba"
-                    )
-                    expect(
-                        tokenMatcher(
-                            $nestedOptionCst.children.bamba[0].children.C[0],
-                            C
-                        )
-                    ).to.be.true
-                    expect(tokenMatcher(cst.children.B[0], B)).to.be.true
-                })
-
-                it("path NOT taken", () => {
-                    let input = [createTokenInstance(B)]
-                    let parser = new CstOptionalNestedTerminalParser(input)
-                    let cst = parser.ruleWithOptional()
-                    expect(cst.name).to.equal("ruleWithOptional")
-                    expect(cst.children).to.have.keys("$nestedOption", "B")
-                    let $nestedOptionCst = cst.children.$nestedOption[0]
-                    expect($nestedOptionCst.children.A[0]).to.be.undefined
-                    expect($nestedOptionCst.children.bamba[0]).to.be.undefined
-                    expect(tokenMatcher(cst.children.B[0], B)).to.be.true
-                })
-            })
-
-            it("Can output a CST when using OR with nested named Alternatives", () => {
-                class CstAlternationNestedAltParser extends Parser {
-                    constructor(input: IToken[] = []) {
-                        super(input, ALL_TOKENS, {
-                            outputCst: true
-                        })
-                        ;(<any>Parser).performSelfAnalysis(this)
-                    }
-
-                    public testRule = this.RULE("testRule", () => {
-                        this.OR([
+                    this.OR({
+                        NAME: "$nestedOr",
+                        DEF: [
                             {
-                                NAME: "$first_alternative",
                                 ALT: () => {
                                     this.CONSUME(A)
                                 }
@@ -465,471 +503,424 @@ function defineCstSpecs(
                                     this.SUBRULE(this.bamba)
                                 }
                             }
-                        ])
+                        ]
                     })
+                })
 
-                    public bamba = this.RULE("bamba", () => {
-                        this.CONSUME(C)
+                public bamba = this.RULE("bamba", () => {
+                    this.CONSUME(C)
+                })
+            }
+
+            let input = [createRegularToken(A)]
+            let parser = new CstAlternationNestedParser(input)
+            let cst = parser.testRule()
+            expect(cst.name).to.equal("testRule")
+            expect(cst.children).to.have.keys("$nestedOr")
+            let orCst = cst.children.$nestedOr[0]
+            expect(orCst.children).to.have.keys("A")
+            expect(tokenStructuredMatcher(orCst.children.A[0], A)).to.be.true
+            expect(orCst.children.bamba).to.be.undefined
+            expect(orCst.children.B).to.be.undefined
+        })
+
+        it("Can output a CST when using OR - single Alt", () => {
+            class CstAlternationNestedAltSingleParser extends Parser {
+                constructor(input: IToken[] = []) {
+                    super(input, ALL_TOKENS, {
+                        outputCst: true
                     })
+                    ;(<any>Parser).performSelfAnalysis(this)
                 }
 
-                let input = [createTokenInstance(A)]
-                let parser = new CstAlternationNestedAltParser(input)
-                let cst = parser.testRule()
-                expect(cst.name).to.equal("testRule")
-                expect(cst.children).to.have.keys(
-                    "$first_alternative",
-                    "B",
-                    "bamba"
-                )
-                let firstAltCst = cst.children.$first_alternative[0]
-                expect(tokenMatcher(firstAltCst.children.A[0], A)).to.be.true
-                expect(cst.children.bamba[0]).to.be.undefined
-                expect(cst.children.B[0]).to.be.undefined
-            })
-
-            it("Can output a CST when using OR", () => {
-                class CstAlternationNestedParser extends Parser {
-                    constructor(input: IToken[] = []) {
-                        super(input, ALL_TOKENS, {
-                            outputCst: true
-                        })
-                        ;(<any>Parser).performSelfAnalysis(this)
-                    }
-
-                    public testRule = this.RULE("testRule", () => {
-                        this.OR({
-                            NAME: "$nestedOr",
-                            DEF: [
-                                {
-                                    ALT: () => {
-                                        this.CONSUME(A)
-                                    }
-                                },
-                                {
-                                    ALT: () => {
-                                        this.CONSUME(B)
-                                        this.SUBRULE(this.bamba)
-                                    }
-                                }
-                            ]
-                        })
-                    })
-
-                    public bamba = this.RULE("bamba", () => {
-                        this.CONSUME(C)
-                    })
-                }
-
-                let input = [createTokenInstance(A)]
-                let parser = new CstAlternationNestedParser(input)
-                let cst = parser.testRule()
-                expect(cst.name).to.equal("testRule")
-                expect(cst.children).to.have.keys("$nestedOr")
-                let orCst = cst.children.$nestedOr[0]
-                expect(orCst.children).to.have.keys("A", "B", "bamba")
-                expect(tokenMatcher(orCst.children.A[0], A)).to.be.true
-                expect(orCst.children.bamba[0]).to.be.undefined
-                expect(orCst.children.B[0]).to.be.undefined
-            })
-
-            it("Can output a CST when using OR - single Alt", () => {
-                class CstAlternationNestedAltSingleParser extends Parser {
-                    constructor(input: IToken[] = []) {
-                        super(input, ALL_TOKENS, {
-                            outputCst: true
-                        })
-                        ;(<any>Parser).performSelfAnalysis(this)
-                    }
-
-                    public testRule = this.RULE("testRule", () => {
-                        this.OR([
-                            {
-                                NAME: "$nestedAlt",
-                                ALT: () => {
-                                    this.CONSUME(B)
-                                    this.SUBRULE(this.bamba)
-                                }
-                            }
-                        ])
-                    })
-
-                    public bamba = this.RULE("bamba", () => {
-                        this.CONSUME(C)
-                    })
-                }
-
-                let input = [createTokenInstance(B), createTokenInstance(C)]
-                let parser = new CstAlternationNestedAltSingleParser(input)
-                let cst = parser.testRule()
-                expect(cst.name).to.equal("testRule")
-                expect(cst.children).to.have.keys("$nestedAlt")
-                let altCst = cst.children.$nestedAlt[0]
-                expect(altCst.children).to.have.keys("B", "bamba")
-                expect(tokenMatcher(altCst.children.B[0], B)).to.be.true
-                expect(altCst.children.bamba[0].children).to.have.keys("C")
-            })
-
-            it("Can output a CST using Repetitions", () => {
-                class CstMultiTerminalWithManyNestedParser extends Parser {
-                    constructor(input: IToken[] = []) {
-                        super(input, ALL_TOKENS, {
-                            outputCst: true
-                        })
-                        ;(<any>Parser).performSelfAnalysis(this)
-                    }
-
-                    public testRule = this.RULE("testRule", () => {
-                        this.MANY({
-                            NAME: "$nestedMany",
-                            DEF: () => {
-                                this.CONSUME(A)
+                public testRule = this.RULE("testRule", () => {
+                    this.OR([
+                        {
+                            NAME: "$nestedAlt",
+                            ALT: () => {
+                                this.CONSUME(B)
                                 this.SUBRULE(this.bamba)
                             }
-                        })
-                        this.CONSUME(B)
-                    })
+                        }
+                    ])
+                })
 
-                    public bamba = this.RULE("bamba", () => {
-                        this.CONSUME(C)
-                    })
-                }
+                public bamba = this.RULE("bamba", () => {
+                    this.CONSUME(C)
+                })
+            }
 
-                let input = [
-                    createTokenInstance(A),
-                    createTokenInstance(C),
-                    createTokenInstance(A),
-                    createTokenInstance(C),
-                    createTokenInstance(A),
-                    createTokenInstance(C),
-                    createTokenInstance(B)
-                ]
-                let parser = new CstMultiTerminalWithManyNestedParser(input)
-                let cst = parser.testRule()
-                expect(cst.name).to.equal("testRule")
-                expect(cst.children).to.have.keys("B", "$nestedMany")
-                expect(tokenMatcher(cst.children.B[0], B)).to.be.true
-                let nestedManyCst = cst.children.$nestedMany[0]
-                expect(nestedManyCst.children).to.have.keys("A", "bamba")
-
-                expect(nestedManyCst.children.A).to.have.length(3)
-                expect(tokenMatcher(nestedManyCst.children.A[0], A)).to.be.true
-                expect(tokenMatcher(nestedManyCst.children.A[1], A)).to.be.true
-                expect(tokenMatcher(nestedManyCst.children.A[2], A)).to.be.true
-
-                expect(nestedManyCst.children.bamba).to.have.length(3)
-                expect(
-                    tokenMatcher(
-                        nestedManyCst.children.bamba[0].children.C[0],
-                        C
-                    )
-                ).to.be.true
-                expect(
-                    tokenMatcher(
-                        nestedManyCst.children.bamba[1].children.C[0],
-                        C
-                    )
-                ).to.be.true
-                expect(
-                    tokenMatcher(
-                        nestedManyCst.children.bamba[2].children.C[0],
-                        C
-                    )
-                ).to.be.true
-            })
-
-            it("Can output a CST using mandatory Repetitions", () => {
-                class CstAtLeastOneNestedParser extends Parser {
-                    constructor(input: IToken[] = []) {
-                        super(input, ALL_TOKENS, {
-                            outputCst: true
-                        })
-                        ;(<any>Parser).performSelfAnalysis(this)
-                    }
-
-                    public testRule = this.RULE("testRule", () => {
-                        this.AT_LEAST_ONE({
-                            NAME: "$oops",
-                            DEF: () => {
-                                this.CONSUME(A)
-                            }
-                        })
-                        this.CONSUME(B)
-                    })
-                }
-
-                let input = [
-                    createTokenInstance(A),
-                    createTokenInstance(A),
-                    createTokenInstance(A),
-                    createTokenInstance(B)
-                ]
-                let parser = new CstAtLeastOneNestedParser(input)
-                let cst = parser.testRule()
-                expect(cst.name).to.equal("testRule")
-                expect(cst.children).to.have.keys("$oops", "B")
-                expect(tokenMatcher(cst.children.B[0], B)).to.be.true
-                let oopsCst = cst.children.$oops[0]
-                expect(oopsCst.children).to.have.keys("A")
-                expect(oopsCst.children.A).to.have.length(3)
-                expect(tokenMatcher(oopsCst.children.A[0], A)).to.be.true
-                expect(tokenMatcher(oopsCst.children.A[1], A)).to.be.true
-                expect(tokenMatcher(oopsCst.children.A[2], A)).to.be.true
-            })
-
-            it("Can output a CST using Repetitions with separator", () => {
-                class CstNestedRuleWithManySepParser extends Parser {
-                    constructor(input: IToken[] = []) {
-                        super(input, ALL_TOKENS, {
-                            outputCst: true
-                        })
-                        ;(<any>Parser).performSelfAnalysis(this)
-                    }
-
-                    public testRule = this.RULE("testRule", () => {
-                        this.MANY_SEP({
-                            NAME: "$pizza",
-                            SEP: C,
-                            DEF: () => {
-                                this.CONSUME(A)
-                            }
-                        })
-                        this.CONSUME(B)
-                    })
-                }
-
-                let input = [
-                    createTokenInstance(A),
-                    createTokenInstance(C),
-                    createTokenInstance(A),
-                    createTokenInstance(B)
-                ]
-                let parser = new CstNestedRuleWithManySepParser(input)
-                let cst = parser.testRule()
-                expect(cst.name).to.equal("testRule")
-                expect(cst.children).to.have.keys("$pizza", "B")
-                expect(tokenMatcher(cst.children.B[0], B)).to.be.true
-                let pizzaCst = cst.children.$pizza[0]
-                expect(pizzaCst.children.A).to.have.length(2)
-                expect(tokenMatcher(pizzaCst.children.A[0], A)).to.be.true
-                expect(tokenMatcher(pizzaCst.children.A[1], A)).to.be.true
-                expect(pizzaCst.children.C).to.have.length(1)
-                expect(tokenMatcher(pizzaCst.children.C[0], C)).to.be.true
-            })
-
-            it("Can output a CST using Repetitions with separator - mandatory", () => {
-                class CstAtLeastOneSepNestedParser extends Parser {
-                    constructor(input: IToken[] = []) {
-                        super(input, ALL_TOKENS, {
-                            outputCst: true
-                        })
-                        ;(<any>Parser).performSelfAnalysis(this)
-                    }
-
-                    public testRule = this.RULE("testRule", () => {
-                        this.AT_LEAST_ONE_SEP({
-                            NAME: "$nestedName",
-                            SEP: C,
-                            DEF: () => {
-                                this.CONSUME(A)
-                            }
-                        })
-                        this.CONSUME(B)
-                    })
-                }
-
-                let input = [
-                    createTokenInstance(A),
-                    createTokenInstance(C),
-                    createTokenInstance(A),
-                    createTokenInstance(B)
-                ]
-                let parser = new CstAtLeastOneSepNestedParser(input)
-                let cst = parser.testRule()
-                expect(cst.name).to.equal("testRule")
-                expect(cst.children).to.have.keys("$nestedName", "B")
-                expect(tokenMatcher(cst.children.B[0], B)).to.be.true
-
-                let nestedCst = cst.children.$nestedName[0]
-                expect(nestedCst.children.A).to.have.length(2)
-                expect(tokenMatcher(nestedCst.children.A[0], A)).to.be.true
-                expect(tokenMatcher(nestedCst.children.A[1], A)).to.be.true
-                expect(nestedCst.children.C).to.have.length(1)
-                expect(tokenMatcher(nestedCst.children.C[0], C)).to.be.true
-            })
+            let input = [createRegularToken(B), createRegularToken(C)]
+            let parser = new CstAlternationNestedAltSingleParser(input)
+            let cst = parser.testRule()
+            expect(cst.name).to.equal("testRule")
+            expect(cst.children).to.have.keys("$nestedAlt")
+            let altCst = cst.children.$nestedAlt[0]
+            expect(altCst.children).to.have.keys("B", "bamba")
+            expect(tokenStructuredMatcher(altCst.children.B[0], B)).to.be.true
+            expect(altCst.children.bamba[0].children).to.have.keys("C")
         })
 
-        context("Error Recovery", () => {
-            it("re-sync recovery", () => {
-                class CstRecoveryParserReSync extends Parser {
-                    constructor(input: IToken[] = []) {
-                        super(input, ALL_TOKENS, {
-                            outputCst: true,
-                            recoveryEnabled: true
-                        })
-                        ;(<any>Parser).performSelfAnalysis(this)
-                    }
-
-                    public root = this.RULE("root", () => {
-                        this.MANY(() => {
-                            this.OR([
-                                {
-                                    ALT: () => {
-                                        this.SUBRULE(this.first)
-                                    }
-                                },
-                                {
-                                    ALT: () => {
-                                        this.SUBRULE(this.second)
-                                    }
-                                }
-                            ])
-                        })
+        it("Can output a CST using Repetitions", () => {
+            class CstMultiTerminalWithManyNestedParser extends Parser {
+                constructor(input: IToken[] = []) {
+                    super(input, ALL_TOKENS, {
+                        outputCst: true
                     })
-
-                    public first = this.RULE("first", () => {
-                        this.CONSUME(A)
-                        this.CONSUME(B)
-                    })
-
-                    public second = this.RULE("second", () => {
-                        this.CONSUME(C)
-                        this.CONSUME(D)
-                    })
-
-                    protected canTokenTypeBeInsertedInRecovery(
-                        tokType: TokenType
-                    ): boolean {
-                        // we want to force re-sync recovery
-                        return false
-                    }
+                    ;(<any>Parser).performSelfAnalysis(this)
                 }
 
-                let input = createTokenVector([A, E, E, C, D])
-                let parser = new CstRecoveryParserReSync(input)
-                let cst = parser.root()
-                expect(parser.errors).to.have.lengthOf(1)
-                expect(parser.errors[0].message).to.include(
-                    "Expecting token of type --> B <--"
+                public testRule = this.RULE("testRule", () => {
+                    this.MANY({
+                        NAME: "$nestedMany",
+                        DEF: () => {
+                            this.CONSUME(A)
+                            this.SUBRULE(this.bamba)
+                        }
+                    })
+                    this.CONSUME(B)
+                })
+
+                public bamba = this.RULE("bamba", () => {
+                    this.CONSUME(C)
+                })
+            }
+
+            let input = [
+                createRegularToken(A),
+                createRegularToken(C),
+                createRegularToken(A),
+                createRegularToken(C),
+                createRegularToken(A),
+                createRegularToken(C),
+                createRegularToken(B)
+            ]
+            let parser = new CstMultiTerminalWithManyNestedParser(input)
+            let cst = parser.testRule()
+            expect(cst.name).to.equal("testRule")
+            expect(cst.children).to.have.keys("B", "$nestedMany")
+            expect(tokenStructuredMatcher(cst.children.B[0], B)).to.be.true
+            let nestedManyCst = cst.children.$nestedMany[0]
+            expect(nestedManyCst.children).to.have.keys("A", "bamba")
+
+            expect(nestedManyCst.children.A).to.have.length(3)
+            expect(tokenStructuredMatcher(nestedManyCst.children.A[0], A)).to.be
+                .true
+            expect(tokenStructuredMatcher(nestedManyCst.children.A[1], A)).to.be
+                .true
+            expect(tokenStructuredMatcher(nestedManyCst.children.A[2], A)).to.be
+                .true
+
+            expect(nestedManyCst.children.bamba).to.have.length(3)
+            expect(
+                tokenStructuredMatcher(
+                    nestedManyCst.children.bamba[0].children.C[0],
+                    C
                 )
-                expect(parser.errors[0].resyncedTokens).to.have.lengthOf(1)
-                expect(tokenMatcher(parser.errors[0].resyncedTokens[0], E)).to
-                    .be.true
-
-                // expect(parser.errors[0]).
-                expect(cst.name).to.equal("root")
-                expect(cst.children).to.have.keys("first", "second")
-
-                let firstCollection = cst.children.first
-                expect(firstCollection).to.have.lengthOf(1)
-                let first = firstCollection[0]
-                expect(first.recoveredNode).to.be.true
-                expect(first.children).to.have.keys("A", "B")
-                expect(tokenMatcher(first.children.A[0], A)).to.be.true
-                expect(first.children.B[0]).to.be.undefined
-
-                let secondCollection = cst.children.second
-                expect(secondCollection).to.have.lengthOf(1)
-                let second = secondCollection[0]
-                expect(second.recoveredNode).to.be.undefined
-                expect(second.children).to.have.keys("C", "D")
-                expect(tokenMatcher(second.children.C[0], C)).to.be.true
-                expect(tokenMatcher(second.children.D[0], D)).to.be.true
-            })
-
-            it("re-sync recovery nested", () => {
-                class CstRecoveryParserReSyncNested extends Parser {
-                    constructor(input: IToken[] = []) {
-                        super(input, ALL_TOKENS, {
-                            outputCst: true,
-                            recoveryEnabled: true
-                        })
-                        ;(<any>Parser).performSelfAnalysis(this)
-                    }
-
-                    public root = this.RULE("root", () => {
-                        this.MANY(() => {
-                            this.OR([
-                                {
-                                    ALT: () => {
-                                        this.SUBRULE(this.first_root)
-                                    }
-                                },
-                                {
-                                    ALT: () => {
-                                        this.SUBRULE(this.second)
-                                    }
-                                }
-                            ])
-                        })
-                    })
-
-                    public first_root = this.RULE("first_root", () => {
-                        this.SUBRULE(this.first)
-                    })
-
-                    public first = this.RULE("first", () => {
-                        this.CONSUME(A)
-                        this.CONSUME(B)
-                    })
-
-                    public second = this.RULE("second", () => {
-                        this.CONSUME(C)
-                        this.CONSUME(D)
-                    })
-
-                    protected canTokenTypeBeInsertedInRecovery(
-                        tokType: TokenType
-                    ): boolean {
-                        // we want to force re-sync recovery
-                        return false
-                    }
-                }
-
-                let input = createTokenVector([A, E, E, C, D])
-                let parser = new CstRecoveryParserReSyncNested(input)
-                let cst = parser.root()
-                expect(parser.errors).to.have.lengthOf(1)
-                expect(parser.errors[0].message).to.include(
-                    "Expecting token of type --> B <--"
+            ).to.be.true
+            expect(
+                tokenStructuredMatcher(
+                    nestedManyCst.children.bamba[1].children.C[0],
+                    C
                 )
-                expect(parser.errors[0].resyncedTokens).to.have.lengthOf(1)
-                expect(tokenMatcher(parser.errors[0].resyncedTokens[0], E)).to
-                    .be.true
-
-                expect(cst.name).to.equal("root")
-                expect(cst.children).to.have.keys("first_root", "second")
-
-                let firstRootCollection = cst.children.first_root
-                expect(firstRootCollection).to.have.lengthOf(1)
-                let firstRoot = firstRootCollection[0]
-                expect(firstRoot.children).to.have.keys("first")
-
-                let first = firstRoot.children.first[0]
-                expect(first.recoveredNode).to.be.true
-                expect(first.children).to.have.keys("A", "B")
-                expect(tokenMatcher(first.children.A[0], A)).to.be.true
-                expect(first.children.B[0]).to.be.undefined
-
-                let secondCollection = cst.children.second
-                expect(secondCollection).to.have.lengthOf(1)
-                let second = secondCollection[0]
-                expect(second.recoveredNode).to.be.undefined
-                expect(second.children).to.have.keys("C", "D")
-                expect(tokenMatcher(second.children.C[0], C)).to.be.true
-                expect(tokenMatcher(second.children.D[0], D)).to.be.true
-            })
+            ).to.be.true
+            expect(
+                tokenStructuredMatcher(
+                    nestedManyCst.children.bamba[2].children.C[0],
+                    C
+                )
+            ).to.be.true
         })
 
-        after(() => {
-            clearCache()
+        it("Can output a CST using mandatory Repetitions", () => {
+            class CstAtLeastOneNestedParser extends Parser {
+                constructor(input: IToken[] = []) {
+                    super(input, ALL_TOKENS, {
+                        outputCst: true
+                    })
+                    ;(<any>Parser).performSelfAnalysis(this)
+                }
+
+                public testRule = this.RULE("testRule", () => {
+                    this.AT_LEAST_ONE({
+                        NAME: "$oops",
+                        DEF: () => {
+                            this.CONSUME(A)
+                        }
+                    })
+                    this.CONSUME(B)
+                })
+            }
+
+            let input = [
+                createRegularToken(A),
+                createRegularToken(A),
+                createRegularToken(A),
+                createRegularToken(B)
+            ]
+            let parser = new CstAtLeastOneNestedParser(input)
+            let cst = parser.testRule()
+            expect(cst.name).to.equal("testRule")
+            expect(cst.children).to.have.keys("$oops", "B")
+            expect(tokenStructuredMatcher(cst.children.B[0], B)).to.be.true
+            let oopsCst = cst.children.$oops[0]
+            expect(oopsCst.children).to.have.keys("A")
+            expect(oopsCst.children.A).to.have.length(3)
+            expect(tokenStructuredMatcher(oopsCst.children.A[0], A)).to.be.true
+            expect(tokenStructuredMatcher(oopsCst.children.A[1], A)).to.be.true
+            expect(tokenStructuredMatcher(oopsCst.children.A[2], A)).to.be.true
+        })
+
+        it("Can output a CST using Repetitions with separator", () => {
+            class CstNestedRuleWithManySepParser extends Parser {
+                constructor(input: IToken[] = []) {
+                    super(input, ALL_TOKENS, {
+                        outputCst: true
+                    })
+                    ;(<any>Parser).performSelfAnalysis(this)
+                }
+
+                public testRule = this.RULE("testRule", () => {
+                    this.MANY_SEP({
+                        NAME: "$pizza",
+                        SEP: C,
+                        DEF: () => {
+                            this.CONSUME(A)
+                        }
+                    })
+                    this.CONSUME(B)
+                })
+            }
+
+            let input = [
+                createRegularToken(A),
+                createRegularToken(C),
+                createRegularToken(A),
+                createRegularToken(B)
+            ]
+            let parser = new CstNestedRuleWithManySepParser(input)
+            let cst = parser.testRule()
+            expect(cst.name).to.equal("testRule")
+            expect(cst.children).to.have.keys("$pizza", "B")
+            expect(tokenStructuredMatcher(cst.children.B[0], B)).to.be.true
+            let pizzaCst = cst.children.$pizza[0]
+            expect(pizzaCst.children.A).to.have.length(2)
+            expect(tokenStructuredMatcher(pizzaCst.children.A[0], A)).to.be.true
+            expect(tokenStructuredMatcher(pizzaCst.children.A[1], A)).to.be.true
+            expect(pizzaCst.children.C).to.have.length(1)
+            expect(tokenStructuredMatcher(pizzaCst.children.C[0], C)).to.be.true
+        })
+
+        it("Can output a CST using Repetitions with separator - mandatory", () => {
+            class CstAtLeastOneSepNestedParser extends Parser {
+                constructor(input: IToken[] = []) {
+                    super(input, ALL_TOKENS, {
+                        outputCst: true
+                    })
+                    ;(<any>Parser).performSelfAnalysis(this)
+                }
+
+                public testRule = this.RULE("testRule", () => {
+                    this.AT_LEAST_ONE_SEP({
+                        NAME: "$nestedName",
+                        SEP: C,
+                        DEF: () => {
+                            this.CONSUME(A)
+                        }
+                    })
+                    this.CONSUME(B)
+                })
+            }
+
+            let input = [
+                createRegularToken(A),
+                createRegularToken(C),
+                createRegularToken(A),
+                createRegularToken(B)
+            ]
+            let parser = new CstAtLeastOneSepNestedParser(input)
+            let cst = parser.testRule()
+            expect(cst.name).to.equal("testRule")
+            expect(cst.children).to.have.keys("$nestedName", "B")
+            expect(tokenStructuredMatcher(cst.children.B[0], B)).to.be.true
+
+            let nestedCst = cst.children.$nestedName[0]
+            expect(nestedCst.children.A).to.have.length(2)
+            expect(tokenStructuredMatcher(nestedCst.children.A[0], A)).to.be
+                .true
+            expect(tokenStructuredMatcher(nestedCst.children.A[1], A)).to.be
+                .true
+            expect(nestedCst.children.C).to.have.length(1)
+            expect(tokenStructuredMatcher(nestedCst.children.C[0], C)).to.be
+                .true
         })
     })
-}
 
-defineCstSpecs(
-    "Regular Tokens Mode",
-    createToken,
-    createRegularToken,
-    tokenStructuredMatcher
-)
+    context("Error Recovery", () => {
+        it("re-sync recovery", () => {
+            class CstRecoveryParserReSync extends Parser {
+                constructor(input: IToken[] = []) {
+                    super(input, ALL_TOKENS, {
+                        outputCst: true,
+                        recoveryEnabled: true
+                    })
+                    ;(<any>Parser).performSelfAnalysis(this)
+                }
+
+                public root = this.RULE("root", () => {
+                    this.MANY(() => {
+                        this.OR([
+                            {
+                                ALT: () => {
+                                    this.SUBRULE(this.first)
+                                }
+                            },
+                            {
+                                ALT: () => {
+                                    this.SUBRULE(this.second)
+                                }
+                            }
+                        ])
+                    })
+                })
+
+                public first = this.RULE("first", () => {
+                    this.CONSUME(A)
+                    this.CONSUME(B)
+                })
+
+                public second = this.RULE("second", () => {
+                    this.CONSUME(C)
+                    this.CONSUME(D)
+                })
+
+                protected canTokenTypeBeInsertedInRecovery(
+                    tokType: TokenType
+                ): boolean {
+                    // we want to force re-sync recovery
+                    return false
+                }
+            }
+
+            let input = createTokenVector([A, E, E, C, D])
+            let parser = new CstRecoveryParserReSync(input)
+            let cst = parser.root()
+            expect(parser.errors).to.have.lengthOf(1)
+            expect(parser.errors[0].message).to.include(
+                "Expecting token of type --> B <--"
+            )
+            expect(parser.errors[0].resyncedTokens).to.have.lengthOf(1)
+            expect(
+                tokenStructuredMatcher(parser.errors[0].resyncedTokens[0], E)
+            ).to.be.true
+
+            // expect(parser.errors[0]).
+            expect(cst.name).to.equal("root")
+            expect(cst.children).to.have.keys("first", "second")
+
+            let firstCollection = cst.children.first
+            expect(firstCollection).to.have.lengthOf(1)
+            let first = firstCollection[0]
+            expect(first.recoveredNode).to.be.true
+            expect(first.children).to.have.keys("A")
+            expect(tokenStructuredMatcher(first.children.A[0], A)).to.be.true
+            expect(first.children.B).to.be.undefined
+
+            let secondCollection = cst.children.second
+            expect(secondCollection).to.have.lengthOf(1)
+            let second = secondCollection[0]
+            expect(second.recoveredNode).to.be.undefined
+            expect(second.children).to.have.keys("C", "D")
+            expect(tokenStructuredMatcher(second.children.C[0], C)).to.be.true
+            expect(tokenStructuredMatcher(second.children.D[0], D)).to.be.true
+        })
+
+        it("re-sync recovery nested", () => {
+            class CstRecoveryParserReSyncNested extends Parser {
+                constructor(input: IToken[] = []) {
+                    super(input, ALL_TOKENS, {
+                        outputCst: true,
+                        recoveryEnabled: true
+                    })
+                    ;(<any>Parser).performSelfAnalysis(this)
+                }
+
+                public root = this.RULE("root", () => {
+                    this.MANY(() => {
+                        this.OR([
+                            {
+                                ALT: () => {
+                                    this.SUBRULE(this.first_root)
+                                }
+                            },
+                            {
+                                ALT: () => {
+                                    this.SUBRULE(this.second)
+                                }
+                            }
+                        ])
+                    })
+                })
+
+                public first_root = this.RULE("first_root", () => {
+                    this.SUBRULE(this.first)
+                })
+
+                public first = this.RULE("first", () => {
+                    this.CONSUME(A)
+                    this.CONSUME(B)
+                })
+
+                public second = this.RULE("second", () => {
+                    this.CONSUME(C)
+                    this.CONSUME(D)
+                })
+
+                protected canTokenTypeBeInsertedInRecovery(
+                    tokType: TokenType
+                ): boolean {
+                    // we want to force re-sync recovery
+                    return false
+                }
+            }
+
+            let input = createTokenVector([A, E, E, C, D])
+            let parser = new CstRecoveryParserReSyncNested(input)
+            let cst = parser.root()
+            expect(parser.errors).to.have.lengthOf(1)
+            expect(parser.errors[0].message).to.include(
+                "Expecting token of type --> B <--"
+            )
+            expect(parser.errors[0].resyncedTokens).to.have.lengthOf(1)
+            expect(
+                tokenStructuredMatcher(parser.errors[0].resyncedTokens[0], E)
+            ).to.be.true
+
+            expect(cst.name).to.equal("root")
+            expect(cst.children).to.have.keys("first_root", "second")
+
+            let firstRootCollection = cst.children.first_root
+            expect(firstRootCollection).to.have.lengthOf(1)
+            let firstRoot = firstRootCollection[0]
+            expect(firstRoot.children).to.have.keys("first")
+
+            let first = firstRoot.children.first[0]
+            expect(first.recoveredNode).to.be.true
+            expect(first.children).to.have.keys("A")
+            expect(tokenStructuredMatcher(first.children.A[0], A)).to.be.true
+            expect(first.children.B).to.be.undefined
+
+            let secondCollection = cst.children.second
+            expect(secondCollection).to.have.lengthOf(1)
+            let second = secondCollection[0]
+            expect(second.recoveredNode).to.be.undefined
+            expect(second.children).to.have.keys("C", "D")
+            expect(tokenStructuredMatcher(second.children.C[0], C)).to.be.true
+            expect(tokenStructuredMatcher(second.children.D[0], D)).to.be.true
+        })
+    })
+
+    after(() => {
+        clearCache()
+    })
+})

--- a/test/parse/recognizer_spec.ts
+++ b/test/parse/recognizer_spec.ts
@@ -86,12 +86,12 @@ function defineRecognizerSpecs(
                     }
 
                     public topRule = this.RULE("topRule", () => {
-                        this.SUBRULE(this.subRule, [6, "a"])
-                        this.SUBRULE1(this.subRule2, [5, "b"])
-                        this.SUBRULE2(this.subRule, [4, "c"])
-                        this.SUBRULE3(this.subRule, [3, "d"])
-                        this.SUBRULE4(this.subRule, [2, "e"])
-                        this.SUBRULE5(this.subRule, [1, "f"])
+                        this.SUBRULE(this.subRule, { ARGS: [6, "a"] })
+                        this.SUBRULE1(this.subRule2, { ARGS: [5, "b"] })
+                        this.SUBRULE2(this.subRule, { ARGS: [4, "c"] })
+                        this.SUBRULE3(this.subRule, { ARGS: [3, "d"] })
+                        this.SUBRULE4(this.subRule, { ARGS: [2, "e"] })
+                        this.SUBRULE5(this.subRule, { ARGS: [1, "f"] })
                         return {
                             numbers: this.numbers,
                             letters: this.letters


### PR DESCRIPTION
- Avoids the creation of empty arrays in the "children"
  object if no Terminal or NoneTerminal were matched.

- Avoids using "new Function" in CST flows to avoid issues with sites
  using Content Security Policy.