### PR TITLE
Change CustomPatternMatcherFunc definition to match reality

### DIFF
--- a/packages/chevrotain/api.d.ts
+++ b/packages/chevrotain/api.d.ts
@@ -1624,7 +1624,9 @@ export declare type CustomPatternMatcherFunc = (
     groups: {
         [groupName: string]: IToken[]
     }
-) => RegExpExecArray | null
+) => CustomPatternMatcherReturn | RegExpExecArray | null // RegExpExecArray included for legacy reasons
+
+export type CustomPatternMatcherReturn = [string] & { payload?: any }
 
 export interface TokenType {
     name: string


### PR DESCRIPTION
Fixes #1014. I didn't see the need to create a separate type alias for this, but if you prefer that I'd be happy to change it.