### PR TITLE
Make the type of TokenType.PATTERN equal to ITokenConfig.pattern

### DIFF
--- a/packages/chevrotain/api.d.ts
+++ b/packages/chevrotain/api.d.ts
@@ -1631,7 +1631,7 @@ export type CustomPatternMatcherReturn = [string] & { payload?: any }
 export interface TokenType {
     name: string
     GROUP?: string
-    PATTERN?: RegExp | string
+    PATTERN?: RegExp | string | CustomPatternMatcherFunc | ICustomPattern
     LABEL?: string
     LONGER_ALT?: TokenType
     POP_MODE?: boolean

--- a/packages/chevrotain/api.d.ts
+++ b/packages/chevrotain/api.d.ts
@@ -1477,6 +1477,8 @@ export interface ILineTerminatorsTester {
     lastIndex: number
 }
 
+export type TokenPattern = RegExp | string | CustomPatternMatcherFunc | ICustomPattern
+
 export interface ITokenConfig {
     name: string
 
@@ -1505,7 +1507,7 @@ export interface ITokenConfig {
      *
      * For Custom Patterns see: http://sap.github.io/chevrotain/docs/guide/custom_token_patterns.html
      */
-    pattern?: RegExp | string | CustomPatternMatcherFunc | ICustomPattern
+    pattern?: TokenPattern
 
     /**
      * The group property will cause the lexer to collect
@@ -1631,7 +1633,7 @@ export type CustomPatternMatcherReturn = [string] & { payload?: any }
 export interface TokenType {
     name: string
     GROUP?: string
-    PATTERN?: RegExp | string | CustomPatternMatcherFunc | ICustomPattern
+    PATTERN?: TokenPattern
     LABEL?: string
     LONGER_ALT?: TokenType
     POP_MODE?: boolean

--- a/packages/chevrotain/src/utils/utils.ts
+++ b/packages/chevrotain/src/utils/utils.ts
@@ -251,15 +251,15 @@ export function partial(func: Function, ...restArgs: any[]): Function {
     return Function.bind.apply(func, allArgs)
 }
 
-export function isArray(obj: any): boolean {
+export function isArray(obj: any): obj is any[] {
     return Array.isArray(obj)
 }
 
-export function isRegExp(obj: any): boolean {
+export function isRegExp(obj: any): obj is RegExp {
     return obj instanceof RegExp
 }
 
-export function isObject(obj: any): boolean {
+export function isObject(obj: any): obj is Object {
     return obj instanceof Object
 }
 


### PR DESCRIPTION
The configuration's `pattern` property is directly assigned to a new `TokenType`'s `PATTERN` property, so their typing should be equal as well:

https://github.com/SAP/chevrotain/blob/86fec3e1f47aed1683e9005f94803f37b8086e30/packages/chevrotain/src/scan/tokens_public.ts#L63-L65