### PR TITLE
Fix code example in backtracking docs

### DIFF
--- a/packages/chevrotain/docs/features/backtracking.md
+++ b/packages/chevrotain/docs/features/backtracking.md
@@ -32,11 +32,11 @@ the alternatives (in order) instead of trying to choose one using a limited toke
 $.RULE("statement", () => {
     $.OR([
         {
-            GATE: () => $.BACKTRACK($.longRule1),
+            GATE: $.BACKTRACK($.longRule1),
             ALT: () => $.SUBRULE($.longRule1)
         },
         {
-            GATE: () => $.BACKTRACK($.longRule2),
+            GATE: $.BACKTRACK($.longRule2),
             ALT: () => $.SUBRULE($.longRule2)
         }
     ])


### PR DESCRIPTION
Fixing code example as using `BACKTRACK` in `GATE` does not require wrapping in function