### PR TITLE
Make ILexerErrorMessageProvider methods optional

### DIFF
--- a/packages/chevrotain/api.d.ts
+++ b/packages/chevrotain/api.d.ts
@@ -1400,7 +1400,7 @@ export interface ILexerErrorMessageProvider {
      * @param column - Column number where the error occured. (optional)
      *                    Will not be provided when lexer is not defined to track lines/columns
      */
-    buildUnexpectedCharactersMessage(
+    buildUnexpectedCharactersMessage?(
         fullText: string,
         startOffset: number,
         length: number,
@@ -1415,7 +1415,7 @@ export interface ILexerErrorMessageProvider {
      *
      * @param token - The Token that requested pop mode.
      */
-    buildUnableToPopLexerModeMessage(token: IToken): string
+    buildUnableToPopLexerModeMessage?(token: IToken): string
 }
 
 /**


### PR DESCRIPTION
The docs/examples seem to imply that ILexerErrorMessageProvider's methods are optional to implement, in the same way that IParserErrorMessageProvider's are. See here: https://github.com/SAP/chevrotain/blob/master/examples/lexer/custom_errors/custom_errors.js where only one of the methods are implemented.