### PR TITLE
Detect Parsers with none unique names.

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -9,6 +9,7 @@ const versionWithLowDashs = version.replace(/\./g, "_")
 
 const slugMap = {
     "Common Prefix Ambiguities": "COMMON_PREFIX",
+    "None Unique Grammar Name Found": "UNIQUE_GRAMMAR_NAME",
     "No LINE_BREAKS Error": "LINE_BREAKS",
     "Unexpected RegExp Anchor Error": "ANCHORS",
     "Token can never be matched": "UNREACHABLE",

--- a/docs/changes/CHANGELOG.md
+++ b/docs/changes/CHANGELOG.md
@@ -1,3 +1,9 @@
+## X.Y.Z (INSERT_DATE_HERE)
+
+#### Minor Changes
+
+*   [Detect grammars with none unique names](https://github.com/SAP/chevrotain/commit/41543670d6cb46b151f214bc38285eb144b94fe0).
+
 ## 3.3.0 (5-20-2018)
 
 #### Documentation

--- a/docs/guide/resolving_grammar_errors.md
+++ b/docs/guide/resolving_grammar_errors.md
@@ -1,6 +1,7 @@
 # Resolving Grammar Errors
 
 *   [Common Prefix Ambiguities.](#COMMON_PREFIX)
+*   [None Unique Grammar Name Found.](#UNIQUE_GRAMMAR_NAME)
 
 ## Common Prefix Ambiguities
 
@@ -37,3 +38,30 @@ There are two ways to resolve this:
       myRule:
         "A" "B" ("C")?
     ```
+
+## None Unique Grammar Name Found
+
+Chevrotain uses a grammar's constructor name as a **key**
+for caching the results of heavy computations.
+
+This means that every grammar must have a unique name:
+
+```javascript
+// File1
+// unique name "MyParser"
+class MyParser extends Parser {
+    // ...
+}
+
+// File2
+// another unique name: "MyOtherParser"
+class MyParser extends Parser {
+    // ...
+}
+
+// File3
+// None unique name, "MyParser" is already defined in File1
+class MyParser extends Parser {
+    // ...
+}
+```

--- a/src/parse/cache.ts
+++ b/src/parse/cache.ts
@@ -8,19 +8,22 @@ import { filter, forEach, values } from "../utils/utils"
 import { Rule } from "./grammar/gast/gast_public"
 import { IParserDefinitionError, TokenType } from "../../api"
 
-export let CLASS_TO_DEFINITION_ERRORS = new HashTable<
+export const CLASS_TO_DEFINITION_ERRORS = new HashTable<
     IParserDefinitionError[]
 >()
 
-export let CLASS_TO_SELF_ANALYSIS_DONE = new HashTable<boolean>()
+export const CLASS_TO_SELF_ANALYSIS_DONE = new HashTable<boolean>()
+export const CLASS_TO_CONSTRUCTOR = new HashTable<Function>()
 
-export let CLASS_TO_GRAMMAR_PRODUCTIONS = new HashTable<HashTable<Rule>>()
+export const CLASS_TO_GRAMMAR_PRODUCTIONS = new HashTable<HashTable<Rule>>()
 
 export function getProductionsForClass(className: string): HashTable<Rule> {
     return getFromNestedHashTable(className, CLASS_TO_GRAMMAR_PRODUCTIONS)
 }
 
-export let CLASS_TO_RESYNC_FOLLOW_SETS = new HashTable<HashTable<TokenType[]>>()
+export const CLASS_TO_RESYNC_FOLLOW_SETS = new HashTable<
+    HashTable<TokenType[]>
+>()
 
 export function getResyncFollowsForClass(
     className: string
@@ -35,13 +38,13 @@ export function setResyncFollowsForClass(
     CLASS_TO_RESYNC_FOLLOW_SETS.put(className, followSet)
 }
 
-export let CLASS_TO_LOOKAHEAD_FUNCS = new HashTable<HashTable<Function>>()
+export const CLASS_TO_LOOKAHEAD_FUNCS = new HashTable<HashTable<Function>>()
 
 export function getLookaheadFuncsForClass(className: string): Function[] {
     return getArrFromHashTable(className, CLASS_TO_LOOKAHEAD_FUNCS)
 }
 
-export let CLASS_TO_FIRST_AFTER_REPETITION = new HashTable<
+export const CLASS_TO_FIRST_AFTER_REPETITION = new HashTable<
     HashTable<IFirstAfterRepetition>
 >()
 
@@ -51,7 +54,7 @@ export function getFirstAfterRepForClass(
     return getFromNestedHashTable(className, CLASS_TO_FIRST_AFTER_REPETITION)
 }
 
-export let CLASS_TO_PRODUCTION_OVERRIDEN = new HashTable<HashTable<boolean>>()
+export const CLASS_TO_PRODUCTION_OVERRIDEN = new HashTable<HashTable<boolean>>()
 
 export function getProductionOverriddenForClass(
     className: string
@@ -59,13 +62,9 @@ export function getProductionOverriddenForClass(
     return getFromNestedHashTable(className, CLASS_TO_PRODUCTION_OVERRIDEN)
 }
 
-export const CLASS_TO_CST_DICT_DEF_PER_RULE = new HashTable<
-    HashTable<string[]>
->()
-
-export let CLASS_TO_BASE_CST_VISITOR = new HashTable<Function>()
-export let CLASS_TO_BASE_CST_VISITOR_WITH_DEFAULTS = new HashTable<Function>()
-export let CLASS_TO_ALL_RULE_NAMES = new HashTable<string[]>()
+export const CLASS_TO_BASE_CST_VISITOR = new HashTable<Function>()
+export const CLASS_TO_BASE_CST_VISITOR_WITH_DEFAULTS = new HashTable<Function>()
+export const CLASS_TO_ALL_RULE_NAMES = new HashTable<string[]>()
 
 function getFromNestedHashTable(className: string, hashTable: HashTable<any>) {
     let result = hashTable.get(className)
@@ -86,7 +85,7 @@ function getArrFromHashTable(className: string, hashTable: HashTable<any>) {
 }
 
 export function clearCache(): void {
-    let hasTables = filter(
+    const hasTables = filter(
         values(module.exports),
         currHashTable => currHashTable instanceof HashTable
     )

--- a/src/parse/errors_public.ts
+++ b/src/parse/errors_public.ts
@@ -233,7 +233,7 @@ export const defaultGrammarValidatorErrorProvider: IGrammarValidatorErrorMessage
             }> Rule,\n` +
             `<${pathMsg}> may appears as a prefix path in all these alternatives.\n` +
             `https://sap.github.io/chevrotain/docs/guide/resolving_grammar_errors.html#COMMON_PREFIX\n` +
-            `For farther details.`
+            `For Further details.`
 
         return errMsg
     },

--- a/src/parse/grammar/checks.ts
+++ b/src/parse/grammar/checks.ts
@@ -73,7 +73,7 @@ export function validateGrammar(
     let ambiguousAltsErrors = []
 
     // left recursion could cause infinite loops in the following validations.
-    // It is safest to first have the user fix the left recursion errors first and only then examine farther issues.
+    // It is safest to first have the user fix the left recursion errors first and only then examine Further issues.
     if (every(leftRecursionErrors, isEmpty)) {
         emptyAltErrors = map(topLevels, currTopRule =>
             validateEmptyOrAlternative(currTopRule, errMsgProvider)

--- a/src/parse/parser_public.ts
+++ b/src/parse/parser_public.ts
@@ -233,6 +233,7 @@ export class Parser {
 
         parserInstance.selfAnalysisDone = true
         let className = classNameFromInstance(parserInstance)
+        const actualClassConstructor = parserInstance.constructor
 
         // can't test this with nyc tool, instrumentation causes the class name to be not empty.
         /* istanbul ignore if */
@@ -244,6 +245,26 @@ export class Parser {
                 "A Parser's constructor may not be an anonymous Function, it must be a named function\n" +
                     "The constructor's name is used at runtime for performance (caching) purposes."
             )
+        }
+
+        // this information should only be computed once
+        if (!cache.CLASS_TO_CONSTRUCTOR.containsKey(className)) {
+            cache.CLASS_TO_CONSTRUCTOR.put(className, actualClassConstructor)
+        }
+        // Detect multiple Parsers using the same name.
+        // This will mess up the cache logic.
+        else {
+            const expectedClassConstructor = cache.CLASS_TO_CONSTRUCTOR.get(
+                className
+            )
+            if (actualClassConstructor !== expectedClassConstructor) {
+                throw Error(
+                    `None Unique Grammar Name Found: <${className}>\n` +
+                        "\tEvery grammar must have a unique name.\n" +
+                        "\tSee: https://sap.github.io/chevrotain/docs/guide/resolving_grammar_errors.html#UNIQUE_NAME\n" +
+                        "\tFor Further details."
+                )
+            }
         }
 
         // this information should only be computed once
@@ -1571,7 +1592,7 @@ export class Parser {
                                     preRuleFullName
                                 )
                             }
-                            // to be handled farther up the call stack
+                            // to be handled Further up the call stack
                             throw e
                         }
                     } else if (isFirstInvokedRule) {
@@ -1581,7 +1602,7 @@ export class Parser {
                         // even if error recovery is disabled
                         return recoveryValueFunc()
                     } else {
-                        // to be handled farther up the call stack
+                        // to be handled Further up the call stack
                         throw e
                     }
                 } else {

--- a/test/parse/cst_spec.ts
+++ b/test/parse/cst_spec.ts
@@ -58,7 +58,7 @@ context("CST", () => {
     })
 
     it("Can output a CST with labels", () => {
-        class CstTerminalParser extends Parser {
+        class CstTerminalParser2 extends Parser {
             constructor(input: IToken[] = []) {
                 super(input, ALL_TOKENS, {
                     outputCst: true
@@ -82,7 +82,7 @@ context("CST", () => {
             createRegularToken(B),
             createRegularToken(C)
         ]
-        let parser = new CstTerminalParser(input)
+        let parser = new CstTerminalParser2(input)
         let cst = parser.testRule()
         expect(cst.name).to.equal("testRule")
         expect(cst.children).to.have.keys("myLabel", "B", "myOtherLabel")

--- a/test/parse/grammar/checks_spec.ts
+++ b/test/parse/grammar/checks_spec.ts
@@ -846,7 +846,7 @@ describe("The empty alternative detection full flow", () => {
     })
 
     it("will throw an error when an empty alternative is not the last alternative #2", () => {
-        class EmptyAltAmbiguityParser extends Parser {
+        class EmptyAltAmbiguityParser2 extends Parser {
             constructor(input: IToken[] = []) {
                 super(input, [PlusTok, StarTok])
                 ;(<any>Parser).performSelfAnalysis(this)
@@ -871,14 +871,14 @@ describe("The empty alternative detection full flow", () => {
                 ])
             })
         }
-        expect(() => new EmptyAltAmbiguityParser()).to.throw(
+        expect(() => new EmptyAltAmbiguityParser2()).to.throw(
             "Ambiguous empty alternative"
         )
-        expect(() => new EmptyAltAmbiguityParser()).to.throw("1")
-        expect(() => new EmptyAltAmbiguityParser()).to.throw(
+        expect(() => new EmptyAltAmbiguityParser2()).to.throw("1")
+        expect(() => new EmptyAltAmbiguityParser2()).to.throw(
             "Only the last alternative may be an empty alternative."
         )
-        expect(() => new EmptyAltAmbiguityParser()).to.not.throw("undefined")
+        expect(() => new EmptyAltAmbiguityParser2()).to.not.throw("undefined")
     })
 })
 

--- a/test/parse/recognizer_spec.ts
+++ b/test/parse/recognizer_spec.ts
@@ -947,6 +947,32 @@ function defineRecognizerSpecs(
                 )
             })
 
+            describe("Parser Level Validations", () => {
+                before(() => {
+                    class myNoneUniqueSpecialParser extends Parser {
+                        constructor(input: IToken[] = []) {
+                            super(input, ALL_TOKENS)
+                            Parser.performSelfAnalysis(this)
+                        }
+                    }
+                    // init the first parser
+                    new myNoneUniqueSpecialParser([])
+                })
+
+                it("Will throw an error if multiple different parsers exist with the same name", () => {
+                    class myNoneUniqueSpecialParser extends Parser {
+                        constructor(input: IToken[] = []) {
+                            super(input, ALL_TOKENS)
+                            Parser.performSelfAnalysis(this)
+                        }
+                    }
+
+                    expect(() => new myNoneUniqueSpecialParser()).to.throw(
+                        "None Unique Grammar Name Found"
+                    )
+                })
+            })
+
             it("can be initialized with a vector of Tokens", () => {
                 let parser: any = new Parser([], [PlusTok, MinusTok, IntTok])
                 let tokensMap = (<any>parser).tokensMap
@@ -1006,7 +1032,7 @@ function defineRecognizerSpecs(
             })
 
             it("will not swallow none Recognizer errors when attempting 'in rule error recovery'", () => {
-                class InRuleParser extends Parser {
+                class NotSwallowInRuleParser extends Parser {
                     constructor(input: IToken[] = []) {
                         super(input, ALL_TOKENS, {
                             recoveryEnabled: true
@@ -1018,7 +1044,7 @@ function defineRecognizerSpecs(
                         this.CONSUME1(DotTok)
                     })
                 }
-                let parser: any = new InRuleParser([
+                let parser: any = new NotSwallowInRuleParser([
                     createTokenInstance(IntTok, "1")
                 ])
                 parser.tryInRuleRecovery = () => {
@@ -1028,7 +1054,7 @@ function defineRecognizerSpecs(
             })
 
             it("will not swallow none Recognizer errors during Token consumption", () => {
-                class InRuleParser extends Parser {
+                class NotSwallowInTokenConsumption extends Parser {
                     constructor(input: IToken[] = []) {
                         super(input, ALL_TOKENS, {
                             recoveryEnabled: true
@@ -1040,7 +1066,7 @@ function defineRecognizerSpecs(
                         this.CONSUME1(DotTok)
                     })
                 }
-                let parser: any = new InRuleParser([
+                let parser: any = new NotSwallowInTokenConsumption([
                     createTokenInstance(IntTok, "1")
                 ])
                 ;(parser as any).consumeInternal = () => {
@@ -1050,7 +1076,7 @@ function defineRecognizerSpecs(
             })
 
             it("will rethrow none Recognizer errors during Token consumption - recovery disabled + nested rule", () => {
-                class InRuleParser extends Parser {
+                class RethrowOtherErrors extends Parser {
                     constructor(input: IToken[] = []) {
                         super(input, ALL_TOKENS, {
                             recoveryEnabled: true
@@ -1075,7 +1101,7 @@ function defineRecognizerSpecs(
                         }
                     )
                 }
-                let parser: any = new InRuleParser([
+                let parser: any = new RethrowOtherErrors([
                     createTokenInstance(IntTok, "1")
                 ])
                 parser.someRule()
@@ -1237,7 +1263,7 @@ function defineRecognizerSpecs(
             })
 
             it("Supports custom error messages for OR", () => {
-                class LabelAltParser extends Parser {
+                class LabelAltParser2 extends Parser {
                     constructor(input: IToken[] = []) {
                         super(input, [PlusTok, MinusTok])
                         ;(Parser as any).performSelfAnalysis(this)
@@ -1262,7 +1288,7 @@ function defineRecognizerSpecs(
                     })
                 }
 
-                let parser = new LabelAltParser([])
+                let parser = new LabelAltParser2([])
                 parser.rule()
                 expect(parser.errors[0]).to.be.an.instanceof(
                     NoViableAltException


### PR DESCRIPTION
This will throw an error instead of potentially leading to unexpected behavior.

Fixes #715