### PR TITLE
Optimize Lexer Startup time.

### DIFF
--- a/examples/grammars/package.json
+++ b/examples/grammars/package.json
@@ -9,6 +9,7 @@
     },
     "devDependencies": {
         "acorn": "^7.0.0",
+        "benchmark": "^2.1.4",
         "xregexp": "^4.2.0"
     },
     "private": true

--- a/packages/chevrotain/src/parse/parser/traits/recognizer_engine.ts
+++ b/packages/chevrotain/src/parse/parser/traits/recognizer_engine.ts
@@ -838,7 +838,7 @@ export class RecognizerEngine {
         // NOOP when cst is disabled
         this.cstFinallyStateUpdate()
 
-        if (this.RULE_STACK.length === 0 && !this.isAtEndOfInput()) {
+        if (this.RULE_STACK.length === 0 && this.isAtEndOfInput() === false) {
             let firstRedundantTok = this.LA(1)
             let errMsg = this.errorMessageProvider.buildNotAllInputParsedMessage(
                 {

--- a/packages/chevrotain/src/scan/lexer.ts
+++ b/packages/chevrotain/src/scan/lexer.ts
@@ -1,4 +1,4 @@
-import { BaseRegExpVisitor, RegExpParser } from "regexp-to-ast"
+import { BaseRegExpVisitor } from "regexp-to-ast"
 import { tokenName } from "./tokens_public"
 import { IRegExpExec, Lexer, LexerDefinitionErrorType } from "./lexer_public"
 import {
@@ -39,8 +39,7 @@ import {
     IToken,
     TokenType
 } from "../../api"
-
-const regExpParser = new RegExpParser()
+import { getRegExpAst } from "./reg_exp_parser"
 
 const PATTERN = "PATTERN"
 export const DEFAULT_MODE = "defaultMode"
@@ -158,7 +157,6 @@ export function analyzeTokenTypes(
             // ICustomPattern
             return currPattern
         } else if (typeof currPattern === "string") {
-            // IGNORE ABOVE ELSE
             if (currPattern.length === 1) {
                 return currPattern
             } else {
@@ -266,13 +264,6 @@ export function analyzeTokenTypes(
         }
     })
 
-    function addToMapOfArrays(map, key, value) {
-        if (map[key] === undefined) {
-            map[key] = []
-        }
-        map[key].push(value)
-    }
-
     let canBeOptimized = true
     let charCodeToPatternIdxToConfig = []
 
@@ -281,15 +272,32 @@ export function analyzeTokenTypes(
             onlyRelevantTypes,
             (result, currTokType, idx) => {
                 if (typeof currTokType.PATTERN === "string") {
-                    const key = currTokType.PATTERN.charCodeAt(0)
-                    addToMapOfArrays(result, key, patternIdxToConfig[idx])
+                    const charCode = currTokType.PATTERN.charCodeAt(0)
+                    const optimizedIdx = charCodeToOptimizedIndex(charCode)
+                    addToMapOfArrays(
+                        result,
+                        optimizedIdx,
+                        patternIdxToConfig[idx]
+                    )
                 } else if (isArray(currTokType.START_CHARS_HINT)) {
+                    let lastOptimizedIdx
                     forEach(currTokType.START_CHARS_HINT, charOrInt => {
-                        const key =
+                        const charCode =
                             typeof charOrInt === "string"
                                 ? charOrInt.charCodeAt(0)
                                 : charOrInt
-                        addToMapOfArrays(result, key, patternIdxToConfig[idx])
+                        const currOptimizedIdx = charCodeToOptimizedIndex(
+                            charCode
+                        )
+                        // Avoid adding the config multiple times
+                        if (lastOptimizedIdx !== currOptimizedIdx) {
+                            lastOptimizedIdx = currOptimizedIdx
+                            addToMapOfArrays(
+                                result,
+                                currOptimizedIdx,
+                                patternIdxToConfig[idx]
+                            )
+                        }
                     })
                 } else if (isRegExp(currTokType.PATTERN)) {
                     if (currTokType.PATTERN.unicode) {
@@ -304,11 +312,11 @@ export function analyzeTokenTypes(
                             )
                         }
                     } else {
-                        const startCodes = getStartCodes(
+                        // TODO: optimize me - much of the work is done here...
+                        let startCodes = getStartCodes(
                             currTokType.PATTERN,
                             options.ensureOptimizations
                         )
-
                         /* istanbul ignore if */
                         // start code will only be empty given an empty regExp or failure of regexp-to-ast library
                         // the first should be a different validation and the second cannot be tested.
@@ -318,12 +326,20 @@ export function analyzeTokenTypes(
                             // Not actually sure this is an error, no debug message
                             canBeOptimized = false
                         }
+                        let lastOptimizedIdx
                         forEach(startCodes, code => {
-                            addToMapOfArrays(
-                                result,
-                                code,
-                                patternIdxToConfig[idx]
+                            const currOptimizedIdx = charCodeToOptimizedIndex(
+                                code
                             )
+                            // Avoid adding the config multiple times
+                            if (lastOptimizedIdx !== currOptimizedIdx) {
+                                lastOptimizedIdx = currOptimizedIdx
+                                addToMapOfArrays(
+                                    result,
+                                    currOptimizedIdx,
+                                    patternIdxToConfig[idx]
+                                )
+                            }
                         })
                     }
                 } else {
@@ -346,9 +362,7 @@ export function analyzeTokenTypes(
         )
     }
 
-    if (canBeOptimized && charCodeToPatternIdxToConfig.length < 65536) {
-        charCodeToPatternIdxToConfig = packArray(charCodeToPatternIdxToConfig)
-    }
+    charCodeToPatternIdxToConfig = packArray(charCodeToPatternIdxToConfig)
 
     return {
         emptyGroups: emptyGroups,
@@ -479,7 +493,7 @@ export function findEndOfInputAnchor(
         const pattern = currType[PATTERN]
 
         try {
-            const regexpAst = regExpParser.pattern(pattern.toString())
+            const regexpAst = getRegExpAst(pattern)
             const endAnchorVisitor = new EndAnchorFinder()
             endAnchorVisitor.visit(regexpAst)
 
@@ -546,7 +560,7 @@ export function findStartOfInputAnchor(
     let invalidRegex = filter(tokenTypes, currType => {
         const pattern = currType[PATTERN]
         try {
-            const regexpAst = regExpParser.pattern(pattern.toString())
+            const regexpAst = getRegExpAst(pattern)
             const startAnchorVisitor = new StartAnchorFinder()
             startAnchorVisitor.visit(regexpAst)
 
@@ -845,9 +859,8 @@ export function performRuntimeChecks(
     ) {
         errors.push({
             message:
-                `A MultiMode Lexer cannot be initialized with a ${DEFAULT_MODE}: <${
-                    lexerDefinition.defaultMode
-                }>` + `which does not exist\n`,
+                `A MultiMode Lexer cannot be initialized with a ${DEFAULT_MODE}: <${lexerDefinition.defaultMode}>` +
+                `which does not exist\n`,
             type:
                 LexerDefinitionErrorType.MULTI_MODE_LEXER_DEFAULT_MODE_VALUE_DOES_NOT_EXIST
         })
@@ -1085,4 +1098,33 @@ function getCharCodes(charsOrCodes: (number | string)[]): number[] {
     })
 
     return charCodes
+}
+
+function addToMapOfArrays(map, key, value): void {
+    if (map[key] === undefined) {
+        map[key] = [value]
+    } else {
+        map[key].push(value)
+    }
+}
+
+/**
+ * We ae mapping charCode above ASCI (256) into buckets each in the size of 256.
+ * This is because ASCI are the most common start chars so each one of those will get its own
+ * possible token configs vector.
+ *
+ * Tokens starting with charCodes "above" ASCI are uncommon, so we can "afford"
+ * to place these into buckets of possible token configs, What we gain from
+ * this is avoiding the case of creating an optimization 'charCodeToPatternIdxToConfig'
+ * which would contain 10,000+ arrays of small size (e.g unicode Identifiers scenario).
+ * Our 'charCodeToPatternIdxToConfig' max size will now be:
+ * 256 + (2^16 / 2^8) - 1 === 511
+ *
+ * note the hack for fast division integer part extraction
+ * See: https://stackoverflow.com/a/4228528
+ */
+export function charCodeToOptimizedIndex(charCode) {
+    /* tslint:disable */
+    return charCode > 255 ? 255 + ~~(charCode / 255) : charCode
+    /* tslint:enable */
 }

--- a/packages/chevrotain/src/scan/reg_exp.ts
+++ b/packages/chevrotain/src/scan/reg_exp.ts
@@ -1,4 +1,4 @@
-import { RegExpParser, VERSION, BaseRegExpVisitor } from "regexp-to-ast"
+import { VERSION, BaseRegExpVisitor } from "regexp-to-ast"
 import {
     flatten,
     map,
@@ -10,8 +10,8 @@ import {
     isArray,
     every
 } from "../utils/utils"
+import { getRegExpAst } from "./reg_exp_parser"
 
-const regExpParser = new RegExpParser()
 const complementErrorMessage =
     "Complement Sets are not supported for first char optimization"
 export const failedOptimizationPrefixMsg =
@@ -22,7 +22,7 @@ export function getStartCodes(
     ensureOptimizations = false
 ): number[] {
     try {
-        const ast = regExpParser.pattern(regExp.toString())
+        const ast = getRegExpAst(regExp)
         let firstChars = firstChar(ast.value)
         if (ast.flags.ignoreCase) {
             firstChars = applyIgnoreCase(firstChars)
@@ -248,7 +248,7 @@ export function canMatchCharCode(
     pattern: RegExp | string
 ) {
     if (pattern instanceof RegExp) {
-        const ast = regExpParser.pattern(pattern.toString())
+        const ast = getRegExpAst(pattern)
         const charCodeFinder = new CharCodeFinder(charCodes)
         charCodeFinder.visit(ast)
         return charCodeFinder.found

--- a/packages/chevrotain/src/scan/reg_exp_parser.ts
+++ b/packages/chevrotain/src/scan/reg_exp_parser.ts
@@ -1,0 +1,19 @@
+import { RegExpParser, RegExpPattern } from "regexp-to-ast"
+
+let regExpAstCache = {}
+const regExpParser = new RegExpParser()
+
+export function getRegExpAst(regExp: RegExp): RegExpPattern {
+    const regExpStr = regExp.toString()
+    if (regExpAstCache.hasOwnProperty(regExpStr)) {
+        return regExpAstCache[regExpStr]
+    } else {
+        const regExpAst = regExpParser.pattern(regExpStr)
+        regExpAstCache[regExpStr] = regExpAst
+        return regExpAst
+    }
+}
+
+export function clearRegExpParserCache() {
+    regExpAstCache = {}
+}

--- a/packages/chevrotain/test/scan/lexer_spec.ts
+++ b/packages/chevrotain/test/scan/lexer_spec.ts
@@ -2045,35 +2045,6 @@ skipOnBrowser("debugging and messages and optimizations", () => {
         )
     })
 
-    it("won't pack first char optimizations array for too large arrays", () => {
-        // without hints we expect the lexer
-        const PileOfPooNoHints = createToken({
-            name: "PileOfPoo",
-            pattern: /💩/
-        })
-        const pooLexerNoHints = new Lexer([PileOfPooNoHints], {
-            positionTracking: "onlyOffset"
-        })
-        expect(
-            keys(
-                (<any>pooLexerNoHints).charCodeToPatternIdxToConfig.defaultMode
-            ).length
-        ).to.equal("💩".charCodeAt(0) + 1)
-
-        const PileOfPoo = createToken({
-            name: "PileOfPoo",
-            pattern: /💩/,
-            start_chars_hint: [100000]
-        })
-        const pooLexer = new Lexer([PileOfPoo], {
-            positionTracking: "onlyOffset"
-        })
-        expect(
-            keys((<any>pooLexer).charCodeToPatternIdxToConfig.defaultMode)
-                .length
-        ).to.equal(1)
-    })
-
     it("won't optimize with safe mode enabled", () => {
         const Alpha = createToken({
             name: "A",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2614,6 +2614,14 @@ before-after-hook@^2.0.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
   integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
 
+benchmark@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/benchmark/-/benchmark-2.1.4.tgz#09f3de31c916425d498cc2ee565a0ebf3c2a5629"
+  integrity sha1-CfPeMckWQl1JjMLuVloOvzwqVik=
+  dependencies:
+    lodash "^4.17.4"
+    platform "^1.3.3"
+
 better-assert@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/better-assert/-/better-assert-1.0.2.tgz#40866b9e1b9e0b55b481894311e68faffaebc522"
@@ -9142,6 +9150,11 @@ pkg-up@^2.0.0:
   integrity sha1-yBmscoBZpGHKscOImivjxJoATX8=
   dependencies:
     find-up "^2.1.0"
+
+platform@^1.3.3:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.5.tgz#fb6958c696e07e2918d2eeda0f0bc9448d733444"
+  integrity sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==
 
 please-upgrade-node@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
- Only Parse RegExp Sources once.
- Use "buckets" in first char optimiztions to avoid potentially creating many many small arrays.