### PR TITLE
Typo in license name

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "bugs": {
     "url": "https://github.com/SAP/chevrotain/issues"
   },
-  "license": " Apache-2.0",
+  "license": "Apache-2.0",
   "author": {
     "name": "Shahar Soel"
   },


### PR DESCRIPTION
That typo makes some automatic tools (like `license-checker`) to incorrectly understand the license.