### PR TITLE
Optimize Lexer Startup time.

### DIFF
--- a/packages/chevrotain/benchmark_web/index.html
+++ b/packages/chevrotain/benchmark_web/index.html
@@ -279,33 +279,40 @@
 
             var matchingDevSuiteName = _.replace(suite.name, /_.+/, "_Dev")
             var matchingDevSuite = _.find(event.currentTarget, (currSuite) => currSuite.name === matchingDevSuiteName )
-            if (_.endsWith(suite.name, "Latest") && matchingDevSuite.hz) {
-                var latestSuite = suite
-                var $latestCell = $('.' + latestSuite.name + ' .benchSpeed')
-                // always relative to the latest
-                $latestCell.html('100%')
+            try {
+                if (_.endsWith(suite.name, "Latest") && matchingDevSuite.hz) {
+                    var latestSuite = suite
+                    var $latestCell = $('.' + latestSuite.name + ' .benchSpeed')
+                    // always relative to the latest
+                    $latestCell.html('100%')
 
-                var $devCell = $('.' + matchingDevSuite.name + ' .benchSpeed')
-                var speed = ((matchingDevSuite.hz / latestSuite.hz).toFixed(4) * 100).toFixed(2)
-                $devCell.html(speed + '%')
+                    var $devCell = $('.' + matchingDevSuite.name + ' .benchSpeed')
+                    var speed = ((matchingDevSuite.hz / latestSuite.hz).toFixed(4) * 100).toFixed(2)
+                    $devCell.html(speed + '%')
+                }
+            }
+            catch (e) {
+                console.warn(e)
             }
         }).on('complete', function() {
 
-            var suites = this.filter('successful')
-                , fastestSuite = this.filter('fastest')[0]
+            try {
+                var suites = this.filter('successful')
+                    , fastestSuite = this.filter('fastest')[0]
 
-            suites.splice(suites.indexOf(fastestSuite), 1)
+                suites.splice(suites.indexOf(fastestSuite), 1)
 
-            window.clearInterval(dots)
-            $('#wait').html('&nbsp;')
-
-            // TODO: investigate hack around strange race condition
-            setTimeout(function() {
-                $("#runAllButton").prop('disabled', false)
-                $("#runAllButton_lexer").prop('disabled', false)
-                $("#runAllButton_parser").prop('disabled', false)
-            }, 1000)
-
+                window.clearInterval(dots)
+                $('#wait').html('&nbsp;')
+            }
+            finally {
+                // TODO: investigate hack around strange race condition
+                setTimeout(function() {
+                    $("#runAllButton").prop('disabled', false)
+                    $("#runAllButton_lexer").prop('disabled', false)
+                    $("#runAllButton_parser").prop('disabled', false)
+                }, 1000)
+            }
         }).run({'async': true})
     }
 

