### PR TITLE
Update step1_lexing.md

### DIFF
--- a/docs/tutorial/step1_lexing.md
+++ b/docs/tutorial/step1_lexing.md
@@ -41,7 +41,7 @@ How can we define Tokens for Identifiers or Integers?
 ```javascript
 const Identifier = createToken({ name: "Identifier", pattern: /[a-zA-Z]\w*/ })
 
-const Integer = createToken({ name: "Integer", pattern: /0|[1-9]\d+/ })
+const Integer = createToken({ name: "Integer", pattern: /0|[1-9]\d*/ })
 ```
 
 ## Skipping Tokens


### PR DESCRIPTION
Integer Pattern [here](https://github.com/SAP/chevrotain/blob/master/docs/tutorial/step1_lexing.md#more-complex-tokens) uses + instead of *, so it misses integers 1-9.