### PR TITLE
static type checking without any runtime code in api.ts

### DIFF
--- a/packages/chevrotain/src/api.ts
+++ b/packages/chevrotain/src/api.ts
@@ -216,8 +216,11 @@ API.EmbeddedActionsParser = EmbeddedActionsParser as any
 
 // TypeCheck Multi Trait Parser API against official Chevrotain API
 // The only thing this does not check is the constructor signature.
-const mixedDummyInstance: MixedInParser = null
-const officalDummyInstance: defs.Parser = mixedDummyInstance
+type AssertTrue<T extends true> = T
+
+type AssertMixedInParserExtendsParser = AssertTrue<
+    MixedInParser extends defs.Parser ? true : false
+>
 
 API.ParserDefinitionErrorType = ParserDefinitionErrorType
 API.Lexer = Lexer


### PR DESCRIPTION
In the original codes, two variables are declared and assigned in typescript, to ensure that `MixedInParser` extends `defs.Parser`.

https://github.com/SAP/chevrotain/blob/87ed262c36b6f5cb4073e14f4f59901146c6c7a5/packages/chevrotain/src/api.ts#L219-L220

So in the js build, they remain, which is useless and should be omitted:

```js
// part of lib/src/api.js
var mixedDummyInstance = null;
var officalDummyInstance = mixedDummyInstance;
```

So static type checking is used in this pull request to assert `TypeA extends TypeB`. No need for runtime assignment anymore.