### PR TITLE
refactor: rename Flat -> Alternative in GAST structure

### DIFF
--- a/examples/custom_apis/combinator/combinator_api.js
+++ b/examples/custom_apis/combinator/combinator_api.js
@@ -13,7 +13,7 @@ const _ = require("lodash")
 const {
   Rule,
   RepetitionWithSeparator,
-  Flat,
+  Alternative,
   Alternation,
   Terminal,
   NonTerminal,
@@ -36,7 +36,8 @@ function toRule(name) {
 // rule: A B C ...
 function seq(...items) {
   const flatDef = _.flatMap(items, toDefinition)
-  const definition = new Flat({ definition: flatDef })
+  // TODO: here Flat was used outside Alternation
+  const definition = new Alternative({ definition: flatDef })
 
   const orgTextParts = _.map(items, toOriginalText)
   definition.orgText = `seq(${orgTextParts.join(", ")})`
@@ -66,7 +67,7 @@ function delimited(item, separator) {
 // rule: A | B | C | ...
 function choice(...alternatives) {
   const altsDefs = _.map(alternatives, alt => {
-    return new Flat({ definition: toDefinition(alt) })
+    return new Alternative({ definition: toDefinition(alt) })
   })
 
   const orgTextParts = _.map(alternatives, toOriginalText)

--- a/packages/chevrotain/api.d.ts
+++ b/packages/chevrotain/api.d.ts
@@ -2128,7 +2128,7 @@ export declare type ISeparatedIterationResult<OUT> = {
 export interface ISerializedGast {
   type:
     | "NonTerminal"
-    | "Flat"
+    | "Alternative"
     | "Option"
     | "RepetitionMandatory"
     | "RepetitionMandatoryWithSeparator"
@@ -2321,7 +2321,7 @@ export abstract class GAstVisitor {
 
   abstract visitNonTerminal(node: NonTerminal): any
 
-  abstract visitFlat(node: Flat): any
+  abstract visitAlternative(node: Alternative): any
 
   abstract visitOption(node: Option): any
 
@@ -2376,11 +2376,9 @@ export declare class NonTerminal implements IProductionWithOccurrence {
 }
 
 /**
- * The Grammar AST class used to represent a sequence.
- * This is normally only used in {@link Alternation} to distinguish
- * between the different alternatives.
+ * The Grammar AST class used to represent a single alternative in an {@link Alternation}.
  */
-export declare class Flat {
+export declare class Alternative {
   definition: IProduction[]
   ignoreAmbiguities: boolean
 

--- a/packages/chevrotain/docs/changes/BREAKING_CHANGES.md
+++ b/packages/chevrotain/docs/changes/BREAKING_CHANGES.md
@@ -64,6 +64,8 @@
 
 - The TokenType's `tokenName` property has been deprecated (This actually happened in 6.3.1...) use the `name` property instead.
 
+- The GAST `Flat` class was renamed to `Alternative`.
+
 ## 6.0.0
 
 - Due to re-implementation of the grammar analysis via ["grammar recording"](../guide/internals.md#grammar-recording), certain semantics action

--- a/packages/chevrotain/docs/guide/custom_apis.md
+++ b/packages/chevrotain/docs/guide/custom_apis.md
@@ -26,7 +26,7 @@ The structure of the GAST is made up of the following classes:
 - [RepetitionWithSeparator](https://sap.github.io/chevrotain/documentation/6_5_0/classes/repetitionwithseparator.html)
 - [RepetitionMandatory](https://sap.github.io/chevrotain/documentation/6_5_0/classes/repetitionmandatory.html)
 - [RepetitionMandatoryWithSeparator](https://sap.github.io/chevrotain/documentation/6_5_0/classes/repetitionmandatorywithseparator.html)
-- [Flat](https://sap.github.io/chevrotain/documentation/6_5_0/classes/flat.html) (sequence)
+- [Alternative](https://sap.github.io/chevrotain/documentation/6_5_0/classes/alternative.html) (sequence)
 
 For example to define a grammar rule for a fully qualified name:
 
@@ -59,29 +59,29 @@ Important to note that:
 
 - By default the definition array for each GAST class acts as a sequence,
   However in the case of Alternation each element in the definition array represents a different
-  alternative which should be wrapped in a Flat class.
+  alternative which should be wrapped in the `Alternative` class.
 
   e.g:
 
   ```javascript
-  const { Flat, Alternation } = require("chevrotain")
+  const { Alternative, Alternation } = require("chevrotain")
 
   const gastAlts = new Alternation({
     definition: [
       // first alternative
-      new Flat({
+      new Alternative({
         definition: [
           /*...*/
         ]
       }),
       // second alternative
-      new Flat({
+      new Alternative({
         definition: [
           /*...*/
         ]
       }),
       // third alternative
-      new Flat({
+      new Alternative({
         definition: [
           /*...*/
         ]

--- a/packages/chevrotain/src/api.ts
+++ b/packages/chevrotain/src/api.ts
@@ -43,7 +43,7 @@ export { defaultLexerErrorProvider } from "./scan/lexer_errors_public"
 
 export {
   Alternation,
-  Flat,
+  Alternative,
   NonTerminal,
   Option,
   Repetition,

--- a/packages/chevrotain/src/generate/generate.ts
+++ b/packages/chevrotain/src/generate/generate.ts
@@ -8,7 +8,7 @@ import {
   Terminal,
   NonTerminal,
   Alternation,
-  Flat,
+  Alternative,
   Repetition
 } from "../parse/grammar/gast/gast_public"
 import { IProduction, TokenType } from "../../api"
@@ -118,7 +118,7 @@ export function genAlternation(prod: Alternation, n: number): string {
   return result
 }
 
-export function genSingleAlt(prod: Flat, n: number): string {
+export function genSingleAlt(prod: Alternative, n: number): string {
   let result = indent(n, `{`) + NL
 
   result += indent(n + 1, "ALT: function() {") + NL
@@ -147,7 +147,7 @@ function genProd(prod: IProduction, n: number): string {
     return genAlternation(prod, n)
   } else if (prod instanceof Terminal) {
     return genTerminal(prod, n)
-  } else if (prod instanceof Flat) {
+  } else if (prod instanceof Alternative) {
     return genDefinition(prod.definition, n)
   } else {
     throw Error("non exhaustive match")

--- a/packages/chevrotain/src/parse/grammar/checks.ts
+++ b/packages/chevrotain/src/parse/grammar/checks.ts
@@ -28,7 +28,7 @@ import {
 import { nextPossibleTokensAfter } from "./interpreter"
 import {
   Alternation,
-  Flat,
+  Alternative as AlternativeGAST,
   NonTerminal,
   Option,
   Repetition,
@@ -385,7 +385,7 @@ export function getFirstNoneTerminal(definition: IProduction[]): Rule[] {
   if (firstProd instanceof NonTerminal) {
     result.push(firstProd.referencedRule)
   } else if (
-    firstProd instanceof Flat ||
+    firstProd instanceof AlternativeGAST ||
     firstProd instanceof Option ||
     firstProd instanceof RepetitionMandatory ||
     firstProd instanceof RepetitionMandatoryWithSeparator ||
@@ -399,7 +399,7 @@ export function getFirstNoneTerminal(definition: IProduction[]): Rule[] {
     // each sub definition in alternation is a FLAT
     result = utils.flatten(
       utils.map(firstProd.definition, currSubDef =>
-        getFirstNoneTerminal((<Flat>currSubDef).definition)
+        getFirstNoneTerminal((<AlternativeGAST>currSubDef).definition)
       )
     )
   } else if (firstProd instanceof Terminal) {

--- a/packages/chevrotain/src/parse/grammar/follow.ts
+++ b/packages/chevrotain/src/parse/grammar/follow.ts
@@ -2,7 +2,7 @@ import { RestWalker } from "./rest"
 import { first } from "./first"
 import { assign, forEach } from "../../utils/utils"
 import { IN } from "../constants"
-import { Flat, NonTerminal, Rule, Terminal } from "./gast/gast_public"
+import { Alternative, NonTerminal, Rule, Terminal } from "./gast/gast_public"
 import { IProduction, TokenType } from "../../../api"
 
 // This ResyncFollowsWalker computes all of the follows required for RESYNC
@@ -36,7 +36,7 @@ export class ResyncFollowsWalker extends RestWalker {
       buildBetweenProdsFollowPrefix(refProd.referencedRule, refProd.idx) +
       this.topProd.name
     let fullRest: IProduction[] = currRest.concat(prevRest)
-    let restProd = new Flat({ definition: fullRest })
+    let restProd = new Alternative({ definition: fullRest })
     let t_in_topProd_follows = first(restProd)
     this.follows[followName] = t_in_topProd_follows
   }

--- a/packages/chevrotain/src/parse/grammar/gast/gast.ts
+++ b/packages/chevrotain/src/parse/grammar/gast/gast.ts
@@ -2,7 +2,7 @@ import { contains, every, has, some } from "../../../utils/utils"
 import {
   AbstractProduction,
   Alternation,
-  Flat,
+  Alternative,
   NonTerminal,
   Option,
   Repetition,
@@ -17,7 +17,7 @@ import { IProduction, IProductionWithOccurrence } from "../../../../api"
 
 export function isSequenceProd(prod: IProduction): boolean {
   return (
-    prod instanceof Flat ||
+    prod instanceof Alternative ||
     prod instanceof Option ||
     prod instanceof Repetition ||
     prod instanceof RepetitionMandatory ||

--- a/packages/chevrotain/src/parse/grammar/gast/gast_public.ts
+++ b/packages/chevrotain/src/parse/grammar/gast/gast_public.ts
@@ -71,9 +71,7 @@ export class Rule extends AbstractProduction {
   }
 }
 
-// TODO: is this only used in an Alternation?
-//       Perhaps `Flat` should be renamed to `Alternative`?
-export class Flat extends AbstractProduction {
+export class Alternative extends AbstractProduction {
   public ignoreAmbiguities: boolean = false
 
   constructor(options: {
@@ -183,12 +181,12 @@ export class Alternation extends AbstractProduction
   implements IProductionWithOccurrence {
   public idx: number = 1
   public ignoreAmbiguities: boolean = false
-  public definition: Flat[]
+  public definition: Alternative[]
   public hasPredicates: boolean = false
   public maxLookahead?: number
 
   constructor(options: {
-    definition: Flat[]
+    definition: Alternative[]
     idx?: number
     ignoreAmbiguities?: boolean
     hasPredicates?: boolean
@@ -219,7 +217,12 @@ export class Terminal implements IProductionWithOccurrence {
 }
 
 export interface ISerializedBasic extends ISerializedGast {
-  type: "Flat" | "Option" | "RepetitionMandatory" | "Repetition" | "Alternation"
+  type:
+    | "Alternative"
+    | "Option"
+    | "RepetitionMandatory"
+    | "Repetition"
+    | "Alternation"
   idx?: number
 }
 
@@ -271,9 +274,9 @@ export function serializeProduction(node: IProduction): ISerializedGast {
       name: node.nonTerminalName,
       idx: node.idx
     }
-  } else if (node instanceof Flat) {
+  } else if (node instanceof Alternative) {
     return <ISerializedBasic>{
-      type: "Flat",
+      type: "Alternative",
       definition: convertDefinition(node.definition)
     }
   } else if (node instanceof Option) {

--- a/packages/chevrotain/src/parse/grammar/gast/gast_visitor_public.ts
+++ b/packages/chevrotain/src/parse/grammar/gast/gast_visitor_public.ts
@@ -1,6 +1,6 @@
 import {
   Alternation,
-  Flat,
+  Alternative,
   NonTerminal,
   Option,
   Repetition,
@@ -18,8 +18,8 @@ export abstract class GAstVisitor {
     switch (nodeAny.constructor) {
       case NonTerminal:
         return this.visitNonTerminal(nodeAny)
-      case Flat:
-        return this.visitFlat(nodeAny)
+      case Alternative:
+        return this.visitAlternative(nodeAny)
       case Option:
         return this.visitOption(nodeAny)
       case RepetitionMandatory:
@@ -44,7 +44,7 @@ export abstract class GAstVisitor {
 
   public visitNonTerminal(node: NonTerminal): any {}
 
-  public visitFlat(node: Flat): any {}
+  public visitAlternative(node: Alternative): any {}
 
   public visitOption(node: Option): any {}
 

--- a/packages/chevrotain/src/parse/grammar/interpreter.ts
+++ b/packages/chevrotain/src/parse/grammar/interpreter.ts
@@ -13,7 +13,7 @@ import { TokenMatcher } from "../parser/parser"
 import {
   AbstractProduction,
   Alternation,
-  Flat,
+  Alternative,
   NonTerminal,
   Option,
   Repetition,
@@ -127,7 +127,7 @@ export class NextAfterTokenWalker extends AbstractNextPossibleTokensWalker {
       !this.found
     ) {
       let fullRest = currRest.concat(prevRest)
-      let restProd = new Flat({ definition: fullRest })
+      let restProd = new Alternative({ definition: fullRest })
       this.possibleTokTypes = first(restProd)
       this.found = true
     }
@@ -281,7 +281,7 @@ export function possiblePathsFrom(
     let prod = targetDef[i]
 
     /* istanbul ignore else */
-    if (prod instanceof Flat) {
+    if (prod instanceof Alternative) {
       return getAlternativesForProd(prod.definition)
     } else if (prod instanceof NonTerminal) {
       return getAlternativesForProd(prod.definition)
@@ -296,7 +296,7 @@ export function possiblePathsFrom(
       return getAlternativesForProd(newDef)
     } else if (prod instanceof RepetitionMandatoryWithSeparator) {
       const newDef = [
-        new Flat({ definition: prod.definition }),
+        new Alternative({ definition: prod.definition }),
         new Repetition({
           definition: [new Terminal({ terminalType: prod.separator })].concat(
             <any>prod.definition
@@ -564,7 +564,7 @@ export function nextPossibleTokensAfter(
         possiblePaths.push(currAltPath)
         possiblePaths.push(EXIT_ALTERNATIVE)
       }
-    } else if (prod instanceof Flat) {
+    } else if (prod instanceof Alternative) {
       possiblePaths.push({
         idx: currIdx,
         def: prod.definition.concat(drop(currDef)),

--- a/packages/chevrotain/src/parse/grammar/lookahead.ts
+++ b/packages/chevrotain/src/parse/grammar/lookahead.ts
@@ -17,7 +17,7 @@ import {
 import {
   AbstractProduction,
   Alternation,
-  Flat,
+  Alternative as AlternativeGAST,
   Option,
   Repetition,
   RepetitionMandatory,
@@ -636,8 +636,8 @@ export function getLookaheadPathsForOptionalProd(
   )
   let afterDef = afterDefWalker.startWalking()
 
-  let insideFlat = new Flat({ definition: insideDef })
-  let afterFlat = new Flat({ definition: afterDef })
+  let insideFlat = new AlternativeGAST({ definition: insideDef })
+  let afterFlat = new AlternativeGAST({ definition: afterDef })
 
   return lookAheadSequenceFromAlternatives([insideFlat, afterFlat], k)
 }

--- a/packages/chevrotain/src/parse/grammar/rest.ts
+++ b/packages/chevrotain/src/parse/grammar/rest.ts
@@ -2,7 +2,7 @@ import { drop, forEach } from "../../utils/utils"
 import {
   AbstractProduction,
   Alternation,
-  Flat,
+  Alternative,
   NonTerminal,
   Option,
   Repetition,
@@ -25,7 +25,7 @@ export abstract class RestWalker {
         this.walkProdRef(subProd, currRest, prevRest)
       } else if (subProd instanceof Terminal) {
         this.walkTerminal(subProd, currRest, prevRest)
-      } else if (subProd instanceof Flat) {
+      } else if (subProd instanceof Alternative) {
         this.walkFlat(subProd, currRest, prevRest)
       } else if (subProd instanceof Option) {
         this.walkOption(subProd, currRest, prevRest)
@@ -58,7 +58,7 @@ export abstract class RestWalker {
   ): void {}
 
   walkFlat(
-    flatProd: Flat,
+    flatProd: Alternative,
     currRest: IProduction[],
     prevRest: IProduction[]
   ): void {
@@ -141,7 +141,7 @@ export abstract class RestWalker {
       // wrapping each alternative in a single definition wrapper
       // to avoid errors in computing the rest of that alternative in the invocation to computeInProdFollows
       // (otherwise for OR([alt1,alt2]) alt2 will be considered in 'rest' of alt1
-      let prodWrapper = new Flat({ definition: [alt] })
+      let prodWrapper = new Alternative({ definition: [alt] })
       this.walk(prodWrapper, <any>fullOrRest)
     })
   }

--- a/packages/chevrotain/src/parse/parser/traits/gast_recorder.ts
+++ b/packages/chevrotain/src/parse/parser/traits/gast_recorder.ts
@@ -25,7 +25,7 @@ import {
 import { MixedInParser } from "./parser_traits"
 import {
   Alternation,
-  Flat,
+  Alternative,
   NonTerminal,
   Option,
   Repetition,
@@ -408,7 +408,7 @@ function recordOrProd(mainProdArg: any, occurrence: number): any {
   prevProd.definition.push(newOrProd)
 
   forEach(alts, currAlt => {
-    const currAltFlat = new Flat({ definition: [] })
+    const currAltFlat = new Alternative({ definition: [] })
     newOrProd.definition.push(currAltFlat)
     if (has(currAlt, "IGNORE_AMBIGUITIES")) {
       currAltFlat.ignoreAmbiguities = currAlt.IGNORE_AMBIGUITIES

--- a/packages/chevrotain/test/generate/generate_spec.ts
+++ b/packages/chevrotain/test/generate/generate_spec.ts
@@ -6,7 +6,7 @@ import { createToken } from "../../src/scan/tokens_public"
 import { createRegularToken } from "../utils/matchers"
 import {
   Alternation,
-  Flat,
+  Alternative,
   Rule,
   Terminal,
   Option,
@@ -83,7 +83,7 @@ describe("The Code Generation capabilities", () => {
         definition: [
           new Option({
             definition: [
-              new Flat({
+              new Alternative({
                 definition: [new Terminal({ terminalType: Identifier })]
               })
             ]
@@ -120,14 +120,14 @@ describe("The Code Generation capabilities", () => {
         definition: [
           new Alternation({
             definition: [
-              new Flat({
+              new Alternative({
                 definition: [
                   new Terminal({
                     terminalType: Identifier
                   })
                 ]
               }),
-              new Flat({
+              new Alternative({
                 definition: [new Terminal({ terminalType: Integer })]
               })
             ]
@@ -318,7 +318,7 @@ describe("The Code Generation capabilities", () => {
           definition: [
             new Alternation({
               definition: [
-                new Flat({
+                new Alternative({
                   definition: [
                     new RepetitionMandatory({
                       definition: [
@@ -329,7 +329,7 @@ describe("The Code Generation capabilities", () => {
                     })
                   ]
                 }),
-                new Flat({
+                new Alternative({
                   definition: [
                     new Terminal({
                       terminalType: Integer

--- a/packages/chevrotain/test/parse/grammar/checks_spec.ts
+++ b/packages/chevrotain/test/parse/grammar/checks_spec.ts
@@ -22,7 +22,7 @@ import { createToken } from "../../../src/scan/tokens_public"
 import { first, forEach, map } from "../../../src/utils/utils"
 import {
   Alternation,
-  Flat,
+  Alternative,
   NonTerminal,
   Option,
   Repetition,
@@ -342,7 +342,7 @@ describe("the getFirstNoneTerminal function", () => {
     let alternation = [
       new Alternation({
         definition: [
-          new Flat({
+          new Alternative({
             definition: [
               new NonTerminal({
                 nonTerminalName: "dummyRule",
@@ -350,7 +350,7 @@ describe("the getFirstNoneTerminal function", () => {
               })
             ]
           }),
-          new Flat({
+          new Alternative({
             definition: [
               new NonTerminal({
                 nonTerminalName: "dummyRule2",
@@ -358,7 +358,7 @@ describe("the getFirstNoneTerminal function", () => {
               })
             ]
           }),
-          new Flat({
+          new Alternative({
             definition: [
               new NonTerminal({
                 nonTerminalName: "dummyRule3",
@@ -383,7 +383,7 @@ describe("the getFirstNoneTerminal function", () => {
     let alternation = [
       new Repetition({
         definition: [
-          new Flat({
+          new Alternative({
             definition: [
               new NonTerminal({
                 nonTerminalName: "dummyRule",
@@ -391,7 +391,7 @@ describe("the getFirstNoneTerminal function", () => {
               })
             ]
           }),
-          new Flat({
+          new Alternative({
             definition: [
               new NonTerminal({
                 nonTerminalName: "dummyRule2",
@@ -416,7 +416,7 @@ describe("the getFirstNoneTerminal function", () => {
     let alternation = [
       new RepetitionMandatory({
         definition: [
-          new Flat({
+          new Alternative({
             definition: [
               new NonTerminal({
                 nonTerminalName: "dummyRule",
@@ -424,7 +424,7 @@ describe("the getFirstNoneTerminal function", () => {
               })
             ]
           }),
-          new Flat({
+          new Alternative({
             definition: [
               new NonTerminal({
                 nonTerminalName: "dummyRule2",
@@ -1596,7 +1596,7 @@ describe("The no non-empty lookahead validation", () => {
     const alternatives = []
     for (let i = 0; i < 256; i++) {
       alternatives.push(
-        new Flat({
+        new Alternative({
           definition: [
             new NonTerminal({
               nonTerminalName: "dummyRule",

--- a/packages/chevrotain/test/parse/grammar/first_spec.ts
+++ b/packages/chevrotain/test/parse/grammar/first_spec.ts
@@ -9,7 +9,7 @@ import {
 } from "./samples"
 import { setEquality } from "../../utils/matchers"
 import {
-  Flat,
+  Alternative,
   Terminal,
   Option,
   Alternation
@@ -29,14 +29,14 @@ describe("The Grammar Ast first model", () => {
   })
 
   it("can compute the first for a Sequence production ", () => {
-    let seqProduction = new Flat({
+    let seqProduction = new Alternative({
       definition: [new Terminal({ terminalType: EntityTok })]
     })
     let actual = first(seqProduction)
     expect(actual.length).to.equal(1)
     expect(actual[0]).to.equal(EntityTok)
 
-    let seqProduction2 = new Flat({
+    let seqProduction2 = new Alternative({
       definition: [
         new Terminal({ terminalType: EntityTok }),
         new Option({
@@ -52,13 +52,13 @@ describe("The Grammar Ast first model", () => {
   it("can compute the first for an alternatives production ", () => {
     let altProduction = new Alternation({
       definition: [
-        new Flat({
+        new Alternative({
           definition: [new Terminal({ terminalType: EntityTok })]
         }),
-        new Flat({
+        new Alternative({
           definition: [new Terminal({ terminalType: NamespaceTok })]
         }),
-        new Flat({
+        new Alternative({
           definition: [new Terminal({ terminalType: TypeTok })]
         })
       ]
@@ -71,7 +71,7 @@ describe("The Grammar Ast first model", () => {
   })
 
   it("can compute the first for an production with optional prefix", () => {
-    let withOptionalPrefix = new Flat({
+    let withOptionalPrefix = new Alternative({
       definition: [
         new Option({
           definition: [new Terminal({ terminalType: NamespaceTok })]
@@ -82,7 +82,7 @@ describe("The Grammar Ast first model", () => {
     let actual = first(withOptionalPrefix)
     setEquality(actual, [NamespaceTok, EntityTok])
 
-    let withTwoOptPrefix = new Flat({
+    let withTwoOptPrefix = new Alternative({
       definition: [
         new Option({
           definition: [new Terminal({ terminalType: NamespaceTok })]

--- a/packages/chevrotain/test/parse/grammar/gast_spec.ts
+++ b/packages/chevrotain/test/parse/grammar/gast_spec.ts
@@ -10,7 +10,7 @@ import {
   RepetitionWithSeparator,
   Repetition,
   serializeProduction,
-  Flat,
+  Alternative,
   Rule,
   serializeGrammar
 } from "../../../src/parse/grammar/gast/gast_public"
@@ -103,8 +103,8 @@ describe("GAst namespace", () => {
       })
     })
 
-    it("can serialize a Flat", () => {
-      let input = new Flat({
+    it("can serialize a Alternative", () => {
+      let input = new Alternative({
         definition: [
           new Terminal({ terminalType: WithLiteral }),
           new NonTerminal({ nonTerminalName: "bamba" })
@@ -112,7 +112,7 @@ describe("GAst namespace", () => {
       })
       let actual = serializeProduction(input)
       expect(actual).to.deep.equal({
-        type: "Flat",
+        type: "Alternative",
         definition: [
           {
             type: "Terminal",
@@ -282,13 +282,13 @@ describe("GAst namespace", () => {
     it("can serialize a Alternation", () => {
       let input = new Alternation({
         definition: [
-          new Flat({
+          new Alternative({
             definition: [new Terminal({ terminalType: A })]
           }),
-          new Flat({
+          new Alternative({
             definition: [new Terminal({ terminalType: B })]
           }),
-          new Flat({
+          new Alternative({
             definition: [new Terminal({ terminalType: C })]
           })
         ]
@@ -300,7 +300,7 @@ describe("GAst namespace", () => {
         idx: 1,
         definition: [
           {
-            type: "Flat",
+            type: "Alternative",
             definition: [
               {
                 type: "Terminal",
@@ -311,7 +311,7 @@ describe("GAst namespace", () => {
             ]
           },
           {
-            type: "Flat",
+            type: "Alternative",
             definition: [
               {
                 type: "Terminal",
@@ -323,7 +323,7 @@ describe("GAst namespace", () => {
             ]
           },
           {
-            type: "Flat",
+            type: "Alternative",
             definition: [
               {
                 type: "Terminal",

--- a/packages/chevrotain/test/parse/grammar/interperter_spec.ts
+++ b/packages/chevrotain/test/parse/grammar/interperter_spec.ts
@@ -37,7 +37,7 @@ import {
 import { EmbeddedActionsParser } from "../../../src/parse/parser/traits/parser_traits"
 import {
   Alternation,
-  Flat,
+  Alternative,
   Repetition,
   RepetitionWithSeparator,
   Rule,
@@ -661,16 +661,16 @@ describe("The chevrotain grammar interpreter capabilities", () => {
       let alts = [
         new Alternation({
           definition: [
-            new Flat({
+            new Alternative({
               definition: [new Terminal({ terminalType: Alpha })]
             }),
-            new Flat({
+            new Alternative({
               definition: [
                 new Terminal({ terminalType: Beta }),
                 new Terminal({ terminalType: Beta })
               ]
             }),
-            new Flat({
+            new Alternative({
               definition: [
                 new Terminal({ terminalType: Beta }),
                 new Terminal({ terminalType: Alpha }),
@@ -869,7 +869,7 @@ describe("The chevrotain grammar interpreter capabilities", () => {
 
     it("Sequence positive", () => {
       let seq = [
-        new Flat({
+        new Alternative({
           definition: [
             new Terminal({ terminalType: Alpha }),
             new Terminal({ terminalType: Beta }),
@@ -910,7 +910,7 @@ describe("The chevrotain grammar interpreter capabilities", () => {
 
     it("Sequence negative", () => {
       let seq = [
-        new Flat({
+        new Alternative({
           definition: [
             new Terminal({ terminalType: Alpha }),
             new Terminal({ terminalType: Beta }),
@@ -999,23 +999,23 @@ describe("The chevrotain grammar interpreter capabilities", () => {
       let alts = [
         new Alternation({
           definition: [
-            new Flat({
+            new Alternative({
               definition: [new Terminal({ terminalType: Alpha })]
             }),
-            new Flat({
+            new Alternative({
               definition: [
                 new Terminal({ terminalType: Beta }),
                 new Terminal({ terminalType: Beta })
               ]
             }),
-            new Flat({
+            new Alternative({
               definition: [
                 new Terminal({ terminalType: Beta }),
                 new Terminal({ terminalType: Alpha }),
                 new Terminal({ terminalType: Gamma })
               ]
             }),
-            new Flat({
+            new Alternative({
               definition: [new Terminal({ terminalType: Gamma })]
             })
           ]
@@ -1056,16 +1056,16 @@ describe("The chevrotain grammar interpreter capabilities", () => {
       let alts = [
         new Alternation({
           definition: [
-            new Flat({
+            new Alternative({
               definition: [new Terminal({ terminalType: Alpha })]
             }),
-            new Flat({
+            new Alternative({
               definition: [
                 new Terminal({ terminalType: Beta }),
                 new Terminal({ terminalType: Beta })
               ]
             }),
-            new Flat({
+            new Alternative({
               definition: [
                 new Terminal({ terminalType: Beta }),
                 new Terminal({ terminalType: Alpha }),

--- a/packages/chevrotain/test/parse/grammar/lookahead_spec.ts
+++ b/packages/chevrotain/test/parse/grammar/lookahead_spec.ts
@@ -17,7 +17,7 @@ import {
 import { createRegularToken } from "../../utils/matchers"
 import {
   Alternation,
-  Flat,
+  Alternative,
   NonTerminal,
   Option,
   Repetition,
@@ -232,7 +232,7 @@ let cardinality = new Rule({
     new Terminal({ terminalType: DotDotTok }),
     new Alternation({
       definition: [
-        new Flat({
+        new Alternative({
           definition: [
             new Terminal({
               terminalType: UnsignedIntegerLiteralTok,
@@ -240,7 +240,7 @@ let cardinality = new Rule({
             })
           ]
         }),
-        new Flat({
+        new Alternative({
           definition: [new Terminal({ terminalType: AsteriskTok })]
         })
       ]
@@ -274,11 +274,11 @@ let lotsOfOrs = new Rule({
   definition: [
     new Alternation({
       definition: [
-        new Flat({
+        new Alternative({
           definition: [
             new Alternation({
               definition: [
-                new Flat({
+                new Alternative({
                   definition: [
                     new Terminal({
                       terminalType: CommaTok,
@@ -286,7 +286,7 @@ let lotsOfOrs = new Rule({
                     })
                   ]
                 }),
-                new Flat({
+                new Alternative({
                   definition: [
                     new Terminal({
                       terminalType: KeyTok,
@@ -299,7 +299,7 @@ let lotsOfOrs = new Rule({
             })
           ]
         }),
-        new Flat({
+        new Alternative({
           definition: [
             new Terminal({
               terminalType: EntityTok,
@@ -311,7 +311,7 @@ let lotsOfOrs = new Rule({
     }),
     new Alternation({
       definition: [
-        new Flat({
+        new Alternative({
           definition: [
             new Terminal({
               terminalType: DotTok,
@@ -330,7 +330,7 @@ let emptyAltOr = new Rule({
   definition: [
     new Alternation({
       definition: [
-        new Flat({
+        new Alternative({
           definition: [
             new Terminal({
               terminalType: KeyTok,
@@ -338,7 +338,7 @@ let emptyAltOr = new Rule({
             })
           ]
         }),
-        new Flat({
+        new Alternative({
           definition: [
             new Terminal({
               terminalType: EntityTok,
@@ -346,7 +346,7 @@ let emptyAltOr = new Rule({
             })
           ]
         }),
-        new Flat({ definition: [] }) // an empty alternative
+        new Alternative({ definition: [] }) // an empty alternative
       ]
     })
   ]
@@ -578,7 +578,7 @@ context("lookahead specs", () => {
         definition: [
           new Alternation({
             definition: [
-              new Flat({
+              new Alternative({
                 definition: [
                   new Terminal({
                     terminalType: A,
@@ -586,7 +586,7 @@ context("lookahead specs", () => {
                   })
                 ]
               }),
-              new Flat({
+              new Alternative({
                 definition: [
                   new Terminal({
                     terminalType: B,
@@ -660,13 +660,13 @@ context("lookahead specs", () => {
       it("two simple one token alternatives", () => {
         let alt1 = new Alternation({
           definition: [
-            new Flat({
+            new Alternative({
               definition: [new Terminal({ terminalType: Alpha })]
             }),
-            new Flat({
+            new Alternative({
               definition: [new Terminal({ terminalType: Beta })]
             }),
-            new Flat({
+            new Alternative({
               definition: [new Terminal({ terminalType: Beta })]
             })
           ]
@@ -680,19 +680,19 @@ context("lookahead specs", () => {
       it("three simple one token alternatives", () => {
         let alt1 = new Alternation({
           definition: [
-            new Flat({
+            new Alternative({
               definition: [new Terminal({ terminalType: Alpha })]
             }),
-            new Flat({
+            new Alternative({
               definition: [new Terminal({ terminalType: Beta })]
             }),
-            new Flat({
+            new Alternative({
               definition: [new Terminal({ terminalType: Beta })]
             })
           ]
         })
         let alt2 = new Terminal({ terminalType: Gamma })
-        let alt3 = new Flat({
+        let alt3 = new Alternative({
           definition: [
             new Terminal({ terminalType: Delta }),
             new Terminal({ terminalType: Charlie })
@@ -706,16 +706,16 @@ context("lookahead specs", () => {
       it("two complex multi token alternatives", () => {
         let alt1 = new Alternation({
           definition: [
-            new Flat({
+            new Alternative({
               definition: [
                 new Terminal({ terminalType: Alpha }),
                 new Terminal({ terminalType: Beta })
               ]
             }),
-            new Flat({
+            new Alternative({
               definition: [new Terminal({ terminalType: Beta })]
             }),
-            new Flat({
+            new Alternative({
               definition: [
                 new Terminal({ terminalType: Alpha }),
                 new Terminal({ terminalType: Gamma }),
@@ -726,13 +726,13 @@ context("lookahead specs", () => {
         })
         let alt2 = new Alternation({
           definition: [
-            new Flat({
+            new Alternative({
               definition: [
                 new Terminal({ terminalType: Alpha }),
                 new Terminal({ terminalType: Delta })
               ]
             }),
-            new Flat({
+            new Alternative({
               definition: [new Terminal({ terminalType: Charlie })]
             })
           ]
@@ -748,30 +748,30 @@ context("lookahead specs", () => {
       it("three complex multi token alternatives", () => {
         let alt1 = new Alternation({
           definition: [
-            new Flat({
+            new Alternative({
               definition: [
                 new Terminal({ terminalType: Alpha }),
                 new Terminal({ terminalType: Beta }),
                 new Terminal({ terminalType: Gamma })
               ]
             }),
-            new Flat({
+            new Alternative({
               definition: [new Terminal({ terminalType: Beta })]
             })
           ]
         })
         let alt2 = new Alternation({
           definition: [
-            new Flat({
+            new Alternative({
               definition: [
                 new Terminal({ terminalType: Alpha }),
                 new Terminal({ terminalType: Delta })
               ]
             }),
-            new Flat({
+            new Alternative({
               definition: [new Terminal({ terminalType: Charlie })]
             }),
-            new Flat({
+            new Alternative({
               definition: [
                 new Terminal({ terminalType: Gamma }),
                 new Terminal({ terminalType: Gamma })
@@ -781,14 +781,14 @@ context("lookahead specs", () => {
         })
         let alt3 = new Alternation({
           definition: [
-            new Flat({
+            new Alternative({
               definition: [
                 new Terminal({ terminalType: Alpha }),
                 new Terminal({ terminalType: Beta }),
                 new Terminal({ terminalType: Delta })
               ]
             }),
-            new Flat({
+            new Alternative({
               definition: [
                 new Terminal({ terminalType: Charlie }),
                 new Terminal({ terminalType: Beta })
@@ -809,7 +809,7 @@ context("lookahead specs", () => {
       })
 
       it("two complex multi token alternatives with shared prefix", () => {
-        let alt1 = new Flat({
+        let alt1 = new Alternative({
           definition: [
             new Terminal({ terminalType: Alpha }),
             new Terminal({ terminalType: Beta }),
@@ -818,7 +818,7 @@ context("lookahead specs", () => {
           ]
         })
 
-        let alt2 = new Flat({
+        let alt2 = new Alternative({
           definition: [
             new Terminal({ terminalType: Alpha }),
             new Terminal({ terminalType: Beta }),
@@ -837,10 +837,10 @@ context("lookahead specs", () => {
       })
 
       it("simple ambiguous alternatives", () => {
-        let alt1 = new Flat({
+        let alt1 = new Alternative({
           definition: [new Terminal({ terminalType: Alpha })]
         })
-        let alt2 = new Flat({
+        let alt2 = new Alternative({
           definition: [new Terminal({ terminalType: Alpha })]
         })
 
@@ -849,7 +849,7 @@ context("lookahead specs", () => {
       })
 
       it("complex(multi-token) ambiguous alternatives", () => {
-        let alt1 = new Flat({
+        let alt1 = new Alternative({
           definition: [
             new Terminal({ terminalType: Alpha }),
             new Terminal({ terminalType: Beta }),
@@ -857,7 +857,7 @@ context("lookahead specs", () => {
           ]
         })
 
-        let alt2 = new Flat({
+        let alt2 = new Alternative({
           definition: [
             new Terminal({ terminalType: Alpha }),
             new Terminal({ terminalType: Beta }),

--- a/packages/chevrotain/test/parse/grammar/resolver_spec.ts
+++ b/packages/chevrotain/test/parse/grammar/resolver_spec.ts
@@ -2,7 +2,7 @@ import { GastRefResolverVisitor } from "../../../src/parse/grammar/resolver"
 import { ParserDefinitionErrorType } from "../../../src/parse/parser/parser"
 import {
   Alternation,
-  Flat,
+  Alternative,
   NonTerminal,
   Option,
   Repetition,
@@ -60,7 +60,7 @@ describe("The assignOccurrenceIndices utility", () => {
         }),
         new Alternation({
           definition: [
-            new Flat({
+            new Alternative({
               definition: [new Terminal({ terminalType: B })]
             })
           ]
@@ -88,7 +88,7 @@ describe("The assignOccurrenceIndices utility", () => {
         }),
         new Alternation({
           definition: [
-            new Flat({
+            new Alternative({
               definition: [new Terminal({ terminalType: B })]
             })
           ]

--- a/packages/chevrotain/test/parse/grammar/samples.ts
+++ b/packages/chevrotain/test/parse/grammar/samples.ts
@@ -8,7 +8,7 @@ import {
   Terminal
 } from "../../../src/parse/grammar/gast/gast_public"
 import { Alternation } from "../../../src/parse/grammar/gast/gast_public"
-import { Flat } from "../../../src/parse/grammar/gast/gast_public"
+import { Alternative } from "../../../src/parse/grammar/gast/gast_public"
 import { RepetitionWithSeparator } from "../../../src/parse/grammar/gast/gast_public"
 import { filter, values } from "../../../src/utils/utils"
 import { augmentTokenTypes } from "../../../src/scan/tokens"
@@ -222,7 +222,7 @@ export let cardinality = new Rule({
     new Terminal({ terminalType: DotDotTok }),
     new Alternation({
       definition: [
-        new Flat({
+        new Alternative({
           definition: [
             new Terminal({
               terminalType: UnsignedIntegerLiteralTok,
@@ -230,7 +230,7 @@ export let cardinality = new Rule({
             })
           ]
         }),
-        new Flat({
+        new Alternative({
           definition: [new Terminal({ terminalType: AsteriskTok })]
         })
       ]
@@ -264,11 +264,11 @@ export let lotsOfOrs = new Rule({
   definition: [
     new Alternation({
       definition: [
-        new Flat({
+        new Alternative({
           definition: [
             new Alternation({
               definition: [
-                new Flat({
+                new Alternative({
                   definition: [
                     new Terminal({
                       terminalType: CommaTok,
@@ -276,7 +276,7 @@ export let lotsOfOrs = new Rule({
                     })
                   ]
                 }),
-                new Flat({
+                new Alternative({
                   definition: [
                     new Terminal({
                       terminalType: KeyTok,
@@ -289,7 +289,7 @@ export let lotsOfOrs = new Rule({
             })
           ]
         }),
-        new Flat({
+        new Alternative({
           definition: [
             new Terminal({
               terminalType: EntityTok,
@@ -301,7 +301,7 @@ export let lotsOfOrs = new Rule({
     }),
     new Alternation({
       definition: [
-        new Flat({
+        new Alternative({
           definition: [
             new Terminal({
               terminalType: DotTok,
@@ -320,7 +320,7 @@ export let emptyAltOr = new Rule({
   definition: [
     new Alternation({
       definition: [
-        new Flat({
+        new Alternative({
           definition: [
             new Terminal({
               terminalType: KeyTok,
@@ -328,7 +328,7 @@ export let emptyAltOr = new Rule({
             })
           ]
         }),
-        new Flat({
+        new Alternative({
           definition: [
             new Terminal({
               terminalType: EntityTok,
@@ -336,7 +336,7 @@ export let emptyAltOr = new Rule({
             })
           ]
         }),
-        new Flat({ definition: [] }) // an empty alternative
+        new Alternative({ definition: [] }) // an empty alternative
       ]
     })
   ]


### PR DESCRIPTION
the name Flat was not accurate enough...

BREAKING CHANGE: rename Flat to Alternative in GAST structure, this is part of the public API