### PR TITLE
feat: hard Deprecate `ignoredIssues` IParserConfig property

### DIFF
--- a/packages/chevrotain/api.d.ts
+++ b/packages/chevrotain/api.d.ts
@@ -2125,29 +2125,6 @@ export interface IParserConfig {
    */
   maxLookahead?: number
   /**
-   * @deprecated - use the IGNORE_AMBIGUITIES flag on the relevant DSL method instead
-   *               - {@link IOrAlt.IGNORE_AMBIGUITIES}
-   *               - {@link OrMethodOpts.IGNORE_AMBIGUITIES}
-   *
-   * Used to mark parser definition errors that should be ignored.
-   * For example:
-   *
-   * ```
-   *    {
-   *      myCustomRule : {
-   *                      OR3 : true
-   *                     },
-   *      myOtherRule : {
-   *                     OPTION1 : true,
-   *                     OR4 : true
-   *                    }
-   *    }
-   * ```
-   *
-   * Be careful when ignoring errors, they are usually there for a reason :).
-   */
-  ignoredIssues?: IgnoredParserIssues
-  /**
    * Enable This Flag to to support Dynamically defined Tokens.
    * This will disable performance optimizations which cannot work if the whole Token vocabulary is not known
    * During Parser initialization.
@@ -2207,20 +2184,6 @@ export interface IParserConfig {
    *   - For example: via a conditional that checks an env variable.
    */
   skipValidations?: boolean
-}
-
-/**
- * See: {@link IParserConfig.ignoredIssues}
- */
-export declare type IgnoredParserIssues = {
-  [ruleName: string]: IgnoredRuleIssues
-}
-
-/**
- * See: {@link IParserConfig.ignoredIssues}
- */
-export declare type IgnoredRuleIssues = {
-  [dslNameAndOccurrence: string]: boolean
 }
 
 export interface IParserErrorMessageProvider {
@@ -2760,7 +2723,6 @@ export declare function validateGrammar(options: {
   tokenTypes: TokenType[]
   grammarName: string
   errMsgProvider: IGrammarValidatorErrorMessageProvider
-  ignoredIssues?: IgnoredParserIssues
 }): IParserDefinitionError[]
 
 /**

--- a/packages/chevrotain/docs/.vuepress/config.js
+++ b/packages/chevrotain/docs/.vuepress/config.js
@@ -10,6 +10,7 @@ const versionWithLowDashs = version.replace(/\./g, "_")
 const slugMap = {
   "Common Prefix Ambiguities": "COMMON_PREFIX",
   "Ambiguous Alternatives Detected": "AMBIGUOUS_ALTERNATIVES",
+  "Ignoring Ambiguities": "IGNORING_AMBIGUITIES",
   "Terminal Token Name Not Found": "TERMINAL_NAME_NOT_FOUND",
   "Infinite Loop Detected": "INFINITE_LOOP",
   "No LINE_BREAKS Found": "LINE_BREAKS",

--- a/packages/chevrotain/docs/changes/BREAKING_CHANGES.md
+++ b/packages/chevrotain/docs/changes/BREAKING_CHANGES.md
@@ -14,10 +14,16 @@
   }
   ```
 
-  It is also possible (and recommended) to increase the maxLookahead for a specific method rather thn globally.
+  It is also possible (and recommended) to increase the maxLookahead for a specific DSL method rather then globally for all.
   See [relevant issue](https://github.com/SAP/chevrotain/issues/1012).
 
-* Reducing the usage of 'any' in the 'OR' method type signature may cause existing code to fail compilation.
+- The IParserConfig's `ignoredIssues` property has been deprecated.
+  Any Parser still using this property will throw an exception on initialization.
+  If any ambiguities need be ignored, the `IGNORE_AMBIGUITIES` property should be used instead.
+
+  - see: [Ignoring Ambiguities Docs](https://sap.github.io/chevrotain/docs/guide/resolving_grammar_errors.html#IGNORING_AMBIGUITIES)
+
+- Reducing the usage of 'any' in the 'OR' method type signature may cause existing code to fail compilation.
   In such a case an explicit usage of a generic `any` type will resolve the problem.
   ```typescript
   this.OR<any>(/* ... */)

