### PR TITLE
Fix issue with python indentation example

### DIFF
--- a/examples/lexer/python_indentation/python_indentation.js
+++ b/examples/lexer/python_indentation/python_indentation.js
@@ -39,12 +39,10 @@ function matchIndentBase(text, offset, matchedTokens, groups, type) {
   const isStartOfLine =
     // only newlines matched so far
     (noTokensMatchedYet && !noNewLinesMatchedYet) ||
-    // Both newlines and other Tokens have been matched AND the last matched Token is a newline
+    // Both newlines and other Tokens have been matched AND the offset is just after the last newline
     (!noTokensMatchedYet &&
       !noNewLinesMatchedYet &&
-      (!_.isEmpty(newLines) &&
-        !_.isEmpty(matchedTokens) &&
-        _.last(newLines).startOffset) > _.last(matchedTokens).startOffset)
+      offset === _.last(newLines).startOffset + 1)
 
   // indentation can only be matched at the start of a line.
   if (isFirstLine || isStartOfLine) {

--- a/examples/lexer/python_indentation/python_indentation_spec.js
+++ b/examples/lexer/python_indentation/python_indentation_spec.js
@@ -10,6 +10,7 @@ describe("The Chevrotain Lexer ability to lex python like indentation.", () => {
       "  if 2\n" +
       "    if 3\n" +
       "      print 666\n" +
+      "      print 777\n" +
       "  else\n" +
       "    print 999\n"
 
@@ -26,6 +27,8 @@ describe("The Chevrotain Lexer ability to lex python like indentation.", () => {
       "If",
       "IntegerLiteral",
       "Indent",
+      "Print",
+      "IntegerLiteral",
       "Print",
       "IntegerLiteral",
       "Outdent",


### PR DESCRIPTION
The python indentation example had a problem with more than one line at the same indent level.

e.g:

    const {tokens} = tokenize(`
    if
      1
      2
    `)

    console.log(tokens.map(t => [t.image, t.tokenType.name]))

Would output:

    [ 'If', 'Indent', 'IntegerLiteral', 'Outdent', 'IntegerLiteral' ]

The outdent comes before the '2' instead of after.

Improved test case and fix in this PR.