### PR TITLE
feat: allow dash (-) in token name (#1291)

### DIFF
--- a/packages/chevrotain/src/parse/cst/cst_visitor.ts
+++ b/packages/chevrotain/src/parse/cst/cst_visitor.ts
@@ -10,7 +10,6 @@ import {
   map
 } from "../../utils/utils"
 import { defineNameProp, functionName } from "../../lang/lang_extensions"
-import { validTermsPattern } from "../grammar/checks"
 import { ICstVisitor } from "../../../api"
 
 export function defaultVisit<IN, OUT>(ctx: any, param: IN): OUT {
@@ -160,7 +159,6 @@ export function validateRedundantMethods(
 
   for (let prop in visitorInstance) {
     if (
-      validTermsPattern.test(prop) &&
       isFunction(visitorInstance[prop]) &&
       !contains(VALID_PROP_NAMES, prop) &&
       !contains(ruleNames, prop)
@@ -170,8 +168,7 @@ export function validateRedundantMethods(
           `Redundant visitor method: <${prop}> on ${functionName(
             <any>visitorInstance.constructor
           )} CST Visitor\n` +
-          `There is no Grammar Rule corresponding to this method's name.\n` +
-          `For utility methods on visitor classes use methods names that do not match /${validTermsPattern.source}/.`,
+          `There is no Grammar Rule corresponding to this method's name.\n`,
         type: CstVisitorDefinitionError.REDUNDANT_METHOD,
         methodName: prop
       })

--- a/packages/chevrotain/src/parse/grammar/checks.ts
+++ b/packages/chevrotain/src/parse/grammar/checks.ts
@@ -92,16 +92,8 @@ export function validateGrammar(
     errMsgProvider
   )
 
-  let tokenNameErrors: any = utils.map(tokenTypes, (currTokType) =>
-    validateTokenName(currTokType, errMsgProvider)
-  )
-
   const tooManyAltsErrors = map(topLevels, (curRule) =>
     validateTooManyAlts(curRule, errMsgProvider)
-  )
-
-  const ruleNameErrors = map(topLevels, (curRule) =>
-    validateRuleName(curRule, errMsgProvider)
   )
 
   const duplicateRulesError = map(topLevels, (curRule) =>
@@ -116,14 +108,12 @@ export function validateGrammar(
   return <any>(
     utils.flatten(
       duplicateErrors.concat(
-        tokenNameErrors,
         emptyRepetitionErrors,
         leftRecursionErrors,
         emptyAltErrors,
         ambiguousAltsErrors,
         termsNamespaceConflictErrors,
         tooManyAltsErrors,
-        ruleNameErrors,
         duplicateRulesError
       )
     )
@@ -226,50 +216,6 @@ export class OccurrenceValidationCollector extends GAstVisitor {
   public visitTerminal(terminal: Terminal): void {
     this.allProductions.push(terminal)
   }
-}
-
-export const validTermsPattern = /^[a-zA-Z_](?:[\w-]*\w|\w*)$/
-
-// TODO: remove this limitation now that we use recorders
-export function validateRuleName(
-  rule: Rule,
-  errMsgProvider: IGrammarValidatorErrorMessageProvider
-): IParserDefinitionError[] {
-  const errors = []
-  const ruleName = rule.name
-
-  if (!ruleName.match(validTermsPattern)) {
-    errors.push({
-      message: errMsgProvider.buildInvalidRuleNameError({
-        topLevelRule: rule,
-        expectedPattern: validTermsPattern
-      }),
-      type: ParserDefinitionErrorType.INVALID_RULE_NAME,
-      ruleName: ruleName
-    })
-  }
-  return errors
-}
-
-// TODO: remove this limitation now that we use recorders
-export function validateTokenName(
-  tokenType: TokenType,
-  errMsgProvider: IGrammarValidatorErrorMessageProvider
-): IParserDefinitionError[] {
-  const errors = []
-  const tokTypeName = tokenType.name
-
-  if (!tokTypeName.match(validTermsPattern)) {
-    errors.push({
-      message: errMsgProvider.buildTokenNameError({
-        tokenType: tokenType,
-        expectedPattern: validTermsPattern
-      }),
-      type: ParserDefinitionErrorType.INVALID_TOKEN_NAME
-    })
-  }
-
-  return errors
 }
 
 export function validateRuleDoesNotAlreadyExist(

--- a/packages/chevrotain/src/parse/grammar/checks.ts
+++ b/packages/chevrotain/src/parse/grammar/checks.ts
@@ -228,7 +228,7 @@ export class OccurrenceValidationCollector extends GAstVisitor {
   }
 }
 
-export const validTermsPattern = /^[a-zA-Z_]\w*$/
+export const validTermsPattern = /^[a-zA-Z_](?:[\w-]*\w|\w*)$/
 
 // TODO: remove this limitation now that we use recorders
 export function validateRuleName(

--- a/packages/chevrotain/test/parse/grammar/checks_spec.ts
+++ b/packages/chevrotain/test/parse/grammar/checks_spec.ts
@@ -15,7 +15,6 @@ import {
   validateGrammar,
   validateRuleDoesNotAlreadyExist,
   validateRuleIsOverridden,
-  validateRuleName,
   validateTooManyAlts
 } from "../../../src/parse/grammar/checks"
 import { createToken } from "../../../src/scan/tokens_public"
@@ -151,44 +150,6 @@ describe("the grammar validations", () => {
       ParserDefinitionErrorType.DUPLICATE_RULE_NAME
     )
     expect(duplicateErr[0]).to.have.property("ruleName", "A")
-  })
-
-  it("only allows a subset of ECMAScript identifiers as rule names", () => {
-    let res1 = validateRuleName(
-      new Rule({ name: "1baa", definition: [] }),
-      defaultGrammarValidatorErrorProvider
-    )
-    expect(res1).to.have.lengthOf(1)
-    expect(res1[0]).to.have.property("message")
-    expect(res1[0]).to.have.property(
-      "type",
-      ParserDefinitionErrorType.INVALID_RULE_NAME
-    )
-    expect(res1[0]).to.have.property("ruleName", "1baa")
-
-    let res2 = validateRuleName(
-      new Rule({ name: "שלום", definition: [] }),
-      defaultGrammarValidatorErrorProvider
-    )
-    expect(res2).to.have.lengthOf(1)
-    expect(res2[0]).to.have.property("message")
-    expect(res2[0]).to.have.property(
-      "type",
-      ParserDefinitionErrorType.INVALID_RULE_NAME
-    )
-    expect(res2[0]).to.have.property("ruleName", "שלום")
-
-    let res3 = validateRuleName(
-      new Rule({ name: "$bamba", definition: [] }),
-      defaultGrammarValidatorErrorProvider
-    )
-    expect(res3).to.have.lengthOf(1)
-    expect(res3[0]).to.have.property("message")
-    expect(res3[0]).to.have.property(
-      "type",
-      ParserDefinitionErrorType.INVALID_RULE_NAME
-    )
-    expect(res3[0]).to.have.property("ruleName", "$bamba")
   })
 
   it("does not allow overriding a rule which does not already exist", () => {
@@ -916,16 +877,6 @@ describe("The rule names validation full flow", () => {
     expect(() => new DuplicateRulesParser()).to.throw("oops_duplicate")
   })
 
-  it("will throw an error when trying to init a parser with an invalid rule names", () => {
-    expect(() => new InvalidRuleNameParser()).to.throw(
-      "it must match the pattern"
-    )
-    expect(() => new InvalidRuleNameParser()).to.throw(
-      "Invalid grammar rule name"
-    )
-    expect(() => new InvalidRuleNameParser()).to.throw("שלום")
-  })
-
   it(
     "won't throw an errors when trying to init a parser with definition errors but with a flag active to defer handling" +
       "of definition errors (ruleName validation",
@@ -1479,32 +1430,6 @@ describe("The namespace conflict detection full flow", () => {
 
     expect(() => new NameSpaceConflict([])).to.throw(
       "The grammar has both a Terminal(Token) and a Non-Terminal(Rule) named: <Bamba>"
-    )
-  })
-})
-
-describe("The invalid token name validation", () => {
-  it("will throw an error when a Token is using an invalid name", () => {
-    class במבה {
-      static PATTERN = /NA/
-    }
-    class A {
-      static PATTERN = /NA/
-    }
-
-    class InvalidTokenName extends EmbeddedActionsParser {
-      constructor(input: IToken[] = []) {
-        super([במבה, A])
-        this.performSelfAnalysis()
-        this.input = input
-      }
-
-      public someRule = this.RULE("someRule", () => {
-        this.CONSUME(A)
-      })
-    }
-    expect(() => new InvalidTokenName([])).to.throw(
-      "Invalid Grammar Token name: ->במבה<- it must match the pattern: ->/^[a-zA-Z_](?:[\\w-]*\\w|\\w*)$/<-"
     )
   })
 })

--- a/packages/chevrotain/test/parse/grammar/checks_spec.ts
+++ b/packages/chevrotain/test/parse/grammar/checks_spec.ts
@@ -1504,7 +1504,7 @@ describe("The invalid token name validation", () => {
       })
     }
     expect(() => new InvalidTokenName([])).to.throw(
-      "Invalid Grammar Token name: ->במבה<- it must match the pattern: ->/^[a-zA-Z_]\\w*$/<-"
+      "Invalid Grammar Token name: ->במבה<- it must match the pattern: ->/^[a-zA-Z_](?:[\\w-]*\\w|\\w*)$/<-"
     )
   })
 })


### PR DESCRIPTION
Added the possibility to use the dash character in the middle of a token name.
This requirement comes from an idea of the ASN1 language compilation.
ASN1 has keywords like :
ENCODING-CONTROL
RELATIVE-OID-IRI'
ABSTRACT-SYNTAX
TYPE-IDENTIFIER
MINUS-INFINITY
PLUS-INFINITY
NOT-A-NUMBER
RELATIVE-OID
TIME-OF-DAY
DATE-TIME
OID-IRI