### PR TITLE
Update docs for minifying chevrotain parsers with a serialized grammar

### DIFF
--- a/examples/parser/package.json
+++ b/examples/parser/package.json
@@ -2,7 +2,11 @@
     "name": "chevrotain_examples_parser",
     "version": "0.1.0",
     "scripts": {
-        "test": "grunt --gruntfile minification/gruntfile.js && cd webpack && yarn install && yarn bundle && rm -rf node_modules && cd .. && mocha \"!(node_modules)/**/*spec.js\""
+        "build_minification": "grunt --gruntfile minification/gruntfile.js",
+        "build_webpack": "cd webpack && yarn install && yarn bundle && rm -rf node_modules && cd ..",
+        "build_serialized_grammar": "node ./serialized_grammar/gen_serialized.js",
+        "pretest": "npm run build_minification && npm run build_serialized_grammar && npm run build_webpack",
+        "test": "mocha \"!(node_modules)/**/*spec.js\""
     },
     "dependencies": {
         "chevrotain": "*",

--- a/examples/parser/serialized_grammar/README.md
+++ b/examples/parser/serialized_grammar/README.md
@@ -1,0 +1,18 @@
+### Using Serialized Chevrotain Grammars.
+
+Starting with version 3.6, Chevrotain allows parsers to be instantiated with
+a previously serialized grammar. This is useful because it allows for safe
+minification without worrying about name mangling and may even provide cold
+start peformance benefits. However, you must make sure your code is using
+up-to-date serializations of your parsers.
+
+#### Runnable Example
+
+[gen_serialized](./gen_serialized.js) implements serialization of a sample grammar.
+Sample grammar: [grammar.js][./grammar.js].
+Additionally [unit tests](./serialized_spec.js) are included to validate the grammars actually work.
+
+To run the serialization and the tests (from parent directory):
+
+-   `node ./serialized_grammar/gen_serialized.js`
+-   `./node_modules/.bin/mocha serialized_grammar/serialized_spec.js`

--- a/examples/parser/serialized_grammar/gen/grammar.json
+++ b/examples/parser/serialized_grammar/gen/grammar.json
@@ -1,0 +1,30 @@
+[
+  {
+    "type": "Rule",
+    "name": "root",
+    "orgText": "() => {\n            this.CONSUME(Alpha)\n            this.CONSUME(Bravo)\n            this.CONSUME(Charlie)\n        }",
+    "definition": [
+      {
+        "type": "Terminal",
+        "name": "Alpha",
+        "label": "Alpha",
+        "idx": 0,
+        "pattern": "A"
+      },
+      {
+        "type": "Terminal",
+        "name": "Bravo",
+        "label": "Bravo",
+        "idx": 0,
+        "pattern": "B"
+      },
+      {
+        "type": "Terminal",
+        "name": "Charlie",
+        "label": "Charlie",
+        "idx": 0,
+        "pattern": "C"
+      }
+    ]
+  }
+]

--- a/examples/parser/serialized_grammar/gen_serialized.js
+++ b/examples/parser/serialized_grammar/gen_serialized.js
@@ -1,0 +1,20 @@
+const fs = require("fs")
+const path = require("path")
+const { Parser } = require("./grammar")
+const { clearCache } = require("chevrotain")
+
+// we need to clear the cache to prevent the parser from using a stale grammar
+clearCache()
+// instantiate parser without serialized grammar (because it doesn't exist yet!)
+const parser = new Parser([])
+const grammar = parser.getSerializedGastProductions()
+// clear cache again in case tests also initialize the parser
+clearCache()
+// serialized the grammar in a json file
+try {
+    fs.mkdirSync(path.join(__dirname, "./gen"))
+} catch (err) {}
+fs.writeFileSync(
+    path.join(__dirname, "./gen/grammar.json"),
+    JSON.stringify(grammar, null, 2)
+)

--- a/examples/parser/serialized_grammar/grammar.js
+++ b/examples/parser/serialized_grammar/grammar.js
@@ -1,0 +1,65 @@
+const { createToken, Lexer, Parser } = require("chevrotain")
+
+// ----------------- lexer -----------------
+
+const Alpha = createToken({ name: "Alpha", pattern: /A/ })
+const Bravo = createToken({ name: "Bravo", pattern: /B/ })
+const Charlie = createToken({ name: "Charlie", pattern: /C/ })
+
+const allTokens = [Alpha, Bravo, Charlie]
+
+const SerializedLexer = new Lexer(allTokens, { positionTracking: "onlyOffset" })
+
+// ----------------- parser -----------------
+
+class SerializedParser extends Parser {
+    constructor(input, serializedGrammar) {
+        // Invoke super constructor with serialized grammar in parser config.
+        // Passing in serialized grammar without passing it into the parser
+        // would cause parser to always use a stale grammar.
+        super(input, allTokens, { serializedGrammar: serializedGrammar })
+
+        // this.RULE calls will be ignored if a serialized grammar is passed in.
+        this.RULE("root", () => {
+            this.CONSUME(Alpha)
+            this.CONSUME(Bravo)
+            this.CONSUME(Charlie)
+        })
+
+        // this.performSelfAnalysis calls will be ignored as well.
+        this.performSelfAnalysis()
+    }
+}
+
+// ----------------- wrapping it all together -----------------
+
+// try to import serialized grammar in production
+var serializedGrammar
+if (process.env.NODE_ENV === "production") {
+    try {
+        serializedGrammar = require("./gen/grammar.json")
+    } catch (err) {
+        // ignore error
+    }
+}
+// pass in serialized grammar to parser instance
+var parser = new SerializedParser([], serializedGrammar)
+
+function parse(text) {
+    const lexResult = SerializedLexer.tokenize(text)
+
+    parser.input = lexResult.tokens
+    const value = parser.root()
+
+    return {
+        value: value, // this is a pure grammar, the value will always be <undefined>
+        lexErrors: lexResult.errors,
+        parseErrors: parser.errors
+    }
+}
+
+module.exports = {
+    parse,
+    // export parser so build script can serialize it
+    Parser: SerializedParser
+}

--- a/examples/parser/serialized_grammar/serialized_spec.js
+++ b/examples/parser/serialized_grammar/serialized_spec.js
@@ -1,0 +1,18 @@
+const { expect } = require("chai")
+describe("Chevrotain serialized grammar support", () => {
+    let oldNodeEnv
+    before(() => {
+        oldNodeEnv = process.env.NODE_ENV
+        process.env.NODE_ENV = "production"
+    })
+    it("Can use a serialized grammar", () => {
+        const { parse } = require("./grammar")
+        const inputText = "ABC"
+        const lexAndParseResult = parse(inputText)
+        expect(lexAndParseResult.lexErrors).to.be.empty
+        expect(lexAndParseResult.parseErrors).to.be.empty
+    })
+    after(() => {
+        process.env.NODE_ENV = oldNodeEnv
+    })
+})

--- a/examples/parser/webpack/README.md
+++ b/examples/parser/webpack/README.md
@@ -1,14 +1,14 @@
 ### Webpacking of Chevrotain Grammars.
 
 Chevrotain relies on **Function.prototype.toString** and **Function.name**
-to run. This means that webpacking(minification) of Chevrotain grammars must be done carefully.
+to run. This means that webpacking (minification) of Chevrotain grammars must be done carefully.
 
 Safe minification can be achieved by providing [custom uglifyJs options](https://webpack.js.org/configuration/optimization/#optimization-minimizer) to the webpack config
 that will disable the name mangling of the TokenType names.
 
 #### Runnable Example
 
--   [webpack.confg.js](webpack.config.js)
+-   [webpack.config.js](webpack.config.js)
 -   [grammar source](./src/our_grammar.js)
 -   [test](./test/webpack_spec.js)
 


### PR DESCRIPTION
This is the work so far but it’s failing examples/parser tests for two reasons:
1. the tests use a shared cache and are (probably?) run in parallel, so clearing the cache in one test will cause other tests to fail.
2. the tests use the npm release of chevrotain and I can’t link my local package b/c the test command itself calls yarn.

I’ll pick it up again later, I just ran out of time for now.