--- a/packages/chevrotain/docs/guide/resolving_grammar_errors.md
+++ b/packages/chevrotain/docs/guide/resolving_grammar_errors.md
@@ -4,6 +4,7 @@
 - [Ambiguous Alternatives Detected.](#AMBIGUOUS_ALTERNATIVES)
 - [Terminal Token Name Not Found.](#TERMINAL_NAME_NOT_FOUND)
 - [Infinite Loop Detected.](#INFINITE_LOOP)
+- [Ignoring Ambiguities.](#IGNORING_AMBIGUITIES)
 
 ## Common Prefix Ambiguities
 
@@ -46,7 +47,7 @@ There are two ways to resolve this:
 An Ambiguous Alternatives Error occurs when Chevrotain cannot decide between two alternatives in
 an alternation (OR DSL method).
 
-Chevrotain "looks ahead" at most [K (4 by default)][maxlookahead]
+Chevrotain "looks ahead" at most [K (3 by default)][maxlookahead]
 tokens to determine which alternative to pick. An Ambiguous Alternatives Error indicates
 that more than K tokens lookahead is needed.
 
@@ -168,4 +169,37 @@ $.MANY(() => {
 })
 ```
 
+## Ignoring Ambiguities
+
+In some rare cases the Parser may detect ambiguities that are not actually possible or are perhaps implicitly resolved, e.g:
+
+- by the order of alternatives (an alternation alternative is attempted in the order listed).
+
+In such cases the ambiguities may be ignored explicitly by using the [IGNORE_AMBIGUITIES][ignore_ambiguities] property
+on the relevant DSL method.
+
+For example:
+
+- Ignoring all ambiguities of an alternation.
+
+  ```javascript
+  $.OR({
+    IGNORE_AMBIGUITIES: true,
+    DEF: [
+      { ALT: () => $.SUBRULE($.myRule) },
+      { ALT: () => $.SUBRULE($.myOtherRule) }
+    ]
+  })
+  ```
+
+- Ignoring ambiguities related to a **specific alternative** of an alternation:
+
+  ```javascript
+  $.OR([
+    { ALT: () => $.SUBRULE($.myRule), IGNORE_AMBIGUITIES: true },
+    { ALT: () => $.SUBRULE($.myOtherRule) }
+  ])
+  ```
+
 [maxlookahead]: https://sap.github.io/chevrotain/documentation/6_5_0/interfaces/iparserconfig.html#maxlookahead
+[ignore_ambiguities]: https://sap.github.io/chevrotain/documentation/6_5_0/interfaces/ormethodopts.html#ignore_ambiguities

--- a/packages/chevrotain/src/parse/grammar/checks.ts
+++ b/packages/chevrotain/src/parse/grammar/checks.ts
@@ -44,7 +44,6 @@ import {
 } from "./gast/gast_public"
 import { GAstVisitor } from "./gast/gast_visitor_public"
 import {
-  IgnoredParserIssues,
   IGrammarValidatorErrorMessageProvider,
   IOptionallyNamedProduction,
   IParserDefinitionError,
@@ -57,7 +56,6 @@ export function validateGrammar(
   topLevels: Rule[],
   globalMaxLookahead: number,
   tokenTypes: TokenType[],
-  ignoredIssues: IgnoredParserIssues,
   errMsgProvider: IGrammarValidatorErrorMessageProvider,
   grammarName: string
 ): IParserDefinitionError[] {
@@ -82,7 +80,6 @@ export function validateGrammar(
       validateAmbiguousAlternationAlternatives(
         currTopRule,
         globalMaxLookahead,
-        ignoredIssues,
         errMsgProvider
       )
     )
@@ -544,25 +541,11 @@ export function validateEmptyOrAlternative(
 export function validateAmbiguousAlternationAlternatives(
   topLevelRule: Rule,
   globalMaxLookahead: number,
-  ignoredIssues: IgnoredParserIssues,
   errMsgProvider: IGrammarValidatorErrorMessageProvider
 ): IParserAmbiguousAlternativesDefinitionError[] {
   let orCollector = new OrCollector()
   topLevelRule.accept(orCollector)
   let ors = orCollector.alternations
-
-  // TODO: this filtering should be deprecated once we remove the ignoredIssues
-  //  IParserConfig property
-  let ignoredIssuesForCurrentRule = ignoredIssues[topLevelRule.name]
-  if (ignoredIssuesForCurrentRule) {
-    ors = reject(
-      ors,
-      currOr =>
-        ignoredIssuesForCurrentRule[
-          getProductionDslName(currOr) + (currOr.idx === 0 ? "" : currOr.idx)
-        ]
-    )
-  }
 
   // New Handling of ignoring ambiguities
   // - https://github.com/SAP/chevrotain/issues/869

--- a/packages/chevrotain/src/parse/grammar/gast/gast_resolver_public.ts
+++ b/packages/chevrotain/src/parse/grammar/gast/gast_resolver_public.ts
@@ -9,7 +9,6 @@ import {
 } from "../../errors_public"
 import { DslMethodsCollectorVisitor } from "./gast"
 import {
-  IgnoredParserIssues,
   IGrammarResolverErrorMessageProvider,
   IGrammarValidatorErrorMessageProvider,
   IParserDefinitionError,
@@ -38,18 +37,15 @@ export function validateGrammar(options: {
   tokenTypes: TokenType[]
   grammarName: string
   errMsgProvider: IGrammarValidatorErrorMessageProvider
-  ignoredIssues?: IgnoredParserIssues
 }): IParserDefinitionError[] {
   options = defaults(options, {
-    errMsgProvider: defaultGrammarValidatorErrorProvider,
-    ignoredIssues: {}
+    errMsgProvider: defaultGrammarValidatorErrorProvider
   })
 
   return orgValidateGrammar(
     options.rules,
     options.maxLookahead,
     options.tokenTypes,
-    options.ignoredIssues,
     options.errMsgProvider,
     options.grammarName
   )

--- a/packages/chevrotain/src/parse/parser/parser.ts
+++ b/packages/chevrotain/src/parse/parser/parser.ts
@@ -5,7 +5,6 @@ import {
   has,
   isEmpty,
   map,
-  PRINT_WARNING,
   toFastProperties,
   values
 } from "../../utils/utils"
@@ -22,7 +21,6 @@ import {
 } from "../grammar/gast/gast_resolver_public"
 import {
   CstNode,
-  IgnoredParserIssues,
   IParserConfig,
   IParserDefinitionError,
   IRecognitionException,
@@ -63,7 +61,6 @@ export type lookAheadSequence = TokenType[][]
 export const DEFAULT_PARSER_CONFIG: IParserConfig = Object.freeze({
   recoveryEnabled: false,
   maxLookahead: 3,
-  ignoredIssues: <any>{},
   dynamicTokensEnabled: false,
   outputCst: true,
   errorMessageProvider: defaultParserErrorProvider,
@@ -202,7 +199,6 @@ export class Parser {
             rules: values(this.gastProductionsCache),
             maxLookahead: this.maxLookahead,
             tokenTypes: values(this.tokensMap),
-            ignoredIssues: this.ignoredIssues,
             errMsgProvider: defaultGrammarValidatorErrorProvider,
             grammarName: className
           })
@@ -254,7 +250,6 @@ export class Parser {
     })
   }
 
-  ignoredIssues: IgnoredParserIssues = DEFAULT_PARSER_CONFIG.ignoredIssues
   definitionErrors: IParserDefinitionError[] = []
   selfAnalysisDone = false
   protected skipValidations: boolean
@@ -274,19 +269,14 @@ export class Parser {
     that.initGastRecorder(config)
     that.initPerformanceTracer(config)
 
-    /* istanbul ignore if - complete over-kill to test this, we should only add a test when we actually hard deprecate it and throw an error... */
-    if (
-      has(config, "ignoredIssues") &&
-      config.ignoredIssues !== DEFAULT_PARSER_CONFIG.ignoredIssues
-    ) {
-      PRINT_WARNING(
-        "The <ignoredIssues> IParserConfig property is soft-deprecated and will be removed in future versions.\n\t" +
-          "Please use the <IGNORE_AMBIGUITIES> flag on the relevant DSL method instead."
+    if (has(config, "ignoredIssues")) {
+      throw new Error(
+        "The <ignoredIssues> IParserConfig property has been deprecated.\n\t" +
+          "Please use the <IGNORE_AMBIGUITIES> flag on the relevant DSL method instead.\n\t" +
+          "See: https://sap.github.io/chevrotain/docs/guide/resolving_grammar_errors.html#IGNORING_AMBIGUITIES\n\t" +
+          "For further details."
       )
     }
-    this.ignoredIssues = has(config, "ignoredIssues")
-      ? config.ignoredIssues
-      : DEFAULT_PARSER_CONFIG.ignoredIssues
 
     this.skipValidations = has(config, "skipValidations")
       ? config.skipValidations

--- a/packages/chevrotain/test/parse/grammar/checks_spec.ts
+++ b/packages/chevrotain/test/parse/grammar/checks_spec.ts
@@ -109,7 +109,6 @@ describe("the grammar validations", () => {
       [qualifiedNameErr1, qualifiedNameErr2],
       5,
       [],
-      {},
       defaultGrammarValidatorErrorProvider,
       "bamba"
     )

--- a/packages/chevrotain/test/parse/recognizer/recognizer_config_spec.ts
+++ b/packages/chevrotain/test/parse/recognizer/recognizer_config_spec.ts
@@ -31,4 +31,18 @@ describe("The Recognizer's Configuration", () => {
     expect((<any>parser).maxLookahead).to.equal(3)
     expect((<any>parser).nodeLocationTracking).to.be.equal("none")
   })
+
+  it("default config values - no config", () => {
+    const A = createToken({ name: "A" })
+
+    const invalidConfig = { ignoredIssues: {} }
+    class IgnoredIssuesParser extends Parser {
+      constructor() {
+        super([A], invalidConfig as any)
+      }
+    }
+    expect(() => new IgnoredIssuesParser()).to.throw(
+      "The <ignoredIssues> IParserConfig property has been deprecated"
+    )
+  })
 })

--- a/packages/chevrotain/test/parse/recognizer_lookahead_spec.ts
+++ b/packages/chevrotain/test/parse/recognizer_lookahead_spec.ts
@@ -1084,16 +1084,7 @@ describe("lookahead Regular Tokens Mode", () => {
 
       constructor(input: IToken[] = []) {
         super(ALL_TOKENS, {
-          outputCst: false,
-          ignoredIssues: {
-            orRule: {
-              OR: true,
-              OR2: true,
-              OR3: true,
-              OR4: true,
-              OR5: true
-            }
-          }
+          outputCst: false
         })
 
         this.performSelfAnalysis()
@@ -1107,164 +1098,179 @@ describe("lookahead Regular Tokens Mode", () => {
       private parseOrRule(): string {
         let total = ""
 
-        this.OR([
-          {
-            ALT: () => {
-              this.CONSUME1(OneTok)
-              total += "A1"
+        this.OR({
+          IGNORE_AMBIGUITIES: true,
+          DEF: [
+            {
+              ALT: () => {
+                this.CONSUME1(OneTok)
+                total += "A1"
+              }
+            },
+            {
+              ALT: () => {
+                this.CONSUME2(OneTok)
+                total += "OOPS!"
+              }
+            },
+            {
+              ALT: () => {
+                this.CONSUME1(ThreeTok)
+                total += "A3"
+              }
+            },
+            {
+              ALT: () => {
+                this.CONSUME1(FourTok)
+                total += "A4"
+              }
+            },
+            {
+              ALT: () => {
+                this.CONSUME1(FiveTok)
+                total += "A5"
+              }
             }
-          },
-          {
-            ALT: () => {
-              this.CONSUME2(OneTok)
-              total += "OOPS!"
-            }
-          },
-          {
-            ALT: () => {
-              this.CONSUME1(ThreeTok)
-              total += "A3"
-            }
-          },
-          {
-            ALT: () => {
-              this.CONSUME1(FourTok)
-              total += "A4"
-            }
-          },
-          {
-            ALT: () => {
-              this.CONSUME1(FiveTok)
-              total += "A5"
-            }
-          }
-        ])
+          ]
+        })
 
-        this.OR2([
-          {
-            ALT: () => {
-              this.CONSUME2(FourTok)
-              total += "B4"
+        this.OR2({
+          IGNORE_AMBIGUITIES: true,
+          DEF: [
+            {
+              ALT: () => {
+                this.CONSUME2(FourTok)
+                total += "B4"
+              }
+            },
+            {
+              ALT: () => {
+                this.CONSUME2(ThreeTok)
+                total += "B3"
+              }
+            },
+            {
+              ALT: () => {
+                this.CONSUME2(TwoTok)
+                total += "B2"
+              }
+            },
+            {
+              ALT: () => {
+                this.CONSUME3(TwoTok)
+                total += "OOPS!"
+              }
+            },
+            {
+              ALT: () => {
+                this.CONSUME2(FiveTok)
+                total += "B5"
+              }
             }
-          },
-          {
-            ALT: () => {
-              this.CONSUME2(ThreeTok)
-              total += "B3"
-            }
-          },
-          {
-            ALT: () => {
-              this.CONSUME2(TwoTok)
-              total += "B2"
-            }
-          },
-          {
-            ALT: () => {
-              this.CONSUME3(TwoTok)
-              total += "OOPS!"
-            }
-          },
-          {
-            ALT: () => {
-              this.CONSUME2(FiveTok)
-              total += "B5"
-            }
-          }
-        ])
+          ]
+        })
 
-        this.OR3([
-          {
-            ALT: () => {
-              this.CONSUME3(FourTok)
-              total += "C4"
+        this.OR3({
+          IGNORE_AMBIGUITIES: true,
+          DEF: [
+            {
+              ALT: () => {
+                this.CONSUME3(FourTok)
+                total += "C4"
+              }
+            },
+            {
+              ALT: () => {
+                this.CONSUME3(ThreeTok)
+                total += "C3"
+              }
+            },
+            {
+              ALT: () => {
+                this.CONSUME4(ThreeTok)
+                total += "OOPS!"
+              }
+            },
+            {
+              ALT: () => {
+                this.CONSUME3(FiveTok)
+                total += "C5"
+              }
+            },
+            {
+              ALT: () => {
+                this.CONSUME3(OneTok)
+                total += "C1"
+              }
             }
-          },
-          {
-            ALT: () => {
-              this.CONSUME3(ThreeTok)
-              total += "C3"
-            }
-          },
-          {
-            ALT: () => {
-              this.CONSUME4(ThreeTok)
-              total += "OOPS!"
-            }
-          },
-          {
-            ALT: () => {
-              this.CONSUME3(FiveTok)
-              total += "C5"
-            }
-          },
-          {
-            ALT: () => {
-              this.CONSUME3(OneTok)
-              total += "C1"
-            }
-          }
-        ])
+          ]
+        })
 
-        this.OR4([
-          {
-            ALT: () => {
-              this.CONSUME4(OneTok)
-              total += "D1"
+        this.OR4({
+          IGNORE_AMBIGUITIES: true,
+          DEF: [
+            {
+              ALT: () => {
+                this.CONSUME4(OneTok)
+                total += "D1"
+              }
+            },
+            {
+              ALT: () => {
+                this.CONSUME4(FourTok)
+                total += "D4"
+              }
+            },
+            {
+              ALT: () => {
+                this.CONSUME5(FourTok)
+                total += "OOPS!"
+              }
+            },
+            {
+              ALT: () => {
+                this.CONSUME4(TwoTok)
+                total += "D2"
+              }
             }
-          },
-          {
-            ALT: () => {
-              this.CONSUME4(FourTok)
-              total += "D4"
-            }
-          },
-          {
-            ALT: () => {
-              this.CONSUME5(FourTok)
-              total += "OOPS!"
-            }
-          },
-          {
-            ALT: () => {
-              this.CONSUME4(TwoTok)
-              total += "D2"
-            }
-          }
-        ])
+          ]
+        })
 
-        this.OR5([
-          {
-            ALT: () => {
-              this.CONSUME5(TwoTok)
-              total += "E2"
+        this.OR5({
+          IGNORE_AMBIGUITIES: true,
+          DEF: [
+            {
+              ALT: () => {
+                this.CONSUME5(TwoTok)
+                total += "E2"
+              }
+            },
+            {
+              ALT: () => {
+                this.CONSUME5(OneTok)
+                total += "E1"
+              }
+            },
+            {
+              ALT: () => {
+                this.CONSUME4(FiveTok)
+                total += "E5"
+              }
+            },
+            {
+              ALT: () => {
+                this.CONSUME5(ThreeTok)
+                total += "E3"
+              }
+            },
+            {
+              ALT: () => {
+                this.CONSUME5(FiveTok)
+                total += "OOPS!"
+              }
             }
-          },
-          {
-            ALT: () => {
-              this.CONSUME5(OneTok)
-              total += "E1"
-            }
-          },
-          {
-            ALT: () => {
-              this.CONSUME4(FiveTok)
-              total += "E5"
-            }
-          },
-          {
-            ALT: () => {
-              this.CONSUME5(ThreeTok)
-              total += "E3"
-            }
-          },
-          {
-            ALT: () => {
-              this.CONSUME5(FiveTok)
-              total += "OOPS!"
-            }
-          }
-        ])
+          ]
+        })
 
         return total
       }


### PR DESCRIPTION
Docs included in commit

BREAKING CHANGE: The `ignoredIssues` property was removed and a Parser will throw an error if said
property is used.