--- a/packages/chevrotain/src/parse/parser/traits/recognizer_engine.ts
+++ b/packages/chevrotain/src/parse/parser/traits/recognizer_engine.ts
@@ -838,7 +838,7 @@ export class RecognizerEngine {
         // NOOP when cst is disabled
         this.cstFinallyStateUpdate()
 
-        if (this.RULE_STACK.length === 0 && !this.isAtEndOfInput()) {
+        if (this.RULE_STACK.length === 0 && this.isAtEndOfInput() === false) {
             let firstRedundantTok = this.LA(1)
             let errMsg = this.errorMessageProvider.buildNotAllInputParsedMessage(
                 {

--- a/packages/chevrotain/src/scan/lexer.ts
+++ b/packages/chevrotain/src/scan/lexer.ts
@@ -1,4 +1,4 @@
-import { BaseRegExpVisitor, RegExpParser } from "regexp-to-ast"
+import { BaseRegExpVisitor } from "regexp-to-ast"
 import { tokenName } from "./tokens_public"
 import { IRegExpExec, Lexer, LexerDefinitionErrorType } from "./lexer_public"
 import {
@@ -39,8 +39,7 @@ import {
     IToken,
     TokenType
 } from "../../api"
-
-const regExpParser = new RegExpParser()
+import { getRegExpAst } from "./reg_exp_parser"
 
 const PATTERN = "PATTERN"
 export const DEFAULT_MODE = "defaultMode"
@@ -94,6 +93,8 @@ export function analyzeTokenTypes(
         positionTracking: "full",
         lineTerminatorCharacters: ["\r", "\n"]
     })
+
+    initCharCodeToOptimizedIndexMap()
 
     let onlyRelevantTypes = reject(tokenTypes, currType => {
         return currType[PATTERN] === Lexer.NA
@@ -158,7 +159,6 @@ export function analyzeTokenTypes(
             // ICustomPattern
             return currPattern
         } else if (typeof currPattern === "string") {
-            // IGNORE ABOVE ELSE
             if (currPattern.length === 1) {
                 return currPattern
             } else {
@@ -266,13 +266,6 @@ export function analyzeTokenTypes(
         }
     })
 
-    function addToMapOfArrays(map, key, value) {
-        if (map[key] === undefined) {
-            map[key] = []
-        }
-        map[key].push(value)
-    }
-
     let canBeOptimized = true
     let charCodeToPatternIdxToConfig = []
 
@@ -281,15 +274,32 @@ export function analyzeTokenTypes(
             onlyRelevantTypes,
             (result, currTokType, idx) => {
                 if (typeof currTokType.PATTERN === "string") {
-                    const key = currTokType.PATTERN.charCodeAt(0)
-                    addToMapOfArrays(result, key, patternIdxToConfig[idx])
+                    const charCode = currTokType.PATTERN.charCodeAt(0)
+                    const optimizedIdx = charCodeToOptimizedIndex(charCode)
+                    addToMapOfArrays(
+                        result,
+                        optimizedIdx,
+                        patternIdxToConfig[idx]
+                    )
                 } else if (isArray(currTokType.START_CHARS_HINT)) {
+                    let lastOptimizedIdx
                     forEach(currTokType.START_CHARS_HINT, charOrInt => {
-                        const key =
+                        const charCode =
                             typeof charOrInt === "string"
                                 ? charOrInt.charCodeAt(0)
                                 : charOrInt
-                        addToMapOfArrays(result, key, patternIdxToConfig[idx])
+                        const currOptimizedIdx = charCodeToOptimizedIndex(
+                            charCode
+                        )
+                        // Avoid adding the config multiple times
+                        if (lastOptimizedIdx !== currOptimizedIdx) {
+                            lastOptimizedIdx = currOptimizedIdx
+                            addToMapOfArrays(
+                                result,
+                                currOptimizedIdx,
+                                patternIdxToConfig[idx]
+                            )
+                        }
                     })
                 } else if (isRegExp(currTokType.PATTERN)) {
                     if (currTokType.PATTERN.unicode) {
@@ -304,11 +314,11 @@ export function analyzeTokenTypes(
                             )
                         }
                     } else {
-                        const startCodes = getStartCodes(
+                        // TODO: optimize me - much of the work is done here...
+                        let startCodes = getStartCodes(
                             currTokType.PATTERN,
                             options.ensureOptimizations
                         )
-
                         /* istanbul ignore if */
                         // start code will only be empty given an empty regExp or failure of regexp-to-ast library
                         // the first should be a different validation and the second cannot be tested.
@@ -318,12 +328,20 @@ export function analyzeTokenTypes(
                             // Not actually sure this is an error, no debug message
                             canBeOptimized = false
                         }
+                        let lastOptimizedIdx
                         forEach(startCodes, code => {
-                            addToMapOfArrays(
-                                result,
-                                code,
-                                patternIdxToConfig[idx]
+                            const currOptimizedIdx = charCodeToOptimizedIndex(
+                                code
                             )
+                            // Avoid adding the config multiple times
+                            if (lastOptimizedIdx !== currOptimizedIdx) {
+                                lastOptimizedIdx = currOptimizedIdx
+                                addToMapOfArrays(
+                                    result,
+                                    currOptimizedIdx,
+                                    patternIdxToConfig[idx]
+                                )
+                            }
                         })
                     }
                 } else {
@@ -346,9 +364,7 @@ export function analyzeTokenTypes(
         )
     }
 
-    if (canBeOptimized && charCodeToPatternIdxToConfig.length < 65536) {
-        charCodeToPatternIdxToConfig = packArray(charCodeToPatternIdxToConfig)
-    }
+    charCodeToPatternIdxToConfig = packArray(charCodeToPatternIdxToConfig)
 
     return {
         emptyGroups: emptyGroups,
@@ -479,7 +495,7 @@ export function findEndOfInputAnchor(
         const pattern = currType[PATTERN]
 
         try {
-            const regexpAst = regExpParser.pattern(pattern.toString())
+            const regexpAst = getRegExpAst(pattern)
             const endAnchorVisitor = new EndAnchorFinder()
             endAnchorVisitor.visit(regexpAst)
 
@@ -546,7 +562,7 @@ export function findStartOfInputAnchor(
     let invalidRegex = filter(tokenTypes, currType => {
         const pattern = currType[PATTERN]
         try {
-            const regexpAst = regExpParser.pattern(pattern.toString())
+            const regexpAst = getRegExpAst(pattern)
             const startAnchorVisitor = new StartAnchorFinder()
             startAnchorVisitor.visit(regexpAst)
 
@@ -845,9 +861,8 @@ export function performRuntimeChecks(
     ) {
         errors.push({
             message:
-                `A MultiMode Lexer cannot be initialized with a ${DEFAULT_MODE}: <${
-                    lexerDefinition.defaultMode
-                }>` + `which does not exist\n`,
+                `A MultiMode Lexer cannot be initialized with a ${DEFAULT_MODE}: <${lexerDefinition.defaultMode}>` +
+                `which does not exist\n`,
             type:
                 LexerDefinitionErrorType.MULTI_MODE_LEXER_DEFAULT_MODE_VALUE_DOES_NOT_EXIST
         })
@@ -1085,4 +1100,49 @@ function getCharCodes(charsOrCodes: (number | string)[]): number[] {
     })
 
     return charCodes
+}
+
+function addToMapOfArrays(map, key, value): void {
+    if (map[key] === undefined) {
+        map[key] = [value]
+    } else {
+        map[key].push(value)
+    }
+}
+
+/**
+ * We ae mapping charCode above ASCI (256) into buckets each in the size of 256.
+ * This is because ASCI are the most common start chars so each one of those will get its own
+ * possible token configs vector.
+ *
+ * Tokens starting with charCodes "above" ASCI are uncommon, so we can "afford"
+ * to place these into buckets of possible token configs, What we gain from
+ * this is avoiding the case of creating an optimization 'charCodeToPatternIdxToConfig'
+ * which would contain 10,000+ arrays of small size (e.g unicode Identifiers scenario).
+ * Our 'charCodeToPatternIdxToConfig' max size will now be:
+ * 256 + (2^16 / 2^8) - 1 === 511
+ *
+ * note the hack for fast division integer part extraction
+ * See: https://stackoverflow.com/a/4228528
+ */
+export function charCodeToOptimizedIndex(charCode) {
+    return charCode < 256 ? charCode : charCodeToOptimizedIdxMap[charCode]
+}
+
+/**
+ * This is a compromise between cold start / hot running performance
+ * Creating this array takes ~3ms on a modern machine,
+ * But if we perform the computation at runtime as needed the CSS Lexer benchmark
+ * performance degrades by ~10%
+ */
+let charCodeToOptimizedIdxMap = []
+function initCharCodeToOptimizedIndexMap() {
+    if (isEmpty(charCodeToOptimizedIdxMap)) {
+        charCodeToOptimizedIdxMap = new Array(65536)
+        for (let i = 0; i < 65536; i++) {
+            /* tslint:disable */
+            charCodeToOptimizedIdxMap[i] = i > 255 ? 255 + ~~(i / 255) : i
+            /* tslint:enable */
+        }
+    }
 }

--- a/packages/chevrotain/src/scan/reg_exp.ts
+++ b/packages/chevrotain/src/scan/reg_exp.ts
@@ -63,9 +63,14 @@ export function getStartCodes(
     return []
 }
 
+// TODO:
+//  1. Try to use some map to collect data
+//  2. Do we have duplicates here which will affect runtime performance?
+//  3. Try to use a Set in ES6 if we are running in a relevant runtime?
 export function firstChar(ast): number[] {
     switch (ast.type) {
         case "Disjunction":
+            // TODO: Avoid flatten it is resource intensive
             return flatten(map(ast.value, firstChar))
         case "Alternative":
             const startChars = []

--- a/packages/chevrotain/src/scan/reg_exp.ts
+++ b/packages/chevrotain/src/scan/reg_exp.ts
@@ -8,25 +8,28 @@ import {
     PRINT_WARNING,
     find,
     isArray,
-    every
+    every,
+    values
 } from "../utils/utils"
 import { getRegExpAst } from "./reg_exp_parser"
+import { charCodeToOptimizedIndex } from "./lexer"
 
 const complementErrorMessage =
     "Complement Sets are not supported for first char optimization"
 export const failedOptimizationPrefixMsg =
     'Unable to use "first char" lexer optimizations:\n'
 
-export function getStartCodes(
+export function getOptimizedStartCodesIndices(
     regExp: RegExp,
     ensureOptimizations = false
 ): number[] {
     try {
         const ast = getRegExpAst(regExp)
-        let firstChars = firstChar(ast.value)
-        if (ast.flags.ignoreCase) {
-            firstChars = applyIgnoreCase(firstChars)
-        }
+        const firstChars = firstCharOptimizedIndices(
+            ast.value,
+            {},
+            ast.flags.ignoreCase
+        )
 
         return firstChars
     } catch (e) {
@@ -63,17 +66,14 @@ export function getStartCodes(
     return []
 }
 
-// TODO:
-//  1. Try to use some map to collect data
-//  2. Do we have duplicates here which will affect runtime performance?
-//  3. Try to use a Set in ES6 if we are running in a relevant runtime?
-export function firstChar(ast): number[] {
+export function firstCharOptimizedIndices(ast, result, ignoreCase): number[] {
     switch (ast.type) {
         case "Disjunction":
-            // TODO: Avoid flatten it is resource intensive
-            return flatten(map(ast.value, firstChar))
+            forEach(ast.value, subAst =>
+                firstCharOptimizedIndices(subAst, result, ignoreCase)
+            )
+            break
         case "Alternative":
-            const startChars = []
             const terms = ast.value
             for (let i = 0; i < terms.length; i++) {
                 const term = terms[i]
@@ -102,33 +102,50 @@ export function firstChar(ast): number[] {
                 const atom = term
                 switch (atom.type) {
                     case "Character":
-                        startChars.push(atom.value)
+                        addOptimizedIdxToResult(atom.value, result, ignoreCase)
                         break
                     case "Set":
                         if (atom.complement === true) {
                             throw Error(complementErrorMessage)
                         }
-
-                        // TODO: this may still be slow when there are many codes
                         forEach(atom.value, code => {
                             if (typeof code === "number") {
-                                startChars.push(code)
+                                addOptimizedIdxToResult(
+                                    code,
+                                    result,
+                                    ignoreCase
+                                )
                             } else {
-                                //range
+                                // range
                                 const range = code
                                 for (
                                     let rangeCode = range.from;
                                     rangeCode <= range.to;
                                     rangeCode++
                                 ) {
-                                    startChars.push(rangeCode)
+                                    // TODO: this could potentially be optimized
+                                    //       to traverse the range in jumps the size of the optimizedIndices buckets
+                                    //       However there are too many edge cases for such an optimization...
+                                    //       and it needs a grammar to have **many** different tokens
+                                    //       starting with **very wide** range of charCodes
+                                    //       in order to gain a **small** benefit during initialization...
+                                    //       Also the init time boost could also be accomplished directly by the end user
+                                    //       By providing the startCharHints, so handling it is not worth it.
+                                    addOptimizedIdxToResult(
+                                        rangeCode,
+                                        result,
+                                        ignoreCase
+                                    )
                                 }
                             }
                         })
                         break
                     case "Group":
-                        const groupCodes = firstChar(atom.value)
-                        forEach(groupCodes, code => startChars.push(code))
+                        firstCharOptimizedIndices(
+                            atom.value,
+                            result,
+                            ignoreCase
+                        )
                         break
                     /* istanbul ignore next */
                     default:
@@ -150,29 +167,47 @@ export function firstChar(ast): number[] {
                     break
                 }
             }
-
-            return startChars
+            break
         /* istanbul ignore next */
         default:
             throw Error("non exhaustive match!")
     }
+
+    // console.log(Object.keys(result).length)
+    return values(result)
 }
 
-export function applyIgnoreCase(firstChars: number[]): number[] {
-    const firstCharsCase = []
-    forEach(firstChars, charCode => {
-        firstCharsCase.push(charCode)
+function addOptimizedIdxToResult(
+    code: number,
+    result: number[],
+    ignoreCase: boolean
+) {
+    const optimizedCharIdx = charCodeToOptimizedIndex(code)
+    result[optimizedCharIdx] = optimizedCharIdx
 
-        const char = String.fromCharCode(charCode)
-        /* istanbul ignore else */
-        if (char.toUpperCase() !== char) {
-            firstCharsCase.push(char.toUpperCase().charCodeAt(0))
-        } else if (char.toLowerCase() !== char) {
-            firstCharsCase.push(char.toLowerCase().charCodeAt(0))
+    if (ignoreCase === true) {
+        handleIgnoreCase(code, result)
+    }
+}
+
+function handleIgnoreCase(code: number, result: number[]) {
+    const char = String.fromCharCode(code)
+    const upperChar = char.toUpperCase()
+    /* istanbul ignore else */
+    if (upperChar !== char) {
+        const optimizedCharIdx = charCodeToOptimizedIndex(
+            upperChar.charCodeAt(0)
+        )
+        result[optimizedCharIdx] = optimizedCharIdx
+    } else {
+        const lowerChar = char.toLowerCase()
+        if (lowerChar !== char) {
+            const optimizedCharIdx = charCodeToOptimizedIndex(
+                lowerChar.charCodeAt(0)
+            )
+            result[optimizedCharIdx] = optimizedCharIdx
         }
-    })
-
-    return firstCharsCase
+    }
 }
 
 function findCode(setNode, targetCharCodes) {
@@ -215,6 +250,11 @@ class CharCodeFinder extends BaseRegExpVisitor {
     }
 
     visitChildren(node) {
+        // No need to keep looking...
+        if (this.found === true) {
+            return
+        }
+
         // switch lookaheads as they do not actually consume any characters thus
         // finding a charCode at lookahead context does not mean that regexp can actually contain it in a match.
         switch (node.type) {

--- a/packages/chevrotain/src/scan/reg_exp.ts
+++ b/packages/chevrotain/src/scan/reg_exp.ts
@@ -1,4 +1,4 @@
-import { RegExpParser, VERSION, BaseRegExpVisitor } from "regexp-to-ast"
+import { VERSION, BaseRegExpVisitor } from "regexp-to-ast"
 import {
     flatten,
     map,
@@ -10,8 +10,8 @@ import {
     isArray,
     every
 } from "../utils/utils"
+import { getRegExpAst } from "./reg_exp_parser"
 
-const regExpParser = new RegExpParser()
 const complementErrorMessage =
     "Complement Sets are not supported for first char optimization"
 export const failedOptimizationPrefixMsg =
@@ -22,7 +22,7 @@ export function getStartCodes(
     ensureOptimizations = false
 ): number[] {
     try {
-        const ast = regExpParser.pattern(regExp.toString())
+        const ast = getRegExpAst(regExp)
         let firstChars = firstChar(ast.value)
         if (ast.flags.ignoreCase) {
             firstChars = applyIgnoreCase(firstChars)
@@ -248,7 +248,7 @@ export function canMatchCharCode(
     pattern: RegExp | string
 ) {
     if (pattern instanceof RegExp) {
-        const ast = regExpParser.pattern(pattern.toString())
+        const ast = getRegExpAst(pattern)
         const charCodeFinder = new CharCodeFinder(charCodes)
         charCodeFinder.visit(ast)
         return charCodeFinder.found

--- a/packages/chevrotain/src/scan/reg_exp_parser.ts
+++ b/packages/chevrotain/src/scan/reg_exp_parser.ts
@@ -1,0 +1,19 @@
+import { RegExpParser, RegExpPattern } from "regexp-to-ast"
+
+let regExpAstCache = {}
+const regExpParser = new RegExpParser()
+
+export function getRegExpAst(regExp: RegExp): RegExpPattern {
+    const regExpStr = regExp.toString()
+    if (regExpAstCache.hasOwnProperty(regExpStr)) {
+        return regExpAstCache[regExpStr]
+    } else {
+        const regExpAst = regExpParser.pattern(regExpStr)
+        regExpAstCache[regExpStr] = regExpAst
+        return regExpAst
+    }
+}
+
+export function clearRegExpParserCache() {
+    regExpAstCache = {}
+}

--- a/packages/chevrotain/test/scan/lexer_spec.ts
+++ b/packages/chevrotain/test/scan/lexer_spec.ts
@@ -2045,35 +2045,6 @@ skipOnBrowser("debugging and messages and optimizations", () => {
         )
     })
 
-    it("won't pack first char optimizations array for too large arrays", () => {
-        // without hints we expect the lexer
-        const PileOfPooNoHints = createToken({
-            name: "PileOfPoo",
-            pattern: /💩/
-        })
-        const pooLexerNoHints = new Lexer([PileOfPooNoHints], {
-            positionTracking: "onlyOffset"
-        })
-        expect(
-            keys(
-                (<any>pooLexerNoHints).charCodeToPatternIdxToConfig.defaultMode
-            ).length
-        ).to.equal("💩".charCodeAt(0) + 1)
-
-        const PileOfPoo = createToken({
-            name: "PileOfPoo",
-            pattern: /💩/,
-            start_chars_hint: [100000]
-        })
-        const pooLexer = new Lexer([PileOfPoo], {
-            positionTracking: "onlyOffset"
-        })
-        expect(
-            keys((<any>pooLexer).charCodeToPatternIdxToConfig.defaultMode)
-                .length
-        ).to.equal(1)
-    })
-
     it("won't optimize with safe mode enabled", () => {
         const Alpha = createToken({
             name: "A",

--- a/packages/chevrotain/test/scan/regexp_spec.ts
+++ b/packages/chevrotain/test/scan/regexp_spec.ts
@@ -1,6 +1,9 @@
 import { createToken } from "../../src/scan/tokens_public"
 import { Lexer } from "../../src/scan/lexer_public"
-import { canMatchCharCode, getStartCodes } from "../../src/scan/reg_exp"
+import {
+    canMatchCharCode,
+    getOptimizedStartCodesIndices
+} from "../../src/scan/reg_exp"
 
 describe("The Chevrotain regexp analysis", () => {
     it("Will re-attempt none 'optimized' patterns if the optimization failed", () => {
@@ -35,44 +38,68 @@ describe("the regExp analysis", () => {
     context("first codes", () => {
         it("can compute for string literal", () => {
             expect(
-                getStartCodes(
+                getOptimizedStartCodesIndices(
                     /"(?:[^\\"]|\\(?:[bfnrtv"\\/]|u[0-9a-fA-F]{4}))*"/
                 )
             ).to.deep.equal([34])
         })
 
         it("can compute with assertions", () => {
-            expect(getStartCodes(/^$\b\Ba/)).to.deep.equal([97])
+            expect(getOptimizedStartCodesIndices(/^$\b\Ba/)).to.deep.equal([97])
         })
 
         it("can compute ranges", () => {
-            expect(getStartCodes(/[\n-\r]/)).to.deep.equal([10, 11, 12, 13])
+            expect(getOptimizedStartCodesIndices(/[\n-\r]/)).to.deep.equal([
+                10,
+                11,
+                12,
+                13
+            ])
         })
 
         it("can compute with optional quantifiers", () => {
-            expect(getStartCodes(/b*a/)).to.deep.equal([98, 97])
+            expect(getOptimizedStartCodesIndices(/b*a/)).to.deep.equal([97, 98])
         })
 
         it("will not compute when using complements", () => {
-            expect(getStartCodes(/\D/)).to.be.empty
+            expect(getOptimizedStartCodesIndices(/\D/)).to.be.empty
         })
 
         it("Can compute for ignore case", () => {
-            expect(getStartCodes(/w|A/i)).to.deep.equal([119, 87, 65, 97])
+            expect(getOptimizedStartCodesIndices(/w|A/i)).to.deep.equal([
+                65,
+                87,
+                97,
+                119
+            ])
         })
 
         it("will not compute when using complements #2", () => {
-            expect(getStartCodes(/[^a-z]/, true)).to.be.empty
+            expect(getOptimizedStartCodesIndices(/[^a-z]/, true)).to.be.empty
         })
 
         it("correctly handles nested groups with and without quantifiers", () => {
-            expect(getStartCodes(/(?:)c/)).to.deep.equal([99])
-            expect(getStartCodes(/((ab)?)c/)).to.deep.equal([97, 99])
-            expect(getStartCodes(/((ab))(c)/)).to.deep.equal([97])
-            expect(getStartCodes(/((ab))?c/)).to.deep.equal([97, 99])
-            expect(getStartCodes(/((a?((b?))))?c/)).to.deep.equal([97, 98, 99])
-            expect(getStartCodes(/((a?((b))))c/)).to.deep.equal([97, 98])
-            expect(getStartCodes(/((a+((b))))c/)).to.deep.equal([97])
+            expect(getOptimizedStartCodesIndices(/(?:)c/)).to.deep.equal([99])
+            expect(getOptimizedStartCodesIndices(/((ab)?)c/)).to.deep.equal([
+                97,
+                99
+            ])
+            expect(getOptimizedStartCodesIndices(/((ab))(c)/)).to.deep.equal([
+                97
+            ])
+            expect(getOptimizedStartCodesIndices(/((ab))?c/)).to.deep.equal([
+                97,
+                99
+            ])
+            expect(
+                getOptimizedStartCodesIndices(/((a?((b?))))?c/)
+            ).to.deep.equal([97, 98, 99])
+            expect(getOptimizedStartCodesIndices(/((a?((b))))c/)).to.deep.equal(
+                [97, 98]
+            )
+            expect(getOptimizedStartCodesIndices(/((a+((b))))c/)).to.deep.equal(
+                [97]
+            )
         })
     })
 


### PR DESCRIPTION
- Only Parse RegExp Sources once.
- Use "buckets" in first char optimiztions to avoid potentially creating many many small arrays.