### PR TITLE
refactor: remove `Parser` class

### DIFF
--- a/.idea/chevrotain.iml
+++ b/.idea/chevrotain.iml
@@ -23,6 +23,7 @@
       <excludeFolder url="file://$MODULE_DIR$/packages/chevrotain/docs/.vuepress/dist" />
       <excludeFolder url="file://$MODULE_DIR$/packages/chevrotain/gh-pages" />
       <excludeFolder url="file://$MODULE_DIR$/packages/chevrotain/lib" />
+      <excludeFolder url="file://$MODULE_DIR$/packages/chevrotain/lib_esm" />
       <excludeFolder url="file://$MODULE_DIR$/packages/chevrotain/scripts/gh-pages" />
       <excludeFolder url="file://$MODULE_DIR$/release" />
       <excludeFolder url="file://$MODULE_DIR$/target" />

--- a/packages/chevrotain/api.d.ts
+++ b/packages/chevrotain/api.d.ts
@@ -901,130 +901,6 @@ declare abstract class BaseParser {
 }
 
 /**
- * @deprecated Soft deprecated, CstParser or EmbeddedActionsParser instead.
- *    - {@link CstParser}
- *    - {@link EmbeddedActionsParser}
- */
-export declare class Parser extends BaseParser {
-  /**
-   * @deprecated use {@link Parser.performSelfAnalysis} **instance** method instead.
-   */
-  /* protected */ static performSelfAnalysis(parserInstance: Parser): void
-
-  /**
-   *
-   * @param name - The name of the rule.
-   * @param implementation - The implementation of the rule.
-   * @param [config] - The rule's optional configuration.
-   *
-   * @returns - The parsing rule which is the production implementation wrapped with the parsing logic that handles
-   *                     Parser state / error recovery&reporting/ ...
-   */
-  /* protected */ RULE<T>(
-    name: string,
-    implementation: (...implArgs: any[]) => T,
-    config?: IRuleConfig<T>
-  ): (idxInCallingRule?: number, ...args: any[]) => T
-
-  /**
-   * Same as {@link Parser.RULE}, but should only be used in
-   * "extending" grammars to override rules/productions from the super grammar.
-   * See [Parser Inheritance Example](https://github.com/SAP/chevrotain/tree/master/examples/parser/inheritance).
-   */
-  /* protected */ OVERRIDE_RULE<T>(
-    name: string,
-    impl: (...implArgs: any[]) => T,
-    config?: IRuleConfig<T>
-  ): (idxInCallingRule?: number, ...args: any[]) => T
-
-  /* protected */ SUBRULE<T>(
-    ruleToCall: (idx: number) => T,
-    options?: SubruleMethodOpts
-  ): T
-
-  /**
-   * @see SUBRULE
-   * @hidden
-   */
-  /* protected */ SUBRULE1<T>(
-    ruleToCall: (idx: number) => T,
-    options?: SubruleMethodOpts
-  ): T
-
-  /**
-   * @see SUBRULE
-   * @hidden
-   */
-  /* protected */ SUBRULE2<T>(
-    ruleToCall: (idx: number) => T,
-    options?: SubruleMethodOpts
-  ): T
-
-  /**
-   * @see SUBRULE
-   * @hidden
-   */
-  /* protected */ SUBRULE3<T>(
-    ruleToCall: (idx: number) => T,
-    options?: SubruleMethodOpts
-  ): T
-
-  /**
-   * @see SUBRULE
-   * @hidden
-   */
-  /* protected */ SUBRULE4<T>(
-    ruleToCall: (idx: number) => T,
-    options?: SubruleMethodOpts
-  ): T
-
-  /**
-   * @see SUBRULE
-   * @hidden
-   */
-  /* protected */ SUBRULE5<T>(
-    ruleToCall: (idx: number) => T,
-    options?: SubruleMethodOpts
-  ): T
-
-  /**
-   * @see SUBRULE
-   * @hidden
-   */
-  /* protected */ SUBRULE6<T>(
-    ruleToCall: (idx: number) => T,
-    options?: SubruleMethodOpts
-  ): T
-
-  /**
-   * @see SUBRULE
-   * @hidden
-   */
-  /* protected */ SUBRULE7<T>(
-    ruleToCall: (idx: number) => T,
-    options?: SubruleMethodOpts
-  ): T
-
-  /**
-   * @see SUBRULE
-   * @hidden
-   */
-  /* protected */ SUBRULE8<T>(
-    ruleToCall: (idx: number) => T,
-    options?: SubruleMethodOpts
-  ): T
-
-  /**
-   * @see SUBRULE
-   * @hidden
-   */
-  /* protected */ SUBRULE9<T>(
-    ruleToCall: (idx: number) => T,
-    options?: SubruleMethodOpts
-  ): T
-}
-
-/**
  * A Parser that outputs a Concrete Syntax Tree.
  * See:
  *    - https://sap.github.io/chevrotain/docs/tutorial/step3_adding_actions_root.html#alternatives
@@ -1036,7 +912,7 @@ export declare class CstParser extends BaseParser {
   /**
    * @deprecated use {@link Parser.performSelfAnalysis} **instance** method instead.
    */
-  /* protected */ static performSelfAnalysis(parserInstance: Parser): void
+  /* protected */ static performSelfAnalysis(parserInstance: CstParser): void
 
   /**
    * Creates a Grammar Rule
@@ -1185,7 +1061,9 @@ export declare class EmbeddedActionsParser extends BaseParser {
   /**
    * @deprecated use {@link Parser.performSelfAnalysis} **instance** method instead.
    */
-  /* protected */ static performSelfAnalysis(parserInstance: Parser): void
+  /* protected */ static performSelfAnalysis(
+    parserInstance: EmbeddedActionsParser
+  ): void
 
   // TODO: remove `outputCST` from the config options in the constructor
 
