### PR TITLE
Get correct startCodes for RegExp patterns with nested groups

### DIFF
--- a/packages/chevrotain/test/scan/regexp_spec.ts
+++ b/packages/chevrotain/test/scan/regexp_spec.ts
@@ -64,6 +64,15 @@ describe("the regExp analysis", () => {
         it("will not compute when using complements #2", () => {
             expect(getStartCodes(/[^a-z]/, true)).to.be.empty
         })
+
+        it("correctly handles nested groups with and without quantifiers", () => {
+            expect(getStartCodes(/((ab)?)c/)).to.deep.equal([97, 99])
+            expect(getStartCodes(/((ab))(c)/)).to.deep.equal([97])
+            expect(getStartCodes(/((ab))?c/)).to.deep.equal([97, 99])
+            expect(getStartCodes(/((a?((b?))))?c/)).to.deep.equal([97, 98, 99])
+            expect(getStartCodes(/((a?((b))))c/)).to.deep.equal([97, 98])
+            expect(getStartCodes(/((a+((b))))c/)).to.deep.equal([97])
+        })
     })
 
     context("can match charCode", () => {


### PR DESCRIPTION
This fixes issues where the chevrotain Lexer engine fails to match tokens that _should_ match. The issues occur when tokens' RegExp patterns have nested capturing groups.

Test that failed before this PR and that pass afterward are included.

Closes #933.