### PR TITLE
Add generics to getBaseCSTVisitorConstructor

### DIFF
--- a/packages/chevrotain/src/parse/parser/traits/tree_builder.ts
+++ b/packages/chevrotain/src/parse/parser/traits/tree_builder.ts
@@ -223,10 +223,10 @@ export class TreeBuilder {
     this.setNodeLocationFromNode(preCstNode.location, ruleCstResult.location)
   }
 
-  getBaseCstVisitorConstructor(
+  getBaseCstVisitorConstructor<IN = any, OUT = any>(
     this: MixedInParser
   ): {
-    new (...args: any[]): ICstVisitor<any, any>
+    new (...args: any[]): ICstVisitor<IN, OUT>
   } {
     if (isUndefined(this.baseCstVisitorConstructor)) {
       const newBaseCstVisitorConstructor = createBaseSemanticVisitorConstructor(
@@ -240,10 +240,10 @@ export class TreeBuilder {
     return <any>this.baseCstVisitorConstructor
   }
 
-  getBaseCstVisitorConstructorWithDefaults(
+  getBaseCstVisitorConstructorWithDefaults<IN = any, OUT = any>(
     this: MixedInParser
   ): {
-    new (...args: any[]): ICstVisitor<any, any>
+    new (...args: any[]): ICstVisitor<IN, OUT>
   } {
     if (isUndefined(this.baseCstVisitorWithDefaultsConstructor)) {
       const newConstructor = createBaseVisitorConstructorWithDefaults(


### PR DESCRIPTION
I'd like to define the types of ICSTVisitor rather than having it always be of type `any`.