### PR TITLE
fix: update type declaration for CstChildrenDictionary

### DIFF
--- a/packages/chevrotain/api.d.ts
+++ b/packages/chevrotain/api.d.ts
@@ -1964,7 +1964,7 @@ export interface CstNodeLocation {
 }
 
 export declare type CstChildrenDictionary = {
-  [identifier: string]: CstElement[]
+  [identifier: string]: CstElement[] | undefined
 }
 
 export declare type CstElement = IToken | CstNode


### PR DESCRIPTION
Following discussion in #1305 I made a minimal patch to the type declarations.