@@ -2133,15 +2011,6 @@ export interface IParserConfig {
    */
   dynamicTokensEnabled?: boolean
   /**
-   * @deprecated - extend either CstParser or EmbeddedActionsParser to control this flag instead
-   *               - @see CstParser
-   *               - @see EmbeddedActionsParser
-   *
-   * Enable automatic Concrete Syntax Tree creation
-   * For in-depth docs on [Concrete Syntax Trees](http://sap.github.io/chevrotain/docs/guide/concrete_syntax_tree.html):
-   */
-  outputCst?: boolean
-  /**
    * Enable computation of CST nodes location.
    * By default this is set to "none", meaning this feature is disabled.
    * See: http://sap.github.io/chevrotain/docs/guide/concrete_syntax_tree.html#cstnode-location
@@ -2886,11 +2755,11 @@ export declare function createSyntaxDiagramsCode(
  *
  * - See detailed docs for [Custom APIs](http://sap.github.io/chevrotain/docs/guide/custom_apis.html).
  */
-export declare function generateParserFactory(options: {
+export declare function generateParserFactory<T extends BaseParser>(options: {
   name: string
   rules: Rule[]
   tokenVocabulary: TokenVocabulary
-}): (config?: IParserConfig) => Parser
+}): (config?: IParserConfig) => T
 
 /**
  * Generate A Parser's text from a set of Rules.

--- a/packages/chevrotain/benchmark_web/parsers/css/css_dev.html
+++ b/packages/chevrotain/benchmark_web/parsers/css/css_dev.html
@@ -1,29 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>Title</title>
-</head>
-<body>
+  </head>
+  <body>
+    <script src="../worker_api.js"></script>
+    <script src="../options.js"></script>
 
-<script src="../worker_api.js"></script>
-<script src="../options.js"></script>
-
-<script>
-    // relative ti thr worker impel file
-    initWorker({
-        startRule:     "stylesheet",
-        parserConfig:  window.globalOptions.dev,
+    <script>
+      // relative ti thr worker impel file
+      initWorker({
+        startRule: "stylesheet",
+        parserConfig: window.globalOptions.dev,
         importScripts: [
-            "../../lib/chevrotain.js",
-            "https://unpkg.com/xregexp@3.2.0/xregexp-all.js",
-            "./css/css_parser.js",
-            "./css/1K_css.js",
-            "./api.js"]
-    })
-</script>
-
-
-</body>
+          "../../lib/chevrotain.js",
+          "https://unpkg.com/xregexp@3.2.0/xregexp-all.js",
+          "./options.js",
+          "./css/css_parser.js",
+          "./css/1K_css.js",
+          "./api.js"
+        ]
+      })
+    </script>
+  </body>
 </html>
-

--- a/packages/chevrotain/benchmark_web/parsers/css/css_latest.html
+++ b/packages/chevrotain/benchmark_web/parsers/css/css_latest.html
@@ -1,29 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>Title</title>
-</head>
-<body>
+  </head>
+  <body>
+    <script src="../worker_api.js"></script>
+    <script src="../options.js"></script>
 
-<script src="../worker_api.js"></script>
-<script src="../options.js"></script>
-
-<script>
-    // relative to the worker impel file
-    initWorker({
-        startRule:     "stylesheet",
-        parserConfig:  window.globalOptions.latest,
+    <script>
+      // relative to the worker impel file
+      initWorker({
+        startRule: "stylesheet",
+        parserConfig: window.globalOptions.latest,
         importScripts: [
-            "https://unpkg.com/chevrotain/lib/chevrotain.js",
-            "https://unpkg.com/xregexp@3.2.0/xregexp-all.js",
-            "./css/css_parser.js",
-            "./css/1K_css.js",
-            "./api.js"]
-    })
-</script>
-
-
-</body>
+          "https://unpkg.com/chevrotain/lib/chevrotain.js",
+          "https://unpkg.com/xregexp@3.2.0/xregexp-all.js",
+          "./options.js",
+          "./css/css_parser.js",
+          "./css/1K_css.js",
+          "./api.js"
+        ]
+      })
+    </script>
+  </body>
 </html>
-

--- a/packages/chevrotain/benchmark_web/parsers/css/css_parser.js
+++ b/packages/chevrotain/benchmark_web/parsers/css/css_parser.js
@@ -241,10 +241,13 @@ var Minus = createToken({ name: "Minus", pattern: /-/ })
 
 var lexerDefinition = cssTokens
 
-// ----------------- parser -----------------
+var ChevrotainParser = self.globalOptions.outputCst
+  ? chevrotain.CstParser
+  : chevrotain.EmbeddedActionsParser
 
+// ----------------- parser -----------------
 function parser(config) {
-  chevrotain.Parser.call(this, cssTokens, config)
+  ChevrotainParser.call(this, cssTokens, config)
 
   var $ = this
 
@@ -589,7 +592,7 @@ function parser(config) {
   this.performSelfAnalysis()
 }
 
-parser.prototype = Object.create(chevrotain.Parser.prototype)
+parser.prototype = Object.create(ChevrotainParser.prototype)
 parser.prototype.constructor = parser
 
 // ----------------- wrapping it all together -----------------

--- a/packages/chevrotain/benchmark_web/parsers/ecma5/ecma5_dev.html
+++ b/packages/chevrotain/benchmark_web/parsers/ecma5/ecma5_dev.html
@@ -1,31 +1,29 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>Title</title>
-</head>
-<body>
+  </head>
+  <body>
+    <script src="../worker_api.js"></script>
+    <script src="../options.js"></script>
 
-<script src="../worker_api.js"></script>
-<script src="../options.js"></script>
-
-<script>
-    // relative to the worker impel file
-    initWorker({
-        startRule:     "Program",
-        parserConfig:  window.globalOptions.dev,
+    <script>
+      // relative to the worker impel file
+      initWorker({
+        startRule: "Program",
+        parserConfig: window.globalOptions.dev,
         importScripts: [
-            "../../lib/chevrotain.js",
-            "https://unpkg.com/acorn@5.1.2/dist/acorn.js",
-            "./ecma5/ecma5_tokens.js",
-            "./ecma5/ecma5_lexer.js",
-            "./ecma5/ecma5_parser.js",
-            "./api.js"],
-        sampleUrl:     "https://unpkg.com/benchmark@2.1.4/benchmark.js"
-    })
-</script>
-
-
-</body>
+          "../../lib/chevrotain.js",
+          "https://unpkg.com/acorn@5.1.2/dist/acorn.js",
+          "./options.js",
+          "./ecma5/ecma5_tokens.js",
+          "./ecma5/ecma5_lexer.js",
+          "./ecma5/ecma5_parser.js",
+          "./api.js"
+        ],
+        sampleUrl: "https://unpkg.com/benchmark@2.1.4/benchmark.js"
+      })
+    </script>
+  </body>
 </html>
-

--- a/packages/chevrotain/benchmark_web/parsers/ecma5/ecma5_latest.html
+++ b/packages/chevrotain/benchmark_web/parsers/ecma5/ecma5_latest.html
@@ -1,31 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>Title</title>
-</head>
-<body>
+  </head>
+  <body>
+    <script src="../worker_api.js"></script>
+    <script src="../options.js"></script>
 
-<script src="../worker_api.js"></script>
-<script src="../options.js"></script>
-
-<script>
-    // relative to the worker impel file
-    initWorker({
-        startRule:     "Program",
-        parserConfig:  window.globalOptions.latest,
+    <script>
+      // relative to the worker impel file
+      initWorker({
+        startRule: "Program",
+        parserConfig: window.globalOptions.latest,
         importScripts: [
-            "https://unpkg.com/chevrotain/lib/chevrotain.js",
-            "https://unpkg.com/acorn@5.1.2/dist/acorn.js",
-            "./ecma5/ecma5_tokens.js",
-            "./ecma5/ecma5_lexer.js",
-            "./ecma5/ecma5_parser.js",
-            "./api.js"],
-        sampleUrl:     "https://unpkg.com/benchmark@2.1.4/benchmark.js"
-    })
-</script>
+          "https://unpkg.com/chevrotain/lib/chevrotain.js",
+          "https://unpkg.com/acorn@5.1.2/dist/acorn.js",
+          "./options.js",
 
-
-</body>
+          "./ecma5/ecma5_tokens.js",
+          "./ecma5/ecma5_lexer.js",
+          "./ecma5/ecma5_parser.js",
+          "./api.js"
+        ],
+        sampleUrl: "https://unpkg.com/benchmark@2.1.4/benchmark.js"
+      })
+    </script>
+  </body>
 </html>
-

--- a/packages/chevrotain/benchmark_web/parsers/ecma5/ecma5_parser.js
+++ b/packages/chevrotain/benchmark_web/parsers/ecma5/ecma5_parser.js
@@ -2,7 +2,9 @@
 
 const chevrotain = self.chevrotain
 
-const Parser = chevrotain.Parser
+const Parser = self.globalOptions.outputCst
+  ? chevrotain.CstParser
+  : chevrotain.EmbeddedActionsParser
 const tokenMatcher = chevrotain.tokenMatcher
 const EOF = chevrotain.EOF
 
@@ -19,15 +21,7 @@ class ECMAScript5Parser extends Parser {
   }
 
   constructor(config) {
-    super(
-      tokens,
-      Object.assign({}, config, {
-        ignoredIssues: {
-          Statement: { OR: true },
-          SourceElements: { OR: true }
-        }
-      })
-    )
+    super(tokens, config)
 
     this.SUPER_CONSUME = super.CONSUME
     this.SUPER_CONSUME2 = super.CONSUME2
@@ -361,7 +355,7 @@ class ECMAScript5Parser extends Parser {
       $.OR(
         $.c2 ||
           ($.c2 = [
-            { ALT: () => $.SUBRULE($.Block) },
+            { ALT: () => $.SUBRULE($.Block), IGNORE_AMBIGUITIES: true },
             { ALT: () => $.SUBRULE($.VariableStatement) },
             { ALT: () => $.SUBRULE($.EmptyStatement) },
             // "LabelledStatement" must appear before "ExpressionStatement" due to common lookahead prefix ("inner :" vs "inner")
@@ -791,7 +785,10 @@ class ECMAScript5Parser extends Parser {
         // FunctionDeclaration appearing before statement implements [lookahead != {{, function}] in ExpressionStatement
         // See Function  https://www.ecma-international.org/ecma-262/5.1/index.html#sec-12.4Declaration
         $.OR([
-          { ALT: () => $.SUBRULE($.FunctionDeclaration) },
+          {
+            ALT: () => $.SUBRULE($.FunctionDeclaration),
+            IGNORE_AMBIGUITIES: true
+          },
           { ALT: () => $.SUBRULE($.Statement) }
         ])
       })

--- a/packages/chevrotain/benchmark_web/parsers/json/json_dev.html
+++ b/packages/chevrotain/benchmark_web/parsers/json/json_dev.html
@@ -16,6 +16,7 @@
         parserConfig:  window.globalOptions.dev,
         importScripts: [
             "../../lib/chevrotain.js",
+            "./options.js",
             "./json/json_parser.js",
             "./json/1K_json.js",
             "./api.js"]

--- a/packages/chevrotain/benchmark_web/parsers/json/json_latest.html
+++ b/packages/chevrotain/benchmark_web/parsers/json/json_latest.html
@@ -1,27 +1,26 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>Title</title>
-</head>
-<body>
+  </head>
+  <body>
+    <script src="../worker_api.js"></script>
+    <script src="../options.js"></script>
 
-<script src="../worker_api.js"></script>
-<script src="../options.js"></script>
-
-<script>
-    // relative to the worker impel file
-    initWorker({
-        startRule:     "json",
-        parserConfig:  window.globalOptions.latest,
+    <script>
+      // relative to the worker impel file
+      initWorker({
+        startRule: "json",
+        parserConfig: window.globalOptions.latest,
         importScripts: [
-            "https://unpkg.com/chevrotain/lib/chevrotain.js",
-            "./json/json_parser.js",
-            "./json/1K_json.js",
-            "./api.js"]
-    })
-</script>
-
-
-</body>
+          "https://unpkg.com/chevrotain/lib/chevrotain.js",
+          "./options.js",
+          "./json/json_parser.js",
+          "./json/1K_json.js",
+          "./api.js"
+        ]
+      })
+    </script>
+  </body>
 </html>

--- a/packages/chevrotain/benchmark_web/parsers/json/json_parser.js
+++ b/packages/chevrotain/benchmark_web/parsers/json/json_parser.js
@@ -51,7 +51,9 @@ var lexerDefinition = jsonTokens
 
 // https://github.com/SAP/chevrotain/blob/master/docs/faq.md#Q6
 // (Do not create a new Parser instance for each new input.)
-var ChevrotainParser = chevrotain.Parser
+var ChevrotainParser = self.globalOptions.outputCst
+  ? chevrotain.CstParser
+  : chevrotain.EmbeddedActionsParser
 
 function parser(options) {
   ChevrotainParser.call(this, jsonTokens, options)

--- a/packages/chevrotain/benchmark_web/parsers/options.js
+++ b/packages/chevrotain/benchmark_web/parsers/options.js
@@ -1,4 +1,5 @@
-window.globalOptions = {
-  dev: { outputCst: false, maxLookahead: 2 },
-  latest: { outputCst: false, maxLookahead: 2 }
+self.globalOptions = {
+  outputCst: true,
+  dev: { maxLookahead: 2, outputCst: false },
+  latest: { maxLookahead: 2, outputCst: false }
 }

--- a/packages/chevrotain/docs/changes/BREAKING_CHANGES.md
+++ b/packages/chevrotain/docs/changes/BREAKING_CHANGES.md
@@ -17,6 +17,11 @@
   It is also possible (and recommended) to increase the maxLookahead for a specific DSL method rather then globally for all.
   See [relevant issue](https://github.com/SAP/chevrotain/issues/1012).
 
+- The deprecated `Parser` class has been fully removed, use `CstParser` or `EmbeddedActionsParser`
+  depending if your parser outputs a [CST](https://sap.github.io/chevrotain/docs/guide/concrete_syntax_tree.html) or not.
+  the `outputCst` property of the IParserConfig was also removed as this behavior is now controlled by base Parser class which is
+  extended.
+
 - The IParserConfig's `ignoredIssues` property has been deprecated.
   Any Parser still using this property will throw an exception on initialization.
   If any ambiguities need be ignored, the `IGNORE_AMBIGUITIES` property should be used instead.

--- a/packages/chevrotain/src/api.ts
+++ b/packages/chevrotain/src/api.ts
@@ -2,7 +2,6 @@
 export { VERSION } from "./version"
 
 export {
-  Parser,
   CstParser,
   EmbeddedActionsParser,
   ParserDefinitionErrorType,
@@ -85,3 +84,12 @@ export {
   generateParserFactory,
   generateParserModule
 } from "./generate/generate_public"
+
+export class Parser {
+  constructor() {
+    throw new Error(
+      "The Parser class has been deprecated, use CstParser or EmbeddedActionsParser instead.\t\n" +
+        "See: https://sap.github.io/chevrotain/docs/changes/BREAKING_CHANGES.html#_7-0-0"
+    )
+  }
+}

--- a/packages/chevrotain/src/generate/generate_public.ts
+++ b/packages/chevrotain/src/generate/generate_public.ts
@@ -1,11 +1,11 @@
-import { Parser, Rule, IParserConfig, TokenVocabulary } from "../../api"
+import { Rule, IParserConfig, TokenVocabulary, BaseParser } from "../../api"
 import { genUmdModule, genWrapperFunction } from "./generate"
 
-export function generateParserFactory(options: {
+export function generateParserFactory<T extends BaseParser>(options: {
   name: string
   rules: Rule[]
   tokenVocabulary: TokenVocabulary
-}): (config?: IParserConfig) => Parser {
+}): (config?: IParserConfig) => T {
   const wrapperText = genWrapperFunction({
     name: options.name,
     rules: options.rules

--- a/packages/chevrotain/src/parse/parser/parser.ts
+++ b/packages/chevrotain/src/parse/parser/parser.ts
@@ -254,10 +254,7 @@ export class Parser {
   selfAnalysisDone = false
   protected skipValidations: boolean
 
-  constructor(
-    tokenVocabulary: TokenVocabulary,
-    config: IParserConfig = DEFAULT_PARSER_CONFIG
-  ) {
+  constructor(tokenVocabulary: TokenVocabulary, config: IParserConfig) {
     const that: MixedInParser = this as any
     that.initErrorHandler(config)
     that.initLexerAdapter()

--- a/packages/chevrotain/src/parse/parser/traits/parser_traits.ts
+++ b/packages/chevrotain/src/parse/parser/traits/parser_traits.ts
@@ -35,15 +35,6 @@ export type MixedInParser = ParserConstructorImpel &
   GastRecorder &
   PerformanceTracer
 
-interface MixedInParserConstructor {
-  new (
-    tokenVocabulary: defs.TokenVocabulary,
-    config?: defs.IParserConfig
-  ): defs.Parser
-}
-
-export const Parser: MixedInParserConstructor = <any>ParserConstructorImpel
-
 interface MixedInCstParserConstructor {
   new (
     tokenVocabulary: defs.TokenVocabulary,

--- a/packages/chevrotain/src/parse/parser/traits/tree_builder.ts
+++ b/packages/chevrotain/src/parse/parser/traits/tree_builder.ts
@@ -48,9 +48,9 @@ export class TreeBuilder {
   initTreeBuilder(this: MixedInParser, config: IParserConfig) {
     this.LAST_EXPLICIT_RULE_STACK = []
     this.CST_STACK = []
-    this.outputCst = has(config, "outputCst")
-      ? config.outputCst
-      : DEFAULT_PARSER_CONFIG.outputCst
+
+    // outputCst is no longer exposed/defined in the pubic API
+    this.outputCst = (config as any).outputCst
 
     this.nodeLocationTracking = has(config, "nodeLocationTracking")
       ? config.nodeLocationTracking

--- a/packages/chevrotain/test/deprecation_spec.ts
+++ b/packages/chevrotain/test/deprecation_spec.ts
@@ -1,0 +1,13 @@
+import { expect } from "chai"
+
+import { Parser } from "../src/api"
+
+describe("Chevrotain's runtime deprecation checks", () => {
+  it("Will throw an error if someone tries to use the deprecated Parser class", () => {
+    expect(() => new Parser()).to.throw("The Parser class has been deprecated")
+    expect(() => new Parser()).to.throw("CstParser or EmbeddedActionsParser")
+    expect(() => new Parser()).to.throw(
+      "https://sap.github.io/chevrotain/docs/changes/BREAKING_CHANGES.html#_7-0-0"
+    )
+  })
+})

--- a/packages/chevrotain/test/full_flow/backtracking/backtracking_parser.ts
+++ b/packages/chevrotain/test/full_flow/backtracking/backtracking_parser.ts
@@ -4,8 +4,8 @@
 // generally one should avoid having to use backtracking, and this specific example can be resolved by parsing
 // both statements in a single rule and only distinguishing between them later, but lets see an example of using backtracking :)
 
-import { Parser } from "../../../src/parse/parser/traits/parser_traits"
-import { IParserConfig, IToken } from "../../../api"
+import { EmbeddedActionsParser } from "../../../src/parse/parser/traits/parser_traits"
+import { IParserConfig } from "../../../api"
 
 export enum RET_TYPE {
   WITH_DEFAULT,
@@ -42,13 +42,11 @@ export class IdentTok {
   static PATTERN = /NA/
 }
 
-const configuration: IParserConfig = {
-  outputCst: false
-}
+const configuration: IParserConfig = {}
 
 // extending the BaseErrorRecoveryRecognizer in this example because it too has logic related to backtracking
 // that needs to be tested too.
-export class BackTrackingParser extends Parser {
+export class BackTrackingParser extends EmbeddedActionsParser {
   constructor() {
     // DOCS: note the second parameter in the super class. this is the namespace in which the token constructors are defined.
     //       it is mandatory to provide this map to be able to perform self analysis

--- a/packages/chevrotain/test/full_flow/error_recovery/sql_statements/sql_recovery_parser.ts
+++ b/packages/chevrotain/test/full_flow/error_recovery/sql_statements/sql_recovery_parser.ts
@@ -5,7 +5,7 @@
  * INSERT (32, "SHAHAR") INTO schema2.Persons
  * DELETE (31, "SHAHAR") FROM schema2.Persons
  */
-import { Parser } from "../../../../src/parse/parser/traits/parser_traits"
+import { EmbeddedActionsParser } from "../../../../src/parse/parser/traits/parser_traits"
 import * as allTokens from "./sql_recovery_tokens"
 import {
   INVALID_DDL,
@@ -46,13 +46,12 @@ const allTokensToUse = { ...allTokens }
 augmentTokenTypes(<any>allTokensToUse)
 
 // DOCS: to enable error recovery functionality one must extend BaseErrorRecoveryRecognizer
-export class DDLExampleRecoveryParser extends Parser {
+export class DDLExampleRecoveryParser extends EmbeddedActionsParser {
   constructor(isRecoveryEnabled: boolean = true) {
     // DOCS: note the first parameter in the super class. this is the namespace in which the token constructors are defined.
     //       it is mandatory to provide this map to be able to perform self analysis
     //       and allow the framework to "understand" the implemented grammar.
     super(allTokensToUse, {
-      outputCst: false,
       recoveryEnabled: isRecoveryEnabled
     })
     // DOCS: The call to performSelfAnalysis needs to happen after all the RULEs have been defined

--- a/packages/chevrotain/test/full_flow/error_recovery/switch_case/switchcase_recovery_parser.ts
+++ b/packages/chevrotain/test/full_flow/error_recovery/switch_case/switchcase_recovery_parser.ts
@@ -28,10 +28,7 @@
  * }
  */
 
-import {
-  EmbeddedActionsParser,
-  Parser
-} from "../../../../src/parse/parser/traits/parser_traits"
+import { EmbeddedActionsParser } from "../../../../src/parse/parser/traits/parser_traits"
 import * as allTokens from "./Switchcase_recovery_tokens"
 import {
   CaseTok,

--- a/packages/chevrotain/test/generate/generate_spec.ts
+++ b/packages/chevrotain/test/generate/generate_spec.ts
@@ -1,4 +1,3 @@
-import { Parser } from "../../src/parse/parser/traits/parser_traits"
 import {
   generateParserModule,
   generateParserFactory

--- a/packages/chevrotain/test/parse/cst_spec.ts
+++ b/packages/chevrotain/test/parse/cst_spec.ts
@@ -1,5 +1,5 @@
 import { createToken } from "../../src/scan/tokens_public"
-import { CstParser, Parser } from "../../src/parse/parser/traits/parser_traits"
+import { CstParser } from "../../src/parse/parser/traits/parser_traits"
 import { tokenStructuredMatcher } from "../../src/scan/tokens"
 import { createRegularToken } from "../utils/matchers"
 import { map } from "../../src/utils/utils"
@@ -96,7 +96,6 @@ function defineTestSuit(recoveryMode) {
       class CstTerminalParserWithLabels extends CstParser {
         constructor(input: IToken[] = []) {
           super(ALL_TOKENS, {
-            outputCst: true,
             recoveryEnabled: true
           })
           this.performSelfAnalysis()
@@ -132,7 +131,6 @@ function defineTestSuit(recoveryMode) {
       class CstTerminalAlternationParser extends CstParser {
         constructor(input: IToken[] = []) {
           super(ALL_TOKENS, {
-            outputCst: true,
             recoveryEnabled: recoveryMode
           })
           this.performSelfAnalysis()
@@ -173,7 +171,6 @@ function defineTestSuit(recoveryMode) {
       class CstTerminalAlternationSingleAltParser extends CstParser {
         constructor(input: IToken[] = []) {
           super(ALL_TOKENS, {
-            outputCst: true,
             recoveryEnabled: recoveryMode
           })
           this.performSelfAnalysis()
@@ -205,7 +202,6 @@ function defineTestSuit(recoveryMode) {
       class CstMultiTerminalParser extends CstParser {
         constructor(input: IToken[] = []) {
           super(ALL_TOKENS, {
-            outputCst: true,
             recoveryEnabled: recoveryMode
           })
           this.performSelfAnalysis()
@@ -238,7 +234,6 @@ function defineTestSuit(recoveryMode) {
       class CstMultiTerminalWithManyParser extends CstParser {
         constructor(input: IToken[] = []) {
           super(ALL_TOKENS, {
-            outputCst: true,
             recoveryEnabled: recoveryMode
           })
           this.performSelfAnalysis()
@@ -288,7 +283,6 @@ function defineTestSuit(recoveryMode) {
       class CstOptionalTerminalParser extends CstParser {
         constructor(input: IToken[] = []) {
           super(ALL_TOKENS, {
-            outputCst: true,
             recoveryEnabled: recoveryMode
           })
           this.performSelfAnalysis()
@@ -342,7 +336,6 @@ function defineTestSuit(recoveryMode) {
       class CstMultiTerminalWithAtLeastOneParser extends CstParser {
         constructor(input: IToken[] = []) {
           super(ALL_TOKENS, {
-            outputCst: true,
             recoveryEnabled: recoveryMode
           })
           this.performSelfAnalysis()
@@ -378,7 +371,6 @@ function defineTestSuit(recoveryMode) {
       class CstMultiTerminalWithManySepParser extends CstParser {
         constructor(input: IToken[] = []) {
           super(ALL_TOKENS, {
-            outputCst: true,
             recoveryEnabled: recoveryMode
           })
           this.performSelfAnalysis()
@@ -419,7 +411,6 @@ function defineTestSuit(recoveryMode) {
       class CstMultiTerminalWithAtLeastOneSepParser extends CstParser {
         constructor(input: IToken[] = []) {
           super(ALL_TOKENS, {
-            outputCst: true,
             recoveryEnabled: recoveryMode
           })
           this.performSelfAnalysis()
@@ -668,7 +659,6 @@ function defineTestSuit(recoveryMode) {
         class CstOptionalNestedTerminalParser extends CstParser {
           constructor(input: IToken[] = []) {
             super(ALL_TOKENS, {
-              outputCst: true,
               recoveryEnabled: recoveryMode
             })
             this.performSelfAnalysis()
@@ -729,7 +719,6 @@ function defineTestSuit(recoveryMode) {
         class CstAlternationNestedAltParser extends CstParser {
           constructor(input: IToken[] = []) {
             super(ALL_TOKENS, {
-              outputCst: true,
               recoveryEnabled: recoveryMode
             })
             this.performSelfAnalysis()
@@ -773,7 +762,6 @@ function defineTestSuit(recoveryMode) {
         class CstAlternationNestedParser extends CstParser {
           constructor(input: IToken[] = []) {
             super(ALL_TOKENS, {
-              outputCst: true,
               recoveryEnabled: recoveryMode
             })
             this.performSelfAnalysis()
@@ -820,7 +808,6 @@ function defineTestSuit(recoveryMode) {
         class CstAlternationNestedAltSingleParser extends CstParser {
           constructor(input: IToken[] = []) {
             super(ALL_TOKENS, {
-              outputCst: true,
               recoveryEnabled: recoveryMode
             })
             this.performSelfAnalysis()
@@ -859,7 +846,6 @@ function defineTestSuit(recoveryMode) {
         class CstMultiTerminalWithManyNestedParser extends CstParser {
           constructor(input: IToken[] = []) {
             super(ALL_TOKENS, {
-              outputCst: true,
               recoveryEnabled: recoveryMode
             })
             this.performSelfAnalysis()
@@ -918,7 +904,6 @@ function defineTestSuit(recoveryMode) {
         class CstAtLeastOneNestedParser extends CstParser {
           constructor(input: IToken[] = []) {
             super(ALL_TOKENS, {
-              outputCst: true,
               recoveryEnabled: recoveryMode
             })
             this.performSelfAnalysis()
@@ -959,7 +944,6 @@ function defineTestSuit(recoveryMode) {
         class CstNestedRuleWithManySepParser extends CstParser {
           constructor(input: IToken[] = []) {
             super(ALL_TOKENS, {
-              outputCst: true,
               recoveryEnabled: recoveryMode
             })
             this.performSelfAnalysis()
@@ -1001,7 +985,6 @@ function defineTestSuit(recoveryMode) {
         class CstAtLeastOneSepNestedParser extends CstParser {
           constructor(input: IToken[] = []) {
             super(ALL_TOKENS, {
-              outputCst: true,
               recoveryEnabled: recoveryMode
             })
             this.performSelfAnalysis()
@@ -1204,7 +1187,6 @@ function defineTestSuit(recoveryMode) {
         class CstRecoveryParserReSync extends CstParser {
           constructor(input: IToken[] = []) {
             super(ALL_TOKENS, {
-              outputCst: true,
               recoveryEnabled: true
             })
             this.performSelfAnalysis()
@@ -1280,7 +1262,6 @@ function defineTestSuit(recoveryMode) {
         class CstRecoveryParserReSyncNested extends CstParser {
           constructor(input: IToken[] = []) {
             super(ALL_TOKENS, {
-              outputCst: true,
               recoveryEnabled: true
             })
             this.performSelfAnalysis()

--- a/packages/chevrotain/test/parse/cst_visitor_spec.ts
+++ b/packages/chevrotain/test/parse/cst_visitor_spec.ts
@@ -13,7 +13,7 @@ describe("The CSTVisitor", () => {
 
   class CstTerminalParserReturnVisitor extends CstParser {
     constructor(input: IToken[] = []) {
-      super(ALL_TOKENS, { outputCst: true })
+      super(ALL_TOKENS, {})
       this.performSelfAnalysis()
     }
 

--- a/packages/chevrotain/test/parse/grammar/checks_spec.ts
+++ b/packages/chevrotain/test/parse/grammar/checks_spec.ts
@@ -1,6 +1,6 @@
 import {
   CstParser,
-  Parser
+  EmbeddedActionsParser
 } from "../../../src/parse/parser/traits/parser_traits"
 import {
   EMPTY_ALT,
@@ -458,7 +458,7 @@ export class StarTok {
   static PATTERN = /NA/
 }
 
-class ErroneousOccurrenceNumUsageParser2 extends Parser {
+class ErroneousOccurrenceNumUsageParser2 extends EmbeddedActionsParser {
   constructor(input: IToken[] = []) {
     super([PlusTok])
     this.performSelfAnalysis()
@@ -474,7 +474,7 @@ class ErroneousOccurrenceNumUsageParser2 extends Parser {
 let myToken = createToken({ name: "myToken" })
 let myOtherToken = createToken({ name: "myOtherToken" })
 
-class ValidOccurrenceNumUsageParser extends Parser {
+class ValidOccurrenceNumUsageParser extends EmbeddedActionsParser {
   constructor(input: IToken[] = []) {
     super([myToken, myOtherToken])
     this.performSelfAnalysis()
@@ -489,7 +489,7 @@ class ValidOccurrenceNumUsageParser extends Parser {
 
 describe("The duplicate occurrence validations full flow", () => {
   it("will throw errors on duplicate Terminals consumption in the same top level rule", () => {
-    class ErroneousOccurrenceNumUsageParser1 extends Parser {
+    class ErroneousOccurrenceNumUsageParser1 extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([PlusTok])
         this.performSelfAnalysis()
@@ -524,7 +524,7 @@ describe("The duplicate occurrence validations full flow", () => {
   })
 
   it("will throw errors on duplicate MANY productions in the same top level rule", () => {
-    class ErroneousOccurrenceNumUsageParser3 extends Parser {
+    class ErroneousOccurrenceNumUsageParser3 extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([PlusTok, MinusTok])
         this.performSelfAnalysis()
@@ -558,7 +558,7 @@ describe("The duplicate occurrence validations full flow", () => {
 
 describe("The Recorder runtime checks full flow", () => {
   it("will return EOF for LA calls during recording phase", () => {
-    class LookAheadParser extends Parser {
+    class LookAheadParser extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([myToken, myOtherToken])
         this.performSelfAnalysis()
@@ -575,7 +575,7 @@ describe("The Recorder runtime checks full flow", () => {
   })
 
   it("won't invoke semantic actions during recording phase", () => {
-    class SemanticActionsParsers extends Parser {
+    class SemanticActionsParsers extends EmbeddedActionsParser {
       counter: number
       constructor(input: IToken[] = []) {
         super([myToken, myOtherToken])
@@ -598,7 +598,7 @@ describe("The Recorder runtime checks full flow", () => {
   })
 
   it("won't execute backtracking during recording phase", () => {
-    class BacktrackingRecordingParser extends Parser {
+    class BacktrackingRecordingParser extends EmbeddedActionsParser {
       counter: number
       constructor(input: IToken[] = []) {
         super([myToken, myOtherToken])
@@ -629,7 +629,7 @@ describe("The Recorder runtime checks full flow", () => {
   })
 
   it("will throw an error when trying to init a parser with unresolved rule references", () => {
-    class InvalidRefParser extends Parser {
+    class InvalidRefParser extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([myToken, myOtherToken])
         this.performSelfAnalysis()
@@ -650,7 +650,7 @@ describe("The Recorder runtime checks full flow", () => {
   })
 
   it("will throw an error when trying to init a parser with unresolved tokenType references", () => {
-    class InvalidTokTypeParser extends Parser {
+    class InvalidTokTypeParser extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([myToken, myOtherToken])
         this.performSelfAnalysis()
@@ -674,7 +674,7 @@ describe("The Recorder runtime checks full flow", () => {
     "will throw an error when trying to init a parser with an invalid method idx",
     () => {
       it("consume", () => {
-        class InvalidIdxParser extends Parser {
+        class InvalidIdxParser extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
             super([myToken, myOtherToken])
             this.performSelfAnalysis()
@@ -720,7 +720,7 @@ describe("The Recorder runtime checks full flow", () => {
       })
 
       it("option", () => {
-        class InvalidIdxParser extends Parser {
+        class InvalidIdxParser extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
             super([myToken, myOtherToken])
             this.performSelfAnalysis()
@@ -743,7 +743,7 @@ describe("The Recorder runtime checks full flow", () => {
       })
 
       it("many", () => {
-        class InvalidIdxParser extends Parser {
+        class InvalidIdxParser extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
             super([myToken, myOtherToken])
             this.performSelfAnalysis()
@@ -766,7 +766,7 @@ describe("The Recorder runtime checks full flow", () => {
       })
 
       it("atLeastOne", () => {
-        class InvalidIdxParser extends Parser {
+        class InvalidIdxParser extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
             super([myToken, myOtherToken])
             this.performSelfAnalysis()
@@ -789,7 +789,7 @@ describe("The Recorder runtime checks full flow", () => {
       })
 
       it("or", () => {
-        class InvalidIdxParser extends Parser {
+        class InvalidIdxParser extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
             super([myToken, myOtherToken])
             this.performSelfAnalysis()
@@ -819,7 +819,7 @@ describe("The Recorder runtime checks full flow", () => {
 
   context("augmenting error messages", () => {
     it("will add additional details to other runtime exceptions encountered during recording phase", () => {
-      class OtherRecordingErrorParser extends Parser {
+      class OtherRecordingErrorParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
           super([myToken, myOtherToken])
           this.performSelfAnalysis()
@@ -837,7 +837,7 @@ describe("The Recorder runtime checks full flow", () => {
     })
 
     it("will not fail when the original error is immutable", () => {
-      class OtherRecordingErrorParser extends Parser {
+      class OtherRecordingErrorParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
           super([myToken, myOtherToken])
           this.performSelfAnalysis()
@@ -860,7 +860,7 @@ describe("The reference resolver validation full flow", () => {
     "won't throw an error when trying to init a parser with definition errors but with a flag active to defer handling" +
       "of definition errors",
     () => {
-      class DupConsumeParser extends Parser {
+      class DupConsumeParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
           super([myToken, myOtherToken])
           this.performSelfAnalysis()
@@ -873,16 +873,20 @@ describe("The reference resolver validation full flow", () => {
         })
       }
 
-      ;(Parser as any).DEFER_DEFINITION_ERRORS_HANDLING = true
+      Object.getPrototypeOf(
+        EmbeddedActionsParser
+      ).DEFER_DEFINITION_ERRORS_HANDLING = true
       expect(() => new DupConsumeParser()).to.not.throw()
       expect(() => new DupConsumeParser()).to.not.throw()
       expect(() => new DupConsumeParser()).to.not.throw()
-      ;(Parser as any).DEFER_DEFINITION_ERRORS_HANDLING = false
+      Object.getPrototypeOf(
+        EmbeddedActionsParser
+      ).DEFER_DEFINITION_ERRORS_HANDLING = false
     }
   )
 })
 
-class DuplicateRulesParser extends Parser {
+class DuplicateRulesParser extends EmbeddedActionsParser {
   constructor(input: IToken[] = []) {
     super([myToken, myOtherToken])
     this.performSelfAnalysis()
@@ -893,7 +897,7 @@ class DuplicateRulesParser extends Parser {
   public two = this.RULE("oops_duplicate", () => {})
 }
 
-class InvalidRuleNameParser extends Parser {
+class InvalidRuleNameParser extends EmbeddedActionsParser {
   constructor(input: IToken[] = []) {
     super([myToken, myOtherToken])
     this.performSelfAnalysis()
@@ -926,12 +930,16 @@ describe("The rule names validation full flow", () => {
     "won't throw an errors when trying to init a parser with definition errors but with a flag active to defer handling" +
       "of definition errors (ruleName validation",
     () => {
-      ;(Parser as any).DEFER_DEFINITION_ERRORS_HANDLING = true
+      Object.getPrototypeOf(
+        EmbeddedActionsParser
+      ).DEFER_DEFINITION_ERRORS_HANDLING = true
       expect(() => new InvalidRuleNameParser()).to.not.throw()
       expect(() => new InvalidRuleNameParser()).to.not.throw()
       expect(() => new DuplicateRulesParser()).to.not.throw()
       expect(() => new DuplicateRulesParser()).to.not.throw()
-      ;(Parser as any).DEFER_DEFINITION_ERRORS_HANDLING = false
+      Object.getPrototypeOf(
+        EmbeddedActionsParser
+      ).DEFER_DEFINITION_ERRORS_HANDLING = false
     }
   )
 })
@@ -940,7 +948,7 @@ class StarToken {
   static PATTERN = /NA/
 }
 
-class DirectlyLeftRecursive extends Parser {
+class DirectlyLeftRecursive extends EmbeddedActionsParser {
   constructor(input: IToken[] = []) {
     super([StarToken])
     this.performSelfAnalysis()
@@ -952,7 +960,7 @@ class DirectlyLeftRecursive extends Parser {
   })
 }
 
-class InDirectlyLeftRecursive extends Parser {
+class InDirectlyLeftRecursive extends EmbeddedActionsParser {
   constructor(input: IToken[] = []) {
     super([StarToken])
     this.performSelfAnalysis()
@@ -968,7 +976,7 @@ class InDirectlyLeftRecursive extends Parser {
   })
 }
 
-class ComplexInDirectlyLeftRecursive extends Parser {
+class ComplexInDirectlyLeftRecursive extends EmbeddedActionsParser {
   constructor(input: IToken[] = []) {
     super([StarToken])
     this.performSelfAnalysis()
@@ -1012,7 +1020,7 @@ describe("The left recursion detection full flow", () => {
 
 describe("The empty alternative detection full flow", () => {
   it("will throw an error when an empty alternative is not the last alternative", () => {
-    class EmptyAltAmbiguityParser extends Parser {
+    class EmptyAltAmbiguityParser extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([PlusTok, StarTok])
         this.performSelfAnalysis()
@@ -1047,7 +1055,7 @@ describe("The empty alternative detection full flow", () => {
   })
 
   it("will throw an error when an empty alternative is not the last alternative - Indirect", () => {
-    class EmptyAltIndirectAmbiguityParser extends Parser {
+    class EmptyAltIndirectAmbiguityParser extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([PlusTok, StarTok])
         this.performSelfAnalysis()
@@ -1086,7 +1094,7 @@ describe("The empty alternative detection full flow", () => {
   })
 
   it("will detect alternative ambiguity with identical lookaheads", () => {
-    class AltAmbiguityParserImplicitOccurence extends Parser {
+    class AltAmbiguityParserImplicitOccurence extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([PlusTok, StarTok])
         this.performSelfAnalysis()
@@ -1121,7 +1129,7 @@ describe("The empty alternative detection full flow", () => {
   })
 
   it("will detect alternative ambiguity with identical lookahead - custom maxLookAhead", () => {
-    class AltAmbiguityParserImplicitOccurrence extends Parser {
+    class AltAmbiguityParserImplicitOccurrence extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([PlusTok, StarTok])
         this.performSelfAnalysis()
@@ -1163,7 +1171,7 @@ describe("The empty alternative detection full flow", () => {
 
   context("IGNORE_AMBIGUITIES flag", () => {
     it("will ignore specific alternative ambiguity", () => {
-      class IgnoreAlternativeAmbiguitiesFlagParser extends Parser {
+      class IgnoreAlternativeAmbiguitiesFlagParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
           super([PlusTok, StarTok])
           this.performSelfAnalysis()
@@ -1192,7 +1200,7 @@ describe("The empty alternative detection full flow", () => {
     })
 
     it("will ignore all alternation ambiguities", () => {
-      class IgnoreAlternationAmbiguitiesFlagParser extends Parser {
+      class IgnoreAlternationAmbiguitiesFlagParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
           super([PlusTok, StarTok])
           this.performSelfAnalysis()
@@ -1230,7 +1238,7 @@ describe("The empty alternative detection full flow", () => {
   })
 
   it("will throw an error when an empty alternative is not the last alternative #2", () => {
-    class EmptyAltAmbiguityParser2 extends Parser {
+    class EmptyAltAmbiguityParser2 extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([PlusTok, StarTok])
         this.performSelfAnalysis()
@@ -1273,7 +1281,7 @@ describe("The prefix ambiguity detection full flow", () => {
     let B = createToken({ name: "B", categories: A })
     let C = createToken({ name: "C" })
 
-    class PrefixAltAmbiguity extends Parser {
+    class PrefixAltAmbiguity extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([A, B, C])
         this.performSelfAnalysis()
@@ -1316,7 +1324,7 @@ describe("The prefix ambiguity detection full flow", () => {
 
     const ALL_TOKENS = [OneTok, TwoTok, Comma]
 
-    class AlternativesAmbiguityParser extends Parser {
+    class AlternativesAmbiguityParser extends EmbeddedActionsParser {
       constructor() {
         super(ALL_TOKENS, {
           maxLookahead: 4
@@ -1367,7 +1375,7 @@ describe("The prefix ambiguity detection full flow", () => {
 
     const ALL_TOKENS = [A, B, C, D]
 
-    class AlternativesAmbiguityParser extends Parser {
+    class AlternativesAmbiguityParser extends EmbeddedActionsParser {
       constructor() {
         super(ALL_TOKENS, {
           maxLookahead: 4
@@ -1410,7 +1418,7 @@ describe("The prefix ambiguity detection full flow", () => {
 
   // TODO: detect these ambiguity with categories
   it("will throw an error when an a common prefix ambiguity is detected - implicit occurrence idx", () => {
-    class PrefixAltAmbiguity2 extends Parser {
+    class PrefixAltAmbiguity2 extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([PlusTok, MinusTok, StarTok])
         this.performSelfAnalysis()
@@ -1456,7 +1464,7 @@ describe("The namespace conflict detection full flow", () => {
       static PATTERN = /NA/
     }
 
-    class NameSpaceConflict extends Parser {
+    class NameSpaceConflict extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([Bamba, A])
 
@@ -1481,7 +1489,7 @@ describe("The nested rule name validation full flow", () => {
       static PATTERN = /NA/
     }
 
-    class NestedNamedInvalid extends Parser {
+    class NestedNamedInvalid extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([A])
         this.performSelfAnalysis()
@@ -1513,7 +1521,7 @@ describe("The duplicated nested name validation full flow", () => {
       static PATTERN = /NA/
     }
 
-    class NestedNamedDuplicate extends Parser {
+    class NestedNamedDuplicate extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([A, B])
         this.performSelfAnalysis()
@@ -1551,7 +1559,7 @@ describe("The invalid token name validation", () => {
       static PATTERN = /NA/
     }
 
-    class InvalidTokenName extends Parser {
+    class InvalidTokenName extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([במבה, A])
         this.performSelfAnalysis()
@@ -1570,7 +1578,7 @@ describe("The invalid token name validation", () => {
 
 describe("The no non-empty lookahead validation", () => {
   it("will throw an error when there are no non-empty lookaheads for AT_LEAST_ONE", () => {
-    class EmptyLookaheadParserAtLeastOne extends Parser {
+    class EmptyLookaheadParserAtLeastOne extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([PlusTok])
         this.performSelfAnalysis()
@@ -1588,7 +1596,7 @@ describe("The no non-empty lookahead validation", () => {
   })
 
   it("will throw an error when there are no non-empty lookaheads for AT_LEAST_ONE_SEP", () => {
-    class EmptyLookaheadParserAtLeastOneSep extends Parser {
+    class EmptyLookaheadParserAtLeastOneSep extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([PlusTok])
         this.performSelfAnalysis()
@@ -1611,7 +1619,7 @@ describe("The no non-empty lookahead validation", () => {
   })
 
   it("will throw an error when there are no non-empty lookaheads for MANY", () => {
-    class EmptyLookaheadParserMany extends Parser {
+    class EmptyLookaheadParserMany extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([PlusTok])
         this.performSelfAnalysis()
@@ -1629,7 +1637,7 @@ describe("The no non-empty lookahead validation", () => {
   })
 
   it("will throw an error when there are no non-empty lookaheads for MANY_SEP", () => {
-    class EmptyLookaheadParserManySep extends Parser {
+    class EmptyLookaheadParserManySep extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([PlusTok])
         this.performSelfAnalysis()

--- a/packages/chevrotain/test/parse/grammar/interperter_spec.ts
+++ b/packages/chevrotain/test/parse/grammar/interperter_spec.ts
@@ -34,7 +34,7 @@ import {
   augmentTokenTypes,
   tokenStructuredMatcher
 } from "../../../src/scan/tokens"
-import { Parser } from "../../../src/parse/parser/traits/parser_traits"
+import { EmbeddedActionsParser } from "../../../src/parse/parser/traits/parser_traits"
 import {
   Alternation,
   Flat,
@@ -1651,7 +1651,7 @@ describe("issue 391 - WITH_SEP variants do not take SEP into account in lookahea
     const allTokens = [WhiteSpace, LParen, RParen, Comma, FatArrow, Identifier]
     const issue391Lexer = new Lexer(allTokens)
 
-    class Issue391Parser extends Parser {
+    class Issue391Parser extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super(allTokens, {
           maxLookahead: 4

--- a/packages/chevrotain/test/parse/grammar/lookahead_spec.ts
+++ b/packages/chevrotain/test/parse/grammar/lookahead_spec.ts
@@ -28,6 +28,7 @@ import {
   Terminal
 } from "../../../src/parse/grammar/gast/gast_public"
 import { IToken, TokenType } from "../../../api"
+import { EmbeddedActionsParser } from "../../../src/parse/parser/traits/parser_traits"
 
 const IdentTok = createToken({ name: "IdentTok" })
 const DotTok = createToken({ name: "DotTok" })
@@ -407,7 +408,7 @@ describe("getProdType", () => {
 })
 
 context("lookahead specs", () => {
-  class ColonParserMock extends Parser {
+  class ColonParserMock extends EmbeddedActionsParser {
     constructor() {
       super([ColonTok])
     }
@@ -417,7 +418,7 @@ context("lookahead specs", () => {
     }
   }
 
-  class IdentParserMock extends Parser {
+  class IdentParserMock extends EmbeddedActionsParser {
     constructor() {
       super([IdentTok])
     }
@@ -427,7 +428,7 @@ context("lookahead specs", () => {
     }
   }
 
-  class CommaParserMock extends Parser {
+  class CommaParserMock extends EmbeddedActionsParser {
     constructor() {
       super([CommaTok])
     }
@@ -437,7 +438,7 @@ context("lookahead specs", () => {
     }
   }
 
-  class EntityParserMock extends Parser {
+  class EntityParserMock extends EmbeddedActionsParser {
     constructor() {
       super([EntityTok])
     }
@@ -447,7 +448,7 @@ context("lookahead specs", () => {
     }
   }
 
-  class KeyParserMock extends Parser {
+  class KeyParserMock extends EmbeddedActionsParser {
     constructor() {
       super([KeyTok])
     }

--- a/packages/chevrotain/test/parse/predicate_spec.ts
+++ b/packages/chevrotain/test/parse/predicate_spec.ts
@@ -1,4 +1,4 @@
-import { Parser } from "../../src/parse/parser/traits/parser_traits"
+import { EmbeddedActionsParser } from "../../src/parse/parser/traits/parser_traits"
 import {
   EarlyExitException,
   NoViableAltException
@@ -28,9 +28,9 @@ describe("The chevrotain support for custom gates/predicates on DSL production:"
       return this.gate
     }
 
-    class PredicateOptionParser extends Parser {
+    class PredicateOptionParser extends EmbeddedActionsParser {
       constructor(input: IToken[] = [], private gate: boolean) {
-        super(ALL_TOKENS, { outputCst: false })
+        super(ALL_TOKENS, {})
         this.performSelfAnalysis()
         this.input = input
       }
@@ -78,9 +78,9 @@ describe("The chevrotain support for custom gates/predicates on DSL production:"
       return this.gate
     }
 
-    class PredicateManyParser extends Parser {
+    class PredicateManyParser extends EmbeddedActionsParser {
       constructor(input: IToken[] = [], private gate: boolean) {
-        super(ALL_TOKENS, { outputCst: false })
+        super(ALL_TOKENS, {})
         this.performSelfAnalysis()
         this.input = input
       }
@@ -129,9 +129,9 @@ describe("The chevrotain support for custom gates/predicates on DSL production:"
       return this.gate
     }
 
-    class PredicateAtLeastOneParser extends Parser {
+    class PredicateAtLeastOneParser extends EmbeddedActionsParser {
       constructor(input: IToken[] = [], private gate: boolean) {
-        super(ALL_TOKENS, { outputCst: false })
+        super(ALL_TOKENS, {})
         this.performSelfAnalysis()
         this.input = input
       }
@@ -190,9 +190,9 @@ describe("The chevrotain support for custom gates/predicates on DSL production:"
       return this.gate
     }
 
-    class PredicateOrParser extends Parser {
+    class PredicateOrParser extends EmbeddedActionsParser {
       constructor(input: IToken[] = [], private gate: boolean) {
-        super(ALL_TOKENS, { outputCst: false })
+        super(ALL_TOKENS, {})
         this.performSelfAnalysis()
         this.input = input
       }
@@ -267,9 +267,9 @@ describe("The chevrotain support for custom gates/predicates on DSL production:"
 
   describe("Predicates shall work with parametrized rules (issue #221)", () => {
     it("predicates in OR", () => {
-      class PredicateWithRuleOrParser extends Parser {
+      class PredicateWithRuleOrParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
-          super(ALL_TOKENS, { outputCst: false })
+          super(ALL_TOKENS, {})
           this.performSelfAnalysis()
           this.input = input
         }
@@ -301,9 +301,9 @@ describe("The chevrotain support for custom gates/predicates on DSL production:"
     })
 
     it("predicates in OPTION", () => {
-      class PredicateWithRuleOptionParser extends Parser {
+      class PredicateWithRuleOptionParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
-          super(ALL_TOKENS, { outputCst: false })
+          super(ALL_TOKENS, {})
           this.performSelfAnalysis()
           this.input = input
         }
@@ -332,9 +332,9 @@ describe("The chevrotain support for custom gates/predicates on DSL production:"
     })
 
     it("predicates in MANY", () => {
-      class PredicateWithRuleManyParser extends Parser {
+      class PredicateWithRuleManyParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
-          super(ALL_TOKENS, { outputCst: false })
+          super(ALL_TOKENS, {})
           this.performSelfAnalysis()
           this.input = input
         }
@@ -369,9 +369,9 @@ describe("The chevrotain support for custom gates/predicates on DSL production:"
     })
 
     it("predicates in AT_LEAST_ONE", () => {
-      class PredicateWithRuleAtLeastOneParser extends Parser {
+      class PredicateWithRuleAtLeastOneParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
-          super(ALL_TOKENS, { outputCst: false })
+          super(ALL_TOKENS, {})
           this.performSelfAnalysis()
           this.input = input
         }

--- a/packages/chevrotain/test/parse/recognizer/infinite_loop_spec.ts
+++ b/packages/chevrotain/test/parse/recognizer/infinite_loop_spec.ts
@@ -1,4 +1,4 @@
-import { Parser } from "../../../src/parse/parser/traits/parser_traits"
+import { EmbeddedActionsParser } from "../../../src/parse/parser/traits/parser_traits"
 import { createRegularToken } from "../../utils/matchers"
 import { augmentTokenTypes } from "../../../src/scan/tokens"
 import { IToken } from "../../../api"
@@ -11,7 +11,7 @@ describe("The Recognizer's capabilities for detecting infinite loops", () => {
   augmentTokenTypes(<any>[PlusTok])
 
   it("Will gracefully 'escape' from an infinite loop in a repetition", () => {
-    class InfiniteLoopParser extends Parser {
+    class InfiniteLoopParser extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([PlusTok])
 
@@ -54,7 +54,7 @@ describe("The Recognizer's capabilities for detecting infinite loops", () => {
 
     const allTokens = [Semi, A, B, C]
 
-    class InfParser extends Parser {
+    class InfParser extends EmbeddedActionsParser {
       constructor() {
         super(allTokens, {
           recoveryEnabled: true

--- a/packages/chevrotain/test/parse/recognizer/recognizer_config_spec.ts
+++ b/packages/chevrotain/test/parse/recognizer/recognizer_config_spec.ts
@@ -1,11 +1,11 @@
-import { Parser } from "../../../src/parse/parser/traits/parser_traits"
+import { EmbeddedActionsParser } from "../../../src/parse/parser/traits/parser_traits"
 import { createToken } from "../../../src/scan/tokens_public"
 
 describe("The Recognizer's Configuration", () => {
   it("default config values - empty config", () => {
     const A = createToken({ name: "A" })
 
-    class EmptyConfigParser extends Parser {
+    class EmptyConfigParser extends EmbeddedActionsParser {
       constructor() {
         super([A], {})
       }
@@ -20,7 +20,7 @@ describe("The Recognizer's Configuration", () => {
   it("default config values - no config", () => {
     const A = createToken({ name: "A" })
 
-    class NoConfigParser extends Parser {
+    class NoConfigParser extends EmbeddedActionsParser {
       constructor() {
         super([A])
       }
@@ -36,7 +36,7 @@ describe("The Recognizer's Configuration", () => {
     const A = createToken({ name: "A" })
 
     const invalidConfig = { ignoredIssues: {} }
-    class IgnoredIssuesParser extends Parser {
+    class IgnoredIssuesParser extends EmbeddedActionsParser {
       constructor() {
         super([A], invalidConfig as any)
       }

--- a/packages/chevrotain/test/parse/recognizer/rules_override_spec.ts
+++ b/packages/chevrotain/test/parse/recognizer/rules_override_spec.ts
@@ -1,4 +1,4 @@
-import { Parser } from "../../../src/parse/parser/traits/parser_traits"
+import { EmbeddedActionsParser } from "../../../src/parse/parser/traits/parser_traits"
 import { createRegularToken } from "../../utils/matchers"
 import { augmentTokenTypes } from "../../../src/scan/tokens"
 import { IToken } from "../../../api"
@@ -15,9 +15,9 @@ describe("The Recognizer's capabilities for overriding grammar productions", () 
   augmentTokenTypes(<any>[PlusTok, MinusTok])
 
   it("Can override an existing rule", () => {
-    class SuperOverrideParser extends Parser {
+    class SuperOverrideParser extends EmbeddedActionsParser {
       constructor(isInvokedByChildConstructor = false) {
-        super(<any>[PlusTok, MinusTok], { outputCst: false })
+        super(<any>[PlusTok, MinusTok], {})
 
         // performSelfAnalysis should only be invoked once.
         if (!isInvokedByChildConstructor) {
@@ -72,7 +72,7 @@ describe("The Recognizer's capabilities for overriding grammar productions", () 
   })
 
   it("Can not override a rule which does not exist", () => {
-    class InvalidOverrideParser extends Parser {
+    class InvalidOverrideParser extends EmbeddedActionsParser {
       constructor(input: IToken[] = []) {
         super([PlusTok, MinusTok])
         this.performSelfAnalysis()

--- a/packages/chevrotain/test/parse/recognizer_lookahead_spec.ts
+++ b/packages/chevrotain/test/parse/recognizer_lookahead_spec.ts
@@ -1,5 +1,5 @@
 import { createToken } from "../../src/scan/tokens_public"
-import { Parser } from "../../src/parse/parser/traits/parser_traits"
+import { EmbeddedActionsParser } from "../../src/parse/parser/traits/parser_traits"
 import { createRegularToken } from "../utils/matchers"
 import { IToken } from "../../api"
 import { isES2015MapSupported } from "../../src/utils/utils"
@@ -31,7 +31,7 @@ describe("lookahead Regular Tokens Mode", () => {
   ]
 
   describe("The implicit lookahead calculation functionality of the Recognizer For OPTION", () => {
-    class OptionsImplicitLookAheadParser extends Parser {
+    class OptionsImplicitLookAheadParser extends EmbeddedActionsParser {
       public getLookAheadCacheSize(): number {
         if (isES2015MapSupported()) {
           // @ts-ignore
@@ -43,7 +43,7 @@ describe("lookahead Regular Tokens Mode", () => {
       }
 
       constructor(input: IToken[] = []) {
-        super(ALL_TOKENS, { outputCst: false })
+        super(ALL_TOKENS, {})
 
         this.performSelfAnalysis()
         this.input = input
@@ -129,7 +129,7 @@ describe("lookahead Regular Tokens Mode", () => {
   })
 
   describe("The implicit lookahead calculation functionality of the Recognizer For MANY", () => {
-    class ManyImplicitLookAheadParser extends Parser {
+    class ManyImplicitLookAheadParser extends EmbeddedActionsParser {
       public getLookAheadCacheSize(): number {
         if (isES2015MapSupported()) {
           // @ts-ignore
@@ -141,7 +141,7 @@ describe("lookahead Regular Tokens Mode", () => {
       }
 
       constructor(input: IToken[] = []) {
-        super(ALL_TOKENS, { outputCst: false })
+        super(ALL_TOKENS, {})
 
         this.performSelfAnalysis()
         this.input = input
@@ -281,7 +281,7 @@ describe("lookahead Regular Tokens Mode", () => {
   })
 
   describe("The implicit lookahead calculation functionality of the Recognizer For MANY_SEP", () => {
-    class ManySepImplicitLookAheadParser extends Parser {
+    class ManySepImplicitLookAheadParser extends EmbeddedActionsParser {
       public getLookAheadCacheSize(): number {
         if (isES2015MapSupported()) {
           // @ts-ignore
@@ -293,7 +293,7 @@ describe("lookahead Regular Tokens Mode", () => {
       }
 
       constructor(input: IToken[] = []) {
-        super(ALL_TOKENS, { outputCst: false })
+        super(ALL_TOKENS, {})
 
         this.performSelfAnalysis()
         this.input = input
@@ -457,7 +457,7 @@ describe("lookahead Regular Tokens Mode", () => {
   })
 
   describe("The implicit lookahead calculation functionality of the Recognizer For AT_LEAST_ONE", () => {
-    class AtLeastOneImplicitLookAheadParser extends Parser {
+    class AtLeastOneImplicitLookAheadParser extends EmbeddedActionsParser {
       public getLookAheadCacheSize(): number {
         if (isES2015MapSupported()) {
           // @ts-ignore
@@ -469,7 +469,7 @@ describe("lookahead Regular Tokens Mode", () => {
       }
 
       constructor(input: IToken[] = []) {
-        super(ALL_TOKENS, { outputCst: false })
+        super(ALL_TOKENS, {})
 
         this.performSelfAnalysis()
         this.input = input
@@ -576,7 +576,7 @@ describe("lookahead Regular Tokens Mode", () => {
   })
 
   describe("The implicit lookahead calculation functionality of the Recognizer For AT_LEAST_ONE_SEP", () => {
-    class AtLeastOneSepImplicitLookAheadParser extends Parser {
+    class AtLeastOneSepImplicitLookAheadParser extends EmbeddedActionsParser {
       public getLookAheadCacheSize(): number {
         if (isES2015MapSupported()) {
           // @ts-ignore
@@ -588,7 +588,7 @@ describe("lookahead Regular Tokens Mode", () => {
       }
 
       constructor(input: IToken[] = []) {
-        super(ALL_TOKENS, { outputCst: false })
+        super(ALL_TOKENS, {})
 
         this.performSelfAnalysis()
         this.input = input
@@ -728,7 +728,7 @@ describe("lookahead Regular Tokens Mode", () => {
   })
 
   describe("The implicit lookahead calculation functionality of the Recognizer For OR", () => {
-    class OrImplicitLookAheadParser extends Parser {
+    class OrImplicitLookAheadParser extends EmbeddedActionsParser {
       public getLookAheadCacheSize(): number {
         if (isES2015MapSupported()) {
           // @ts-ignore
@@ -740,7 +740,7 @@ describe("lookahead Regular Tokens Mode", () => {
       }
 
       constructor(input: IToken[] = []) {
-        super(ALL_TOKENS, { outputCst: false })
+        super(ALL_TOKENS, {})
 
         this.performSelfAnalysis()
         this.input = input
@@ -977,9 +977,9 @@ describe("lookahead Regular Tokens Mode", () => {
 
   describe("OR production ambiguity detection when using implicit lookahead calculation", () => {
     it("will throw an error when two alternatives have the same single token (lookahead 1) prefix", () => {
-      class OrAmbiguityLookAheadParser extends Parser {
+      class OrAmbiguityLookAheadParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
-          super(ALL_TOKENS, { outputCst: false })
+          super(ALL_TOKENS, {})
 
           this.performSelfAnalysis()
           this.input = input
@@ -1024,9 +1024,9 @@ describe("lookahead Regular Tokens Mode", () => {
     })
 
     it("will throw an error when two alternatives have the same multi token (lookahead > 1) prefix", () => {
-      class OrAmbiguityMultiTokenLookAheadParser extends Parser {
+      class OrAmbiguityMultiTokenLookAheadParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
-          super(ALL_TOKENS, { outputCst: false })
+          super(ALL_TOKENS, {})
 
           this.performSelfAnalysis()
           this.input = input
@@ -1071,7 +1071,7 @@ describe("lookahead Regular Tokens Mode", () => {
   })
 
   describe("The implicit lookahead calculation functionality of the Recognizer For OR (with IGNORE_AMBIGUITIES)", () => {
-    class OrImplicitLookAheadParserIgnoreAmbiguities extends Parser {
+    class OrImplicitLookAheadParserIgnoreAmbiguities extends EmbeddedActionsParser {
       public getLookAheadCacheSize(): number {
         if (isES2015MapSupported()) {
           // @ts-ignore
@@ -1083,9 +1083,7 @@ describe("lookahead Regular Tokens Mode", () => {
       }
 
       constructor(input: IToken[] = []) {
-        super(ALL_TOKENS, {
-          outputCst: false
-        })
+        super(ALL_TOKENS, {})
 
         this.performSelfAnalysis()
         this.input = input
@@ -1297,9 +1295,9 @@ describe("lookahead Regular Tokens Mode", () => {
 
   describe("The support for MultiToken (K>1) implicit lookahead capabilities in DSL Production:", () => {
     it("OPTION", () => {
-      class MultiTokenLookAheadForOptionParser extends Parser {
+      class MultiTokenLookAheadForOptionParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
-          super(ALL_TOKENS, { outputCst: false })
+          super(ALL_TOKENS, {})
 
           this.performSelfAnalysis()
           this.input = input
@@ -1336,9 +1334,9 @@ describe("lookahead Regular Tokens Mode", () => {
     })
 
     it("MANY", () => {
-      class MultiTokenLookAheadForManyParser extends Parser {
+      class MultiTokenLookAheadForManyParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
-          super(ALL_TOKENS, { outputCst: false })
+          super(ALL_TOKENS, {})
 
           this.performSelfAnalysis()
           this.input = input
@@ -1388,9 +1386,9 @@ describe("lookahead Regular Tokens Mode", () => {
     })
 
     it("MANY_SEP", () => {
-      class MultiTokenLookAheadForManySepParser extends Parser {
+      class MultiTokenLookAheadForManySepParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
-          super(ALL_TOKENS, { outputCst: false })
+          super(ALL_TOKENS, {})
 
           this.performSelfAnalysis()
           this.input = input
@@ -1443,9 +1441,9 @@ describe("lookahead Regular Tokens Mode", () => {
     })
 
     it("OR", () => {
-      class MultiTokenLookAheadForOrParser extends Parser {
+      class MultiTokenLookAheadForOrParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
-          super(ALL_TOKENS, { outputCst: false })
+          super(ALL_TOKENS, {})
 
           this.performSelfAnalysis()
           this.input = input
@@ -1511,9 +1509,9 @@ describe("lookahead Regular Tokens Mode", () => {
     })
 
     it("AT_LEAST_ONE", () => {
-      class MultiTokenLookAheadForAtLeastOneParser extends Parser {
+      class MultiTokenLookAheadForAtLeastOneParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
-          super(ALL_TOKENS, { outputCst: false })
+          super(ALL_TOKENS, {})
 
           this.performSelfAnalysis()
           this.input = input
@@ -1573,9 +1571,9 @@ describe("lookahead Regular Tokens Mode", () => {
     })
 
     it("AT_LEAST_ONE_SEP", () => {
-      class MultiTokenLookAheadForAtLeastOneSepParser extends Parser {
+      class MultiTokenLookAheadForAtLeastOneSepParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
-          super(ALL_TOKENS, { outputCst: false })
+          super(ALL_TOKENS, {})
 
           this.performSelfAnalysis()
           this.input = input
@@ -1643,9 +1641,9 @@ describe("lookahead Regular Tokens Mode", () => {
 
   describe("The support for MultiToken (K>1) EXPLICIT lookahead capabilities in DSL Production:", () => {
     it("OPTION", () => {
-      class MultiTokenLookAheadForOptionParser extends Parser {
+      class MultiTokenLookAheadForOptionParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
-          super(ALL_TOKENS, { outputCst: false })
+          super(ALL_TOKENS, {})
 
           this.performSelfAnalysis()
           this.input = input
@@ -1682,10 +1680,9 @@ describe("lookahead Regular Tokens Mode", () => {
     })
 
     it("MANY", () => {
-      class MultiTokenLookAheadForManyParser extends Parser {
+      class MultiTokenLookAheadForManyParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
           super(ALL_TOKENS, {
-            outputCst: false,
             // Global Low maxLookahead
             maxLookahead: 1
           })
@@ -1742,9 +1739,9 @@ describe("lookahead Regular Tokens Mode", () => {
     })
 
     it("MANY_SEP", () => {
-      class MultiTokenLookAheadForManySepParser extends Parser {
+      class MultiTokenLookAheadForManySepParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
-          super(ALL_TOKENS, { maxLookahead: 1, outputCst: false })
+          super(ALL_TOKENS, { maxLookahead: 1 })
 
           this.performSelfAnalysis()
           this.input = input
@@ -1798,12 +1795,11 @@ describe("lookahead Regular Tokens Mode", () => {
     })
 
     it("OR", () => {
-      class MultiTokenLookAheadForOrParser extends Parser {
+      class MultiTokenLookAheadForOrParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
           super(ALL_TOKENS, {
             // Global low maxLookahead should cause ambiguities in this grammar
-            maxLookahead: 1,
-            outputCst: false
+            maxLookahead: 1
           })
 
           this.performSelfAnalysis()
@@ -1874,9 +1870,9 @@ describe("lookahead Regular Tokens Mode", () => {
     })
 
     it("AT_LEAST_ONE", () => {
-      class MultiTokenLookAheadForAtLeastOneParser extends Parser {
+      class MultiTokenLookAheadForAtLeastOneParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
-          super(ALL_TOKENS, { maxLookahead: 1, outputCst: false })
+          super(ALL_TOKENS, { maxLookahead: 1 })
 
           this.performSelfAnalysis()
           this.input = input
@@ -1939,9 +1935,9 @@ describe("lookahead Regular Tokens Mode", () => {
     })
 
     it("AT_LEAST_ONE_SEP", () => {
-      class MultiTokenLookAheadForAtLeastOneSepParser extends Parser {
+      class MultiTokenLookAheadForAtLeastOneSepParser extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
-          super(ALL_TOKENS, { maxLookahead: 1, outputCst: false })
+          super(ALL_TOKENS, { maxLookahead: 1 })
 
           this.performSelfAnalysis()
           this.input = input
@@ -2009,11 +2005,9 @@ describe("lookahead Regular Tokens Mode", () => {
   })
 
   describe("Lookahead bug: MANY in OR", () => {
-    class ManyInOrBugParser extends Parser {
+    class ManyInOrBugParser extends EmbeddedActionsParser {
       constructor() {
-        super(ALL_TOKENS, {
-          outputCst: false
-        })
+        super(ALL_TOKENS, {})
         this.performSelfAnalysis()
       }
 
@@ -2066,7 +2060,7 @@ describe("lookahead Regular Tokens Mode", () => {
       const C = createToken({ name: "C" })
       const D = createToken({ name: "D" })
 
-      class CategoriesLookaheadBugParser extends Parser {
+      class CategoriesLookaheadBugParser extends EmbeddedActionsParser {
         constructor() {
           super([A, B, C, D])
           this.performSelfAnalysis()

--- a/packages/chevrotain/test/parse/recognizer_spec.ts
+++ b/packages/chevrotain/test/parse/recognizer_spec.ts
@@ -2,7 +2,7 @@ import { EOF, createToken } from "../../src/scan/tokens_public"
 import { Lexer } from "../../src/scan/lexer_public"
 import {
   EmbeddedActionsParser,
-  Parser
+  CstParser
 } from "../../src/parse/parser/traits/parser_traits"
 import { EMPTY_ALT } from "../../src/parse/parser/parser"
 
@@ -43,7 +43,7 @@ function defineRecognizerSpecs(
           private index = 1
 
           constructor(input: IToken[] = []) {
-            super(ALL_TOKENS, { outputCst: false })
+            super(ALL_TOKENS, {})
 
             this.performSelfAnalysis()
             this.input = input
@@ -81,12 +81,12 @@ function defineRecognizerSpecs(
       })
 
       it("provides a production SUBRULE1-5 that can accept arguments from its caller", () => {
-        class SubRuleArgsParser extends Parser {
+        class SubRuleArgsParser extends EmbeddedActionsParser {
           private numbers = ""
           private letters = ""
 
           constructor(input: IToken[] = []) {
-            super(ALL_TOKENS, { outputCst: false })
+            super(ALL_TOKENS, {})
 
             this.performSelfAnalysis()
             this.input = input
@@ -145,9 +145,9 @@ function defineRecognizerSpecs(
       })
 
       describe("supports EMPTY(...) alternative convenience function", () => {
-        class EmptyAltParser extends Parser {
+        class EmptyAltParser extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
-            super(ALL_TOKENS, { outputCst: false })
+            super(ALL_TOKENS, {})
 
             this.performSelfAnalysis()
             this.input = input
@@ -207,7 +207,7 @@ function defineRecognizerSpecs(
           categories: [Keyword, Literal]
         })
 
-        class CategoriesParser extends Parser {
+        class CategoriesParser extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
             super([Keyword, Literal], {})
 
@@ -237,10 +237,9 @@ function defineRecognizerSpecs(
     })
 
     describe("The Error Recovery functionality of the Chevrotain Parser", () => {
-      class ManyRepetitionRecovery extends Parser {
+      class ManyRepetitionRecovery extends EmbeddedActionsParser {
         constructor(input: IToken[] = [], isErrorRecoveryEnabled = true) {
           super(ALL_TOKENS, {
-            outputCst: false,
             recoveryEnabled: isErrorRecoveryEnabled
           })
 
@@ -273,10 +272,9 @@ function defineRecognizerSpecs(
         }
       }
 
-      class ManySepRepetitionRecovery extends Parser {
+      class ManySepRepetitionRecovery extends EmbeddedActionsParser {
         constructor(input: IToken[] = [], isErrorRecoveryEnabled = true) {
           super(ALL_TOKENS, {
-            outputCst: false,
             recoveryEnabled: isErrorRecoveryEnabled
           })
 
@@ -311,10 +309,9 @@ function defineRecognizerSpecs(
         }
       }
 
-      class ManySepSubRuleRepetitionRecovery extends Parser {
+      class ManySepSubRuleRepetitionRecovery extends EmbeddedActionsParser {
         constructor(input: IToken[] = []) {
           super(ALL_TOKENS, {
-            outputCst: false,
             recoveryEnabled: true
           })
 
@@ -354,10 +351,9 @@ function defineRecognizerSpecs(
         }
       }
 
-      class AtLeastOneRepetitionRecovery extends Parser {
+      class AtLeastOneRepetitionRecovery extends EmbeddedActionsParser {
         constructor(input: IToken[] = [], isErrorRecoveryEnabled = true) {
           super(ALL_TOKENS, {
-            outputCst: false,
             recoveryEnabled: isErrorRecoveryEnabled
           })
 
@@ -391,10 +387,9 @@ function defineRecognizerSpecs(
         }
       }
 
-      class AtLeastOneSepRepetitionRecovery extends Parser {
+      class AtLeastOneSepRepetitionRecovery extends EmbeddedActionsParser {
         constructor(input: IToken[] = [], isErrorRecoveryEnabled = true) {
           super(ALL_TOKENS, {
-            outputCst: false,
             recoveryEnabled: isErrorRecoveryEnabled
           })
 
@@ -427,8 +422,7 @@ function defineRecognizerSpecs(
       }
 
       it("can CONSUME tokens with an index specifying the occurrence for the specific token in the current rule", () => {
-        let parser: any = new Parser(ALL_TOKENS, {
-          outputCst: false,
+        let parser: any = new EmbeddedActionsParser(ALL_TOKENS, {
           recoveryEnabled: true
         })
         parser.reset()
@@ -451,7 +445,7 @@ function defineRecognizerSpecs(
       })
 
       it("will not perform inRepetition recovery while in backtracking mode", () => {
-        let parser: any = new Parser([PlusTok], {})
+        let parser: any = new EmbeddedActionsParser([PlusTok], {})
         parser.isBackTrackingStack.push(1)
         expect(parser.shouldInRepetitionRecoveryBeTried(MinusTok, 1)).to.equal(
           false
@@ -602,10 +596,9 @@ function defineRecognizerSpecs(
           positionTracking: "onlyOffset"
         })
 
-        class SingleTokenInsertRegular extends Parser {
+        class SingleTokenInsertRegular extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
             super(allTokens, {
-              outputCst: false,
               recoveryEnabled: true
             })
 
@@ -639,9 +632,9 @@ function defineRecognizerSpecs(
 
     describe("The Parsing DSL methods are expressions", () => {
       it("OR will return the chosen alternative's grammar action's returned value", () => {
-        class OrExpressionParser extends Parser {
+        class OrExpressionParser extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
-            super(ALL_TOKENS, { outputCst: false })
+            super(ALL_TOKENS, {})
 
             this.performSelfAnalysis()
             this.input = input
@@ -675,9 +668,9 @@ function defineRecognizerSpecs(
       })
 
       it("OPTION will return the grammar action value or undefined if the option was not taken", () => {
-        class OptionExpressionParser extends Parser {
+        class OptionExpressionParser extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
-            super(ALL_TOKENS, { outputCst: false })
+            super(ALL_TOKENS, {})
 
             this.performSelfAnalysis()
             this.input = input
@@ -703,26 +696,28 @@ function defineRecognizerSpecs(
 
     describe("The BaseRecognizer", () => {
       it("Cannot be initialized with a token vector (pre v4.0 API) ", () => {
-        expect(() => new Parser([createTokenInstance(PlusTok)])).to.throw(
+        expect(
+          () => new EmbeddedActionsParser([createTokenInstance(PlusTok)])
+        ).to.throw(
           "The Parser constructor no longer accepts a token vector as the first argument"
         )
       })
 
       it("Cannot be initialized with a serializedGrammar property (pre v6.0 API)", () => {
         const config: any = { serializedGrammar: {} }
-        expect(() => new Parser([], config)).to.throw(
+        expect(() => new EmbeddedActionsParser([], config)).to.throw(
           "The Parser's configuration can no longer contain a <serializedGrammar> property."
         )
       })
 
       it("Cannot be initialized with an empty Token vocabulary", () => {
-        expect(() => new Parser([])).to.throw(
+        expect(() => new EmbeddedActionsParser([])).to.throw(
           "A Token Vocabulary cannot be empty"
         )
       })
 
       it("Can skip Grammar Validations during initialization", () => {
-        class SkipValidationsParser extends Parser {
+        class SkipValidationsParser extends EmbeddedActionsParser {
           constructor(skipValidationsValue) {
             super(ALL_TOKENS, {
               skipValidations: skipValidationsValue
@@ -734,7 +729,7 @@ function defineRecognizerSpecs(
               this.CONSUME(IntTok)
             })
             // old deprecated static api
-            ;(Parser as any).performSelfAnalysis(this)
+            ;(EmbeddedActionsParser as any).performSelfAnalysis(this)
           }
         }
 
@@ -745,7 +740,7 @@ function defineRecognizerSpecs(
       })
 
       it("can only SAVE_ERROR for recognition exceptions", () => {
-        let parser: any = new Parser([IntTok])
+        let parser: any = new EmbeddedActionsParser([IntTok])
         expect(() =>
           parser.SAVE_ERROR(new Error("I am some random Error"))
         ).to.throw(
@@ -755,9 +750,7 @@ function defineRecognizerSpecs(
       })
 
       it("when it runs out of input EOF will be returned", () => {
-        let parser: any = new Parser([IntTok, PlusTok], {
-          outputCst: false
-        })
+        let parser: any = new EmbeddedActionsParser([IntTok, PlusTok], {})
         const sampleInput = [
           createTokenInstance(IntTok, "1"),
           createTokenInstance(PlusTok)
@@ -777,9 +770,9 @@ function defineRecognizerSpecs(
       })
 
       it("invoking an OPTION will return the inner grammar action's value or undefined", () => {
-        class OptionsReturnValueParser extends Parser {
+        class OptionsReturnValueParser extends EmbeddedActionsParser {
           constructor(input: IToken[] = [createTokenInstance(IntTok, "666")]) {
-            super(ALL_TOKENS, { outputCst: false })
+            super(ALL_TOKENS, {})
 
             this.performSelfAnalysis()
             this.input = input
@@ -814,7 +807,7 @@ function defineRecognizerSpecs(
       })
 
       it("will return false if a RecognitionException is thrown during backtracking and rethrow any other kind of Exception", () => {
-        let parser: any = new Parser([IntTok])
+        let parser: any = new EmbeddedActionsParser([IntTok])
         let backTrackingThrows = parser.BACKTRACK(
           () => {
             throw new Error("division by zero, boom")
@@ -842,7 +835,7 @@ function defineRecognizerSpecs(
 
     describe("The BaseRecognizer", () => {
       it("Will throw an error if performSelfAnalysis never called", () => {
-        class WrongOrderOfSelfAnalysisParser extends Parser {
+        class WrongOrderOfSelfAnalysisParser extends EmbeddedActionsParser {
           constructor() {
             super(ALL_TOKENS)
 
@@ -863,7 +856,7 @@ function defineRecognizerSpecs(
       })
 
       it("Will throw an error if performSelfAnalysis is called before all the rules have been defined", () => {
-        class WrongOrderOfSelfAnalysisParser extends Parser {
+        class WrongOrderOfSelfAnalysisParser extends EmbeddedActionsParser {
           constructor() {
             super(ALL_TOKENS)
 
@@ -884,7 +877,7 @@ function defineRecognizerSpecs(
       })
 
       it("Will throw an error is performSelfAnalysis is called before all the rules have been defined - static invocation", () => {
-        class WrongOrderOfSelfAnalysisParser extends Parser {
+        class WrongOrderOfSelfAnalysisParser extends EmbeddedActionsParser {
           constructor() {
             super(ALL_TOKENS)
 
@@ -892,7 +885,7 @@ function defineRecognizerSpecs(
               this.CONSUME(IntTok)
             })
             // old deprecated static api
-            ;(Parser as any).performSelfAnalysis(this)
+            ;(EmbeddedActionsParser as any).performSelfAnalysis(this)
 
             this.RULE("badRule", () => {
               this.CONSUME(IntTok)
@@ -906,7 +899,7 @@ function defineRecognizerSpecs(
       })
 
       it("can be initialized with a vector of Tokens", () => {
-        let parser: any = new Parser([PlusTok, MinusTok, IntTok])
+        let parser: any = new EmbeddedActionsParser([PlusTok, MinusTok, IntTok])
         let tokensMap = (<any>parser).tokensMap
         expect(tokensMap.PlusTok).to.equal(PlusTok)
         expect(tokensMap.MinusTok).to.equal(MinusTok)
@@ -919,7 +912,7 @@ function defineRecognizerSpecs(
           MinusTok: MinusTok,
           IntToken: IntTok
         }
-        let parser: any = new Parser({
+        let parser: any = new EmbeddedActionsParser({
           PlusTok: PlusTok,
           MinusTok: MinusTok,
           IntToken: IntTok
@@ -940,7 +933,7 @@ function defineRecognizerSpecs(
           },
           defaultMode: "bisli"
         }
-        let parser: any = new Parser(multiModeLexerDef)
+        let parser: any = new EmbeddedActionsParser(multiModeLexerDef)
         let tokensMap = (<any>parser).tokensMap
         // the implementation should clone the dictionary to avoid bugs caused by mutability
         expect(tokensMap).not.to.equal(multiModeLexerDef)
@@ -951,20 +944,20 @@ function defineRecognizerSpecs(
 
       it("cannot be initialized with other parameters", () => {
         expect(() => {
-          return new Parser(null)
+          return new EmbeddedActionsParser(null)
         }).to.throw()
 
         expect(() => {
-          return new Parser(<any>666)
+          return new EmbeddedActionsParser(<any>666)
         }).to.throw()
 
         expect(() => {
-          return new Parser(<any>"woof woof")
+          return new EmbeddedActionsParser(<any>"woof woof")
         }).to.throw()
       })
 
       it("will not swallow none Recognizer errors when attempting 'in rule error recovery'", () => {
-        class NotSwallowInRuleParser extends Parser {
+        class NotSwallowInRuleParser extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
             super(ALL_TOKENS, {
               recoveryEnabled: true
@@ -988,7 +981,7 @@ function defineRecognizerSpecs(
       })
 
       it("will not swallow none Recognizer errors during Token consumption", () => {
-        class NotSwallowInTokenConsumption extends Parser {
+        class NotSwallowInTokenConsumption extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
             super(ALL_TOKENS, {
               recoveryEnabled: true
@@ -1012,7 +1005,7 @@ function defineRecognizerSpecs(
       })
 
       it("will rethrow none Recognizer errors during Token consumption - recovery disabled + nested rule", () => {
-        class RethrowOtherErrors extends Parser {
+        class RethrowOtherErrors extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
             super(ALL_TOKENS, {
               recoveryEnabled: true
@@ -1053,7 +1046,7 @@ function defineRecognizerSpecs(
       })
 
       it("Will use Token LABELS for mismatch error messages when available", () => {
-        class LabelTokParser extends Parser {
+        class LabelTokParser extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
             super([PlusTok, MinusTok])
 
@@ -1074,7 +1067,7 @@ function defineRecognizerSpecs(
       })
 
       it("Will not use Token LABELS for mismatch error messages when unavailable", () => {
-        class NoLabelTokParser extends Parser {
+        class NoLabelTokParser extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
             super([PlusTok, MinusTok])
 
@@ -1098,7 +1091,7 @@ function defineRecognizerSpecs(
       it("Supports custom overriding of the mismatch token error message", () => {
         const SemiColon = createToken({ name: "SemiColon" })
 
-        class CustomConsumeErrorParser extends Parser {
+        class CustomConsumeErrorParser extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
             super([SemiColon])
 
@@ -1127,7 +1120,7 @@ function defineRecognizerSpecs(
       })
 
       it("Will use Token LABELS for noViableAlt error messages when unavailable", () => {
-        class LabelAltParser extends Parser {
+        class LabelAltParser extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
             super([PlusTok, MinusTok])
 
@@ -1161,11 +1154,9 @@ function defineRecognizerSpecs(
       })
 
       it("Will use Token LABELS for noViableAlt error messages when unavailable - nestedRuleNames", () => {
-        class LabelAltParserNested extends Parser {
+        class LabelAltParserNested extends CstParser {
           constructor(input: IToken[] = []) {
-            super([PlusTok, MinusTok], {
-              outputCst: true
-            })
+            super([PlusTok, MinusTok], {})
 
             this.performSelfAnalysis()
             this.input = input
@@ -1200,7 +1191,7 @@ function defineRecognizerSpecs(
       })
 
       it("Will not throw a JS runtime exception on noViableAlt - issue #887", () => {
-        class MaxlookaheadOneAlt extends Parser {
+        class MaxlookaheadOneAlt extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
             super([PlusTok, MinusTok], { maxLookahead: 1 })
 
@@ -1234,9 +1225,9 @@ function defineRecognizerSpecs(
       })
 
       it("Supports custom error messages for OR", () => {
-        class LabelAltParser2 extends Parser {
+        class LabelAltParser2 extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
-            super([PlusTok, MinusTok], { outputCst: false })
+            super([PlusTok, MinusTok], {})
 
             this.performSelfAnalysis()
             this.input = input
@@ -1269,7 +1260,7 @@ function defineRecognizerSpecs(
       })
 
       it("Will include the ruleStack in a recognition Exception", () => {
-        class NestedRulesParser extends Parser {
+        class NestedRulesParser extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
             super([PlusTok, MinusTok])
 
@@ -1316,7 +1307,7 @@ function defineRecognizerSpecs(
       })
 
       it("Will build an error message for AT_LEAST_ONE automatically", () => {
-        class ImplicitAtLeastOneErrParser extends Parser {
+        class ImplicitAtLeastOneErrParser extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
             super([PlusTok, MinusTok])
 
@@ -1363,7 +1354,7 @@ function defineRecognizerSpecs(
       })
 
       it("supports custom error messages for AT_LEAST_ONE", () => {
-        class ExplicitAtLeastOneErrParser extends Parser {
+        class ExplicitAtLeastOneErrParser extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
             super([PlusTok, MinusTok])
 
@@ -1408,7 +1399,7 @@ function defineRecognizerSpecs(
       })
 
       it("Will build an error message for AT_LEAST_ONE_SEP automatically", () => {
-        class ImplicitAtLeastOneSepErrParser extends Parser {
+        class ImplicitAtLeastOneSepErrParser extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
             super([PlusTok, MinusTok, IdentTok])
 
@@ -1459,7 +1450,7 @@ function defineRecognizerSpecs(
       })
 
       it("can serialize a Grammar's Structure", () => {
-        class SomeParser extends Parser {
+        class SomeParser extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
             super([PlusTok, MinusTok, IdentTok])
 
@@ -1501,7 +1492,7 @@ function defineRecognizerSpecs(
       })
 
       it("can provide syntactic content assist suggestions", () => {
-        class ContentAssistParser extends Parser {
+        class ContentAssistParser extends EmbeddedActionsParser {
           constructor(input: IToken[] = []) {
             super([PlusTok, MinusTok, IdentTok])
 

--- a/packages/chevrotain/test/parse/traits/perf_tracer_spec.ts
+++ b/packages/chevrotain/test/parse/traits/perf_tracer_spec.ts
@@ -1,5 +1,8 @@
 import { createToken } from "../../../src/scan/tokens_public"
-import { CstParser } from "../../../src/parse/parser/traits/parser_traits"
+import {
+  CstParser,
+  EmbeddedActionsParser
+} from "../../../src/parse/parser/traits/parser_traits"
 
 let skipOnBrowser = describe
 if (typeof window !== "undefined") {
@@ -21,10 +24,9 @@ skipOnBrowser("Chevrotain's Init Performance Tracing", () => {
 
   const PlusTok = createToken({ name: "PlusTok" })
 
-  class TraceParser extends CstParser {
+  class TraceParser extends EmbeddedActionsParser {
     constructor(traceInitVal) {
       super([PlusTok], {
-        outputCst: false,
         traceInitPerf: traceInitVal
       })
       this.performSelfAnalysis()

--- a/packages/chevrotain/test_integration/definitions/api_type_checking.ts
+++ b/packages/chevrotain/test_integration/definitions/api_type_checking.ts
@@ -11,7 +11,6 @@ export type TypeCheckForApi = [
       BaseParser: any
 
       /** @see  https://github.com/SAP/chevrotain/blob/87ed262c36b6f5cb4073e14f4f59901146c6c7a5/packages/chevrotain/src/api.ts#L213-L215*/
-      Parser: any
       CstParser: any
       EmbeddedActionsParser: any
       MismatchedTokenException: ErrorConstructor
@@ -25,6 +24,6 @@ export type TypeCheckForApi = [
     // after *.ts being compiled to *.d.ts,
     // get/set property type is wrongly inferred if property setter specifies this type.
     MixedInParser & { input: apiDefs.IToken[] },
-    apiDefs.Parser
+    apiDefs.BaseParser
   >
 ]

--- a/packages/chevrotain/test_integration/definitions/es6_modules.ts
+++ b/packages/chevrotain/test_integration/definitions/es6_modules.ts
@@ -1,4 +1,4 @@
-import { Parser, Lexer } from "../../lib/chevrotain"
+import { EmbeddedActionsParser, CstParser, Lexer } from "../../lib/chevrotain"
 
 /**
  * This File will be compiled using TSC to verify that the custom build chevrotain.d.ts

--- a/packages/chevrotain/test_integration/definitions/namespaces.ts
+++ b/packages/chevrotain/test_integration/definitions/namespaces.ts
@@ -1,6 +1,7 @@
 /// <reference path="../../lib/chevrotain.d.ts" />
 import Lexer = chevrotain.Lexer
-import Parser = chevrotain.Parser
+import EmbeddedActionsParser = chevrotain.EmbeddedActionsParser
+import CstParser = chevrotain.CstParser
 
 /**
  * This File will be compiled using TSC to verify that the custom build chevrotain.d.ts

--- a/packages/chevrotain/test_integration/sanity/json_parser_spec.js
+++ b/packages/chevrotain/test_integration/sanity/json_parser_spec.js
@@ -9,7 +9,7 @@
   // ----------------- lexer -----------------
   var createToken = chevrotain.createToken
   var Lexer = chevrotain.Lexer
-  var Parser = chevrotain.Parser
+  var CstParser = chevrotain.CstParser
 
   var True = createToken({ name: "True", pattern: /true/ })
   var False = createToken({ name: "False", pattern: /false/ })
@@ -54,7 +54,7 @@
   // ----------------- parser -----------------
   function JsonParser() {
     // invoke super constructor
-    Parser.call(this, allTokens)
+    CstParser.call(this, allTokens)
 
     // not mandatory, using <$> (or any other sign) to reduce verbosity (this. this. this. this. .......)
     var $ = this
@@ -117,7 +117,7 @@
   }
 
   // inheritance as implemented in javascript in the previous decade... :(
-  JsonParser.prototype = Object.create(Parser.prototype)
+  JsonParser.prototype = Object.create(CstParser.prototype)
   JsonParser.prototype.constructor = JsonParser
 
   // ----------------- wrapping it all together -----------------


### PR DESCRIPTION
Use CstParser and EmbeddedActionsParser instead

BREAKING CHANGE: Parser class was removed, use CstParser and EmbeddedActionsParser